### PR TITLE
Improve Bitwarden secret sync workflow

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,9 +1,8 @@
-export PROXMOX_HOST="pve.gibbsgreatly.xyz"
+export PROXMOX_HOST='pve.gibbsgreatly.xyz'
 export PROXMOX_TOKEN_SECRET='__FROM_BITWARDEN__'
-export PROXMOX_USER="automation@pve"
-export PROXMOX_TOKEN_ID="automation@pve!terraform"
+export PROXMOX_USER='automation@pve'
+export PROXMOX_TOKEN_ID='automation@pve!terraform'
 export SERVICE_PASSWORD='__FROM_BITWARDEN__'
-export ANSIBLE_VAULT_PASSWORD='__FROM_BITWARDEN__'
 export PORTAINER_ADMIN_PASSWORD='__FROM_BITWARDEN__'
 
 # ----------------------------------------------------------------
@@ -21,7 +20,7 @@ export TF_VAR_proxmox_node=pve
 # ----------------------------------------------------------------
 # Ansible Configuration
 # ----------------------------------------------------------------
-export ANSIBLE_PRIVATE_KEY_FILE="~/.ssh/id_ed25519"
+export ANSIBLE_PRIVATE_KEY_FILE='~/.ssh/id_ed25519'
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 # ----------------------------------------------------------------
@@ -29,16 +28,16 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 # ----------------------------------------------------------------
 export ANTHROPIC_API_KEY='__FROM_BITWARDEN__'
 
-export TF_VAR_domain="gibbsgreatly.xyz"
-export TF_VAR_ip_address="192.168.1.4"
-export TF_VAR_hostname="management-stack"
+export TF_VAR_domain='gibbsgreatly.xyz'
+export TF_VAR_ip_address='192.168.1.4'
+export TF_VAR_hostname='management-stack'
 
 # ----------------------------------------------------------------
 # Harbor Stack
 # ----------------------------------------------------------------
 export HARBOR_ADMIN_PASSWORD=${SERVICE_PASSWORD}
 export HARBOR_DB_PASSWORD="harbor_db_${SERVICE_PASSWORD}"
-export HARBOR_HOSTNAME="harbor.gibbsgreatly.xyz"
+export HARBOR_HOSTNAME='harbor.gibbsgreatly.xyz'
 export HARBOR_DOCKERHUB_USERNAME='__FROM_BITWARDEN__'
 export HARBOR_DOCKERHUB_PASSWORD='__FROM_BITWARDEN__'
 
@@ -48,20 +47,20 @@ export HARBOR_DOCKERHUB_PASSWORD='__FROM_BITWARDEN__'
 export NPM_DB_PASSWORD="npm_db_${SERVICE_PASSWORD}"
 
 # ----------------------------------------------------------------
-# NetBox Stack Secrets (generate with: openssl rand -base64 32 or 48)
+# NetBox Stack Secrets
 # ----------------------------------------------------------------
-export NETBOX_DB_PASSWORD='__GENERATE: openssl rand -base64 32__'
-export NETBOX_REDIS_PASSWORD='__GENERATE: openssl rand -base64 32__'
-export NETBOX_REDIS_CACHE_PASSWORD='__GENERATE: openssl rand -base64 32__'
-export NETBOX_SECRET_KEY='__GENERATE: openssl rand -base64 48__'
-export NETBOX_API_TOKEN_PEPPER='__GENERATE: openssl rand -base64 48__'
-export NETBOX_SUPERUSER_PASSWORD='__GENERATE: openssl rand -base64 24__'       # admin superuser password
-export NETBOX_SUPERUSER_API_TOKEN='__GENERATE: openssl rand -hex 20__'         # 40-char hex v1 API token
+export NETBOX_DB_PASSWORD='__FROM_BITWARDEN__'
+export NETBOX_REDIS_PASSWORD='__FROM_BITWARDEN__'
+export NETBOX_REDIS_CACHE_PASSWORD='__FROM_BITWARDEN__'
+export NETBOX_SECRET_KEY='__FROM_BITWARDEN__'
+export NETBOX_API_TOKEN_PEPPER='__FROM_BITWARDEN__'
+export NETBOX_SUPERUSER_PASSWORD='__FROM_BITWARDEN__'       # admin superuser password
+export NETBOX_SUPERUSER_API_TOKEN='__FROM_BITWARDEN__'         # 40-char hex v1 API token
 
 # ----------------------------------------------------------------
 # Mikrotik Router API Credentials
 # ----------------------------------------------------------------
-export MIKROTIK_HOST="192.168.1.1"
+export MIKROTIK_HOST='192.168.1.1'
 export MIKROTIK_PORT=443
 export MIKROTIK_USER='__FROM_BITWARDEN__'                                      # api-user account
 export MIKROTIK_PASSWORD='__FROM_BITWARDEN__'                                  # api-user password

--- a/populate-bitwarden.sh
+++ b/populate-bitwarden.sh
@@ -7,7 +7,6 @@ COLLECTION_ID="fa8ec932-22d8-4b7e-b13f-b349013d627b"
 
 ENV_VARS=(
     "PROXMOX_TOKEN_SECRET"
-    "ANSIBLE_VAULT_PASSWORD"
     "SERVICE_PASSWORD"
     "PORTAINER_ADMIN_PASSWORD"
     "ANTHROPIC_API_KEY"
@@ -52,6 +51,7 @@ echo "Pushing secrets to Bitwarden..."
 created_count=0
 updated_count=0
 skipped_count=0
+moved_count=0
 
 for env_var in "${ENV_VARS[@]}"; do
     value="${!env_var:-}"
@@ -77,8 +77,10 @@ for env_var in "${ENV_VARS[@]}"; do
         }')
 
     # Check if item already exists
