### PR TITLE
Security, linting and code quality fixes

### DIFF
--- a/populate-bitwarden.sh
+++ b/populate-bitwarden.sh
@@ -38,7 +38,7 @@ if ! bw status 2>/dev/null | grep -q '"status":"unlocked"'; then
     exit 1
 fi
 
-if [ ! -f ".env" ]; then
+if [[ ! -f ".env" ]]; then
     echo "❌ No .env file found. Create one first."
     exit 1
 fi
@@ -55,7 +55,7 @@ moved_count=0
 for env_var in "${ENV_VARS[@]}"; do
     value="${!env_var:-}"
 
-    if [ -z "$value" ]; then
+    if [[ -z "$value" ]]; then
         echo "⚠️  Skipping $env_var - not set"
         skipped_count=$((skipped_count + 1))
         continue
@@ -81,7 +81,7 @@ for env_var in "${ENV_VARS[@]}"; do
     existing_id=$(printf '%s\n' "$existing_item" | cut -f1)
     existing_org_id=$(printf '%s\n' "$existing_item" | cut -f2)
 
-    if [ -n "$existing_id" ]; then
+    if [[ -n "$existing_id" ]]; then
         echo "🔄 Updating: $env_var"
         echo "$json" | bw encode | bw edit item "$existing_id" --quiet
         updated_count=$((updated_count + 1))
@@ -93,18 +93,14 @@ for env_var in "${ENV_VARS[@]}"; do
         created_count=$((created_count + 1))
     fi
 
-    if [ "${existing_org_id:-}" != "$ORG_ID" ]; then
+    if [[ "${existing_org_id:-}" != "$ORG_ID" ]]; then
         echo "📦 Moving to organization: $env_var"
         move_payload=$(jq -nc --arg coll "$COLLECTION_ID" '[$coll]')
         echo "$move_payload" | bw encode | bw move "$existing_id" "$ORG_ID" --quiet
         moved_count=$((moved_count + 1))
     fi
 
-    if [ $? -eq 0 ]; then
-        echo "   ✅ Done"
-    else
-        echo "   ❌ Failed"
-    fi
+    echo "   ✅ Done"
 done
 
 echo ""

--- a/populate-bitwarden.sh
+++ b/populate-bitwarden.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # populate-bitwarden.sh — Push secrets from .env into Bitwarden
 set -euo pipefail
+export NODE_NO_WARNINGS=1
 
 ORG_ID="03cd75dc-3db4-4b2e-8ecc-af86014151a7"
 COLLECTION_ID="fa8ec932-22d8-4b7e-b13f-b349013d627b"

--- a/sync-secrets.sh
+++ b/sync-secrets.sh
@@ -38,7 +38,7 @@ if ! command -v jq &>/dev/null; then
 fi
 
 # Start with the template
-if [ -f ".env.template" ]; then
+if [[ -f ".env.template" ]]; then
     cp .env.template .env
     echo "Starting with .env.template..."
 else
@@ -64,7 +64,7 @@ for env_var in "${ENV_VARS[@]}"; do
             ' \
             | head -n1
     )
-    if [ -n "$value" ] && [ "$value" != "null" ]; then
+    if [[ -n "$value" && "$value" != "null" ]]; then
         echo "Processing $env_var..."
 
         quoted_value=$(shell_single_quote "$value")

--- a/sync-secrets.sh
+++ b/sync-secrets.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # sync-secrets.sh — Pull secrets from Bitwarden into .env
 set -euo pipefail
+export NODE_NO_WARNINGS=1
 
 ORG_ID="03cd75dc-3db4-4b2e-8ecc-af86014151a7"
 


### PR DESCRIPTION
## Summary

- Replace single-bracket `[ ]` with `[[ ]]` in `populate-bitwarden.sh` and `sync-secrets.sh` (closes #19, closes #20)
- Suppress Node.js `DEP0040` punycode deprecation warnings from Bitwarden CLI (closes #21)
- Exclude `.env` files from SonarCloud analysis
- Add `SONAR_TOKEN` to `.env.template` and Bitwarden sync scripts
- Ignore `.scannerwork` SonarCloud output directory
- Untrack `ansible/_legacy` and add to `.gitignore`
- Various ansible-lint fixes in `proxmox-initial-tests.yml` and `proxmox-initial-setup.yml`
- Add `no_log` to Terraform token parse task to prevent secret leaking into logs
- Fix invalid `pveum user token` permissions command
- Fix PVE subscription nag removal
- Add `apt dist-upgrade` after repo switch

## Test plan

- [ ] `ansible-lint ansible/ --exclude ansible/_legacy/` passes clean
- [ ] `terraform fmt -check -recursive terraform/` passes (pending issues #15)
- [ ] `populate-bitwarden.sh` and `sync-secrets.sh` run without Node.js deprecation warnings
- [ ] SonarCloud scan on main shows 0 open hotspots

🤖 Generated with [Claude Code](https://claude.com/claude-code)