-    existing_id=$(bw list items --search "$env_var" --organizationid "$ORG_ID" 2>/dev/null \
-        | jq -r ".[] | select(.name == \"$env_var\") | .id" | head -1)
+    existing_item=$(bw list items --search "$env_var" 2>/dev/null \
+        | jq -r ".[] | select(.name == \"$env_var\") | [.id, (.organizationId // \"\")] | @tsv" | head -1)
+    existing_id=$(printf '%s\n' "$existing_item" | cut -f1)
+    existing_org_id=$(printf '%s\n' "$existing_item" | cut -f2)
 
     if [ -n "$existing_id" ]; then
         echo "🔄 Updating: $env_var"
@@ -86,8 +88,17 @@ for env_var in "${ENV_VARS[@]}"; do
         updated_count=$((updated_count + 1))
     else
         echo "📝 Creating: $env_var"
-        echo "$json" | bw encode | bw create item --quiet
+        created_item=$(echo "$json" | bw encode | bw create item --quiet)
+        existing_id=$(printf '%s\n' "$created_item" | jq -r '.id')
+        existing_org_id=""
         created_count=$((created_count + 1))
+    fi
+
+    if [ "${existing_org_id:-}" != "$ORG_ID" ]; then
+        echo "📦 Moving to organization: $env_var"
+        move_payload=$(jq -nc --arg coll "$COLLECTION_ID" '[$coll]')
+        echo "$move_payload" | bw encode | bw move "$existing_id" "$ORG_ID" --quiet
+        moved_count=$((moved_count + 1))
     fi
 
     if [ $? -eq 0 ]; then
@@ -98,5 +109,5 @@ for env_var in "${ENV_VARS[@]}"; do
 done
 
 echo ""
-echo "Summary: created=$created_count updated=$updated_count skipped=$skipped_count"
+echo "Summary: created=$created_count updated=$updated_count moved=$moved_count skipped=$skipped_count"
 echo "Done! Check your HomeLab collection."

--- a/sync-secrets.sh
+++ b/sync-secrets.sh
@@ -6,7 +6,6 @@ ORG_ID="03cd75dc-3db4-4b2e-8ecc-af86014151a7"
 
 ENV_VARS=(
     "PROXMOX_TOKEN_SECRET"
-    "ANSIBLE_VAULT_PASSWORD"
     "SERVICE_PASSWORD"
     "PORTAINER_ADMIN_PASSWORD"
     "ANTHROPIC_API_KEY"
@@ -34,6 +33,11 @@ if ! bw status 2>/dev/null | grep -q '"status":"unlocked"'; then
     exit 1
 fi
 
+if ! command -v jq &>/dev/null; then
+    echo "❌ jq is not installed."
+    exit 1
+fi
+
 # Start with the template
 if [ -f ".env.template" ]; then
     cp .env.template .env
@@ -45,21 +49,35 @@ fi
 
 echo "Syncing secrets from Bitwarden..."
 
+bw sync >/dev/null
+
+shell_single_quote() {
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
 for env_var in "${ENV_VARS[@]}"; do
-    value=$(bw get password "$env_var" --organizationid "$ORG_ID" 2>/dev/null)
+    value=$(
+        bw list items --search "$env_var" 2>/dev/null \
+            | jq -r --arg name "$env_var" --arg org "$ORG_ID" '
+                .[]
+                | select(.name == $name and .organizationId == $org)
+                | .login.password
+            ' \
+            | head -n1
+    )
     if [ -n "$value" ] && [ "$value" != "null" ]; then
         echo "Processing $env_var..."
 
-        # Escape sed special characters in the value
-        escaped_value=$(printf '%s\n' "$value" | sed 's/[&/\]/\\&/g')
+        quoted_value=$(shell_single_quote "$value")
+        escaped_value=$(printf '%s\n' "$quoted_value" | sed 's/[&/\]/\\&/g')
 
         if grep -q "${env_var}=.*__FROM_BITWARDEN__" .env; then
-            # Replace the placeholder line entirely with single-quoted value
-            sed -i "s|${env_var}=.*__FROM_BITWARDEN__.*|${env_var}='${escaped_value}'|" .env
+            # Replace the placeholder line entirely with a shell-safe single-quoted value.
+            sed -i "s|${env_var}=.*__FROM_BITWARDEN__.*|${env_var}=${escaped_value}|" .env
             echo "✅ Replaced $env_var in template"
         else
             # If not found in template, append it
-            echo "export ${env_var}='${escaped_value}'" >> .env
+            echo "export ${env_var}=${quoted_value}" >> .env
             echo "✅ Added $env_var to end of file"
         fi
     else


### PR DESCRIPTION
## Summary
- expand Bitwarden secret population and sync coverage for current env-managed secrets
- make sync lookups use list-items plus exact org filtering and shell-safe single-quoted output
- align .env.template with the current env structure and safer quoting defaults

## Testing
- bash -n populate-bitwarden.sh
- bash -n sync-secrets.sh
- manual round-trip test with populate and sync against Bitwarden
