### PR TITLE
feat: merge validated pve-test network layer to main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# Workflow Instructions
+
+## Branching
+
+- `dev/pve-test` is the long-running integration branch tracking the test server state
+- Cut short-lived branches from `dev/pve-test` (e.g. `fix/terraform-fmt`, `feat/harbor-deployment`)
+- Merge short-lived branches → `dev/pve-test`, not `main`
+- PR `dev/pve-test` → `main` only when stable and tested on the test server
+- After merging to `main`, pull `main` back into `dev/pve-test` to stay in sync
+- Never PR directly to `main` unless already on `dev/pve-test` and tested
+
+## Commits and Issues
+
+- After a fix is verified (tests pass, playbook runs clean), commit and close the issue immediately — do not wait to be asked
+- Commit with `Closes #N` in the message
+- Run `gh issue close N --comment "Fixed in commit <sha>"` after committing
+- Do both before reporting back
+
+## Security Scanning
+
+- **snyk**: `/home/steve/.local/bin/snyk iac test terraform/` — Terraform IaC only, not Ansible
+- **sonar-scanner**: `source .env && sonar-scanner` — config in `sonar-project.properties`

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ override.tf.json
 # Terragrunt
 .terragrunt-cache/
 
-# Generated inventory (Terraform output)
+# Generated Terraform outputs in stack dirs
 **/stacks/*/inventory.yml
+**/stacks/*/network-*-vars.yml
 
 # Ansible
 *.retry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Workflow Instructions
+
+## Branching
+
+- `dev/pve-test` is the long-running integration branch tracking the test server state
+- Cut short-lived branches from `dev/pve-test` (e.g. `fix/terraform-fmt`, `feat/harbor-deployment`)
+- Merge short-lived branches → `dev/pve-test`, not `main`
+- PR `dev/pve-test` → `main` only when stable and tested on the test server
+- After merging to `main`, pull `main` back into `dev/pve-test` to stay in sync
+- Never PR directly to `main` unless already on `dev/pve-test` and tested
+
+## Commits and Issues
+
+- After a fix is verified (tests pass, playbook runs clean), commit and close the issue immediately — do not wait to be asked
+- Commit with `Closes #N` in the message
+- Run `gh issue close N --comment "Fixed in commit <sha>"` after committing
+- Do both before reporting back
+
+## Security Scanning
+
+- **snyk**: `/home/steve/.local/bin/snyk iac test terraform/` — Terraform IaC only, not Ansible
+- **sonar-scanner**: `source .env && sonar-scanner` — config in `sonar-project.properties`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Workflow Instructions
+
+## Branching
+
+- `dev/pve-test` is the long-running integration branch tracking the test server state
+- Cut short-lived branches from `dev/pve-test` (e.g. `fix/terraform-fmt`, `feat/harbor-deployment`)
+- Merge short-lived branches → `dev/pve-test`, not `main`
+- PR `dev/pve-test` → `main` only when stable and tested on the test server
+- After merging to `main`, pull `main` back into `dev/pve-test` to stay in sync
+- Never PR directly to `main` unless already on `dev/pve-test` and tested
+
+## Commits and Issues
+
+- After a fix is verified (tests pass, playbook runs clean), commit and close the issue immediately — do not wait to be asked
+- Commit with `Closes #N` in the message
+- Run `gh issue close N --comment "Fixed in commit <sha>"` after committing
+- Do both before reporting back
+
+## Security Scanning
+
+- **snyk**: `/home/steve/.local/bin/snyk iac test terraform/` — Terraform IaC only, not Ansible
+- **sonar-scanner**: `source .env && sonar-scanner` — config in `sonar-project.properties`

--- a/ansible/00-initial-setup/proxmox-initial-setup.yml
+++ b/ansible/00-initial-setup/proxmox-initial-setup.yml
@@ -10,7 +10,7 @@
 # - Idempotent verification that repos are correct
 
 - name: Proxmox VE 9 base configuration
-  hosts: "{{ target_hosts | default('proxmox_production') }}"
+  hosts: "{{ target_hosts | default('proxmox_testbed') }}"
   become: true
   gather_facts: true
 
@@ -44,6 +44,10 @@
     pmx_terraform_user: "automation@pve"
     pmx_terraform_token_id: "terraform"
     pmx_terraform_rotate_token: true          # always create fresh token
+
+    # --- Proxmox firewall backend ---
+    pmx_enable_nftables_firewall_default: false
+    pmx_host_firewall_options_path: "/etc/pve/nodes/{{ ansible_facts['hostname'] }}/host.fw"
 
   pre_tasks:
     - name: Assert Debian 13 (trixie) and Proxmox environment
@@ -247,6 +251,15 @@
           - "TF_VAR_pm_api_token_id={{ terraform_api_token_id | default('') }}"
           - "TF_VAR_pm_api_token_secret={{ terraform_api_token_secret | default('') }}"
       when: pmx_setup_terraform_user
+
+    # ------------------------------
+    # Proxmox firewall backend (host capability)
+    # ------------------------------
+
+    - name: Configure host-level Proxmox firewall backend
+      ansible.builtin.import_tasks: tasks/proxmox-host-firewall-backend.yml
+      tags:
+        - pmx_host_firewall_backend
 
     # ------------------------------
     # IPv6 host tuning for SLAAC (does not touch LXCs)

--- a/ansible/00-initial-setup/tasks/proxmox-host-firewall-backend.yml
+++ b/ansible/00-initial-setup/tasks/proxmox-host-firewall-backend.yml
@@ -1,0 +1,33 @@
+---
+# Host-level Proxmox firewall backend capability.
+# This enables the nftables-backed firewall on the Proxmox host so
+# higher-level network automation can rely on forwarded-traffic policy.
+
+- name: Ensure proxmox-firewall package is installed
+  ansible.builtin.apt:
+    name: proxmox-firewall
+    state: present
+  when: (pmx_enable_nftables_firewall | default(pmx_enable_nftables_firewall_default)) | bool
+
+- name: Enable nftables-backed Proxmox firewall on this host
+  ansible.builtin.shell: |
+    cat > {{ pmx_host_firewall_options_path }} <<'EOF'
+    [OPTIONS]
+    nftables: 1
+    EOF
+  args:
+    executable: /bin/bash
+  when: (pmx_enable_nftables_firewall | default(pmx_enable_nftables_firewall_default)) | bool
+  changed_when: true
+
+- name: Ensure proxmox-firewall service is enabled and running
+  ansible.builtin.systemd:
+    name: proxmox-firewall
+    enabled: true
+    state: started
+  when: (pmx_enable_nftables_firewall | default(pmx_enable_nftables_firewall_default)) | bool
+
+- name: Validate proxmox-firewall compilation
+  ansible.builtin.command: /usr/libexec/proxmox/proxmox-firewall compile
+  when: (pmx_enable_nftables_firewall | default(pmx_enable_nftables_firewall_default)) | bool
+  changed_when: false

--- a/ansible/inventory/dev.yml
+++ b/ansible/inventory/dev.yml
@@ -2,13 +2,18 @@ all:
   children:
     # Proxmox dev/test server
     proxmox:
-      hosts:
-        pve-test.gibbsgreatly.xyz:
-          ansible_host: 192.168.1.40
-          ansible_user: root
-          ansible_ssh_private_key_file: ~/.ssh/id_rsa
-          ansible_python_interpreter: /usr/bin/python3
-          ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+      children:
+        proxmox_testbed:
+          hosts:
+            pve-test.gibbsgreatly.xyz:
+              ansible_host: 192.168.1.40
+              ansible_user: root
+              ansible_ssh_private_key_file: ~/.ssh/id_rsa
+              pmx_enable_nftables_firewall: true
+
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
 
     # Debian template builder containers
     debian_template_builder:

--- a/ansible/inventory/production.yml
+++ b/ansible/inventory/production.yml
@@ -15,6 +15,7 @@ all:
               ansible_host: 192.168.1.40
               ansible_user: root
               ansible_ssh_private_key_file: ~/.ssh/id_rsa
+              pmx_enable_nftables_firewall: true
 
       vars:
         # Common Proxmox variables (apply to ALL Proxmox hosts)

--- a/terraform/lxc/README.md
+++ b/terraform/lxc/README.md
@@ -240,6 +240,29 @@ terraform destroy -target='module.lxc["test-docker"]' \
 terraform destroy
 ```
 
+## Validation
+
+Use the disposable validation stacks on `pve-test` to exercise the network layer end to end.
+
+```bash
+# Single client/service check for the first SDN slice
+./validate-network.sh
+
+# Full 11-case bridge + SDN + isolated matrix
+./validate-network-matrix.sh
+```
+
+`validate-network-matrix.sh` expects generated inventory files for:
+- `net-app-01`
+- `net-svc-01`
+- `net-client-01`
+- `net-service-01`
+- `net-client-02`
+- `net-service-02`
+- `net-isolated-01`
+
+If one of those inventories is missing, apply the corresponding disposable test stack on `pve-test` first.
+
 ## Conventions
 
 - Stack directory name = Terraform map key = Portainer endpoint name

--- a/terraform/lxc/ansible/playbooks/configure-network-firewall.yml
+++ b/terraform/lxc/ansible/playbooks/configure-network-firewall.yml
@@ -1,0 +1,58 @@
+---
+- name: Configure Proxmox firewall policy for an LXC container
+  hosts: all
+  gather_facts: false
+
+  vars:
+    network_firewall_rendered_config: "{{ lookup('template', playbook_dir + '/../templates/lxc-container-firewall.fw.j2') }}"
+
+  tasks:
+    - name: Assert pve-test-only execution
+      ansible.builtin.assert:
+        that:
+          - network_firewall_enable | bool
+          - network_firewall_target == 'pve-test'
+          - network_firewall_pve_host == 'pve-test.gibbsgreatly.xyz'
+          - pve_host == 'pve-test.gibbsgreatly.xyz'
+        fail_msg: "Network-layer firewall automation is restricted to pve-test and must not run on pve."
+        success_msg: "Firewall automation is pinned to pve-test."
+
+    - name: Enable cluster firewall options on pve-test
+      ansible.builtin.shell: |
+        cat > /etc/pve/firewall/cluster.fw <<'EOF'
+        [OPTIONS]
+        enable: 1
+        EOF
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ network_firewall_pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true
+
+    - name: Write container firewall config on pve-test
+      ansible.builtin.shell: |
+        cat > /etc/pve/firewall/{{ network_firewall_vmid }}.fw <<'EOF'
+        {{ network_firewall_rendered_config }}
+        EOF
+        chmod 0640 /etc/pve/firewall/{{ network_firewall_vmid }}.fw
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ network_firewall_pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true
+
+    - name: Validate Proxmox firewall compilation on pve-test
+      ansible.builtin.command:
+        cmd: pve-firewall compile
+      delegate_to: "{{ network_firewall_pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: false

--- a/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
+++ b/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
@@ -1,0 +1,114 @@
+---
+- name: Ensure the pve-test SDN VNet attachment exists
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    network_sdn_nodes_csv: "{{ network_sdn_nodes | join(',') }}"
+
+  tasks:
+    - name: Assert pve-test-only execution
+      ansible.builtin.assert:
+        that:
+          - network_sdn_enable | bool
+          - network_sdn_target == 'pve-test'
+          - network_sdn_pve_host == 'pve-test.gibbsgreatly.xyz'
+          - network_sdn_zone_type == 'simple'
+          - network_sdn_nodes | length > 0
+        fail_msg: "SDN attachment automation is restricted to pve-test simple zones and must not run on pve."
+        success_msg: "SDN attachment automation is pinned to pve-test."
+
+    - name: Read current SDN zones
+      ansible.builtin.command:
+        cmd: pvesh get /cluster/sdn/zones --output-format json
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_sdn_zones_result
+      changed_when: false
+
+    - name: Create simple SDN zone when missing
+      ansible.builtin.command:
+        argv:
+          - pvesh
+          - create
+          - /cluster/sdn/zones
+          - --zone
+          - "{{ network_sdn_zone }}"
+          - --type
+          - "{{ network_sdn_zone_type }}"
+          - --nodes
+          - "{{ network_sdn_nodes_csv }}"
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      when: >-
+        (network_sdn_zones_result.stdout | from_json
+        | selectattr('zone', 'equalto', network_sdn_zone)
+        | list | length) == 0
+      changed_when: true
+
+    - name: Read current SDN VNets
+      ansible.builtin.command:
+        cmd: pvesh get /cluster/sdn/vnets --output-format json
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_sdn_vnets_result
+      changed_when: false
+
+    - name: Create SDN VNet when missing
+      ansible.builtin.command:
+        argv:
+          - pvesh
+          - create
+          - /cluster/sdn/vnets
+          - --vnet
+          - "{{ network_sdn_vnet }}"
+          - --zone
+          - "{{ network_sdn_zone }}"
+          - --alias
+          - "{{ network_sdn_vnet_alias }}"
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      when: >-
+        (network_sdn_vnets_result.stdout | from_json
+        | selectattr('vnet', 'equalto', network_sdn_vnet)
+        | list | length) == 0
+      changed_when: true
+
+    - name: Apply pending SDN changes on pve-test
+      ansible.builtin.command:
+        cmd: pvesh set /cluster/sdn
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: >-
+        (network_sdn_zones_result.stdout | from_json
+        | selectattr('zone', 'equalto', network_sdn_zone)
+        | list | length) == 0
+        or
+        (network_sdn_vnets_result.stdout | from_json
+        | selectattr('vnet', 'equalto', network_sdn_vnet)
+        | list | length) == 0
+
+    - name: Validate proxmox-firewall compilation on pve-test
+      ansible.builtin.command:
+        cmd: /usr/libexec/proxmox/proxmox-firewall compile
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: false

--- a/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
+++ b/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
@@ -5,8 +5,6 @@
 
   vars:
     network_sdn_nodes_csv: "{{ network_sdn_nodes | join(',') }}"
-    network_sdn_legacy_zone_effective: "{{ network_sdn_legacy_zone | default('') }}"
-    network_sdn_legacy_vnet_effective: "{{ network_sdn_legacy_vnet | default('') }}"
 
   tasks:
     - name: Assert pve-test-only execution
@@ -88,89 +86,6 @@
         | list | length) == 0
       changed_when: true
 
-    - name: Inspect pve-test LXC configs for legacy VNet bridge usage
-      ansible.builtin.shell: |
-        grep -R "bridge={{ network_sdn_legacy_vnet_effective }}\\([, ]\\|$\\)" /etc/pve/lxc/*.conf || true
-      args:
-        executable: /bin/bash
-      delegate_to: "{{ network_sdn_pve_host }}"
-      vars:
-        ansible_user: root
-        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
-        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-      register: network_sdn_legacy_bridge_usage
-      when: network_sdn_legacy_vnet_effective | length > 0
-      changed_when: false
-
-    - name: Remove legacy SDN VNet when no guests still use it
-      ansible.builtin.command:
-        argv:
-          - pvesh
-          - delete
-          - "/cluster/sdn/vnets/{{ network_sdn_legacy_vnet_effective }}"
-      delegate_to: "{{ network_sdn_pve_host }}"
-      vars:
-        ansible_user: root
-        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
-        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-      when: >-
-        network_sdn_legacy_vnet_effective | length > 0 and
-        network_sdn_legacy_vnet_effective != network_sdn_vnet and
-        (network_sdn_vnets_result.stdout | from_json
-        | selectattr('vnet', 'equalto', network_sdn_legacy_vnet_effective)
-        | list | length) > 0 and
-        (network_sdn_legacy_bridge_usage.stdout | trim) == ''
-      register: network_sdn_legacy_vnet_delete
-      changed_when: true
-
-    - name: Remove legacy VNet firewall config file when VNet is deleted
-      ansible.builtin.command:
-        cmd: rm -f /etc/pve/sdn/firewall/{{ network_sdn_legacy_vnet_effective }}.fw
-      delegate_to: "{{ network_sdn_pve_host }}"
-      vars:
-        ansible_user: root
-        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
-        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-      when: network_sdn_legacy_vnet_delete is changed
-      changed_when: true
-
-    - name: Refresh SDN VNets after legacy cleanup
-      ansible.builtin.command:
-        cmd: pvesh get /cluster/sdn/vnets --output-format json
-      delegate_to: "{{ network_sdn_pve_host }}"
-      vars:
-        ansible_user: root
-        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
-        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-      register: network_sdn_vnets_after_cleanup_result
-      when: network_sdn_legacy_vnet_effective | length > 0
-      changed_when: false
-
-    - name: Remove legacy SDN zone when no VNets still reference it
-      ansible.builtin.command:
-        argv:
-          - pvesh
-          - delete
-          - "/cluster/sdn/zones/{{ network_sdn_legacy_zone_effective }}"
-      delegate_to: "{{ network_sdn_pve_host }}"
-      vars:
-        ansible_user: root
-        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
-        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-      when: >-
-        network_sdn_legacy_zone_effective | length > 0 and
-        network_sdn_legacy_zone_effective != network_sdn_zone and
-        (network_sdn_zones_result.stdout | from_json
-        | selectattr('zone', 'equalto', network_sdn_legacy_zone_effective)
-        | list | length) > 0 and
-        (
-          (network_sdn_vnets_after_cleanup_result.stdout | default(network_sdn_vnets_result.stdout) | from_json)
-          | selectattr('zone', 'equalto', network_sdn_legacy_zone_effective)
-          | list | length
-        ) == 0
-      register: network_sdn_legacy_zone_delete
-      changed_when: true
-
     - name: Apply pending SDN changes on pve-test
       ansible.builtin.command:
         cmd: pvesh set /cluster/sdn
@@ -187,10 +102,6 @@
         (network_sdn_vnets_result.stdout | from_json
         | selectattr('vnet', 'equalto', network_sdn_vnet)
         | list | length) == 0
-        or
-        (network_sdn_legacy_vnet_delete is defined and network_sdn_legacy_vnet_delete is changed)
-        or
-        (network_sdn_legacy_zone_delete is defined and network_sdn_legacy_zone_delete is changed)
 
     - name: Validate proxmox-firewall compilation on pve-test
       ansible.builtin.command:

--- a/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
+++ b/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml
@@ -5,6 +5,8 @@
 
   vars:
     network_sdn_nodes_csv: "{{ network_sdn_nodes | join(',') }}"
+    network_sdn_legacy_zone_effective: "{{ network_sdn_legacy_zone | default('') }}"
+    network_sdn_legacy_vnet_effective: "{{ network_sdn_legacy_vnet | default('') }}"
 
   tasks:
     - name: Assert pve-test-only execution
@@ -86,6 +88,89 @@
         | list | length) == 0
       changed_when: true
 
+    - name: Inspect pve-test LXC configs for legacy VNet bridge usage
+      ansible.builtin.shell: |
+        grep -R "bridge={{ network_sdn_legacy_vnet_effective }}\\([, ]\\|$\\)" /etc/pve/lxc/*.conf || true
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_sdn_legacy_bridge_usage
+      when: network_sdn_legacy_vnet_effective | length > 0
+      changed_when: false
+
+    - name: Remove legacy SDN VNet when no guests still use it
+      ansible.builtin.command:
+        argv:
+          - pvesh
+          - delete
+          - "/cluster/sdn/vnets/{{ network_sdn_legacy_vnet_effective }}"
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      when: >-
+        network_sdn_legacy_vnet_effective | length > 0 and
+        network_sdn_legacy_vnet_effective != network_sdn_vnet and
+        (network_sdn_vnets_result.stdout | from_json
+        | selectattr('vnet', 'equalto', network_sdn_legacy_vnet_effective)
+        | list | length) > 0 and
+        (network_sdn_legacy_bridge_usage.stdout | trim) == ''
+      register: network_sdn_legacy_vnet_delete
+      changed_when: true
+
+    - name: Remove legacy VNet firewall config file when VNet is deleted
+      ansible.builtin.command:
+        cmd: rm -f /etc/pve/sdn/firewall/{{ network_sdn_legacy_vnet_effective }}.fw
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      when: network_sdn_legacy_vnet_delete is changed
+      changed_when: true
+
+    - name: Refresh SDN VNets after legacy cleanup
+      ansible.builtin.command:
+        cmd: pvesh get /cluster/sdn/vnets --output-format json
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_sdn_vnets_after_cleanup_result
+      when: network_sdn_legacy_vnet_effective | length > 0
+      changed_when: false
+
+    - name: Remove legacy SDN zone when no VNets still reference it
+      ansible.builtin.command:
+        argv:
+          - pvesh
+          - delete
+          - "/cluster/sdn/zones/{{ network_sdn_legacy_zone_effective }}"
+      delegate_to: "{{ network_sdn_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_sdn_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      when: >-
+        network_sdn_legacy_zone_effective | length > 0 and
+        network_sdn_legacy_zone_effective != network_sdn_zone and
+        (network_sdn_zones_result.stdout | from_json
+        | selectattr('zone', 'equalto', network_sdn_legacy_zone_effective)
+        | list | length) > 0 and
+        (
+          (network_sdn_vnets_after_cleanup_result.stdout | default(network_sdn_vnets_result.stdout) | from_json)
+          | selectattr('zone', 'equalto', network_sdn_legacy_zone_effective)
+          | list | length
+        ) == 0
+      register: network_sdn_legacy_zone_delete
+      changed_when: true
+
     - name: Apply pending SDN changes on pve-test
       ansible.builtin.command:
         cmd: pvesh set /cluster/sdn
@@ -102,6 +187,10 @@
         (network_sdn_vnets_result.stdout | from_json
         | selectattr('vnet', 'equalto', network_sdn_vnet)
         | list | length) == 0
+        or
+        (network_sdn_legacy_vnet_delete is defined and network_sdn_legacy_vnet_delete is changed)
+        or
+        (network_sdn_legacy_zone_delete is defined and network_sdn_legacy_zone_delete is changed)
 
     - name: Validate proxmox-firewall compilation on pve-test
       ansible.builtin.command:

--- a/terraform/lxc/ansible/playbooks/configure-network-vnet-firewall.yml
+++ b/terraform/lxc/ansible/playbooks/configure-network-vnet-firewall.yml
@@ -1,0 +1,86 @@
+---
+- name: Configure Proxmox firewall policy for an SDN VNet
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    network_vnet_firewall_rendered_config: "{{ lookup('template', playbook_dir + '/../templates/vnet-firewall.fw.j2') }}"
+
+  tasks:
+    - name: Assert pve-test-only execution
+      ansible.builtin.assert:
+        that:
+          - network_vnet_firewall_enable | bool
+          - network_vnet_firewall_target == 'pve-test'
+          - network_vnet_firewall_pve_host == 'pve-test.gibbsgreatly.xyz'
+          - network_vnet_firewall_vnet | length > 0
+        fail_msg: "VNet firewall automation is restricted to pve-test and must not run on pve."
+        success_msg: "VNet firewall automation is pinned to pve-test."
+
+    - name: Read pve-test host firewall options
+      ansible.builtin.command:
+        cmd: cat /etc/pve/nodes/pve-test/host.fw
+      delegate_to: "{{ network_vnet_firewall_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_vnet_firewall_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_vnet_host_firewall_options
+      changed_when: false
+
+    - name: Assert nftables-backed host firewall is enabled
+      ansible.builtin.assert:
+        that:
+          - "'nftables: 1' in network_vnet_host_firewall_options.stdout"
+        fail_msg: >-
+          VNet firewall enforcement requires the host-level nftables-backed
+          Proxmox firewall to be enabled first. Apply
+          ansible/00-initial-setup/proxmox-initial-setup.yml on pve-test with
+          pmx_enable_nftables_firewall=true before running SDN VNet policy
+          automation.
+        success_msg: "Host-level nftables-backed Proxmox firewall is enabled."
+
+    - name: Ensure SDN firewall directory exists
+      ansible.builtin.command:
+        cmd: mkdir -p /etc/pve/sdn/firewall
+      delegate_to: "{{ network_vnet_firewall_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_vnet_firewall_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: false
+
+    - name: Remove container firewall file for SDN-attached validation container
+      ansible.builtin.command:
+        cmd: rm -f /etc/pve/firewall/{{ network_vnet_firewall_vmid }}.fw
+      delegate_to: "{{ network_vnet_firewall_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_vnet_firewall_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true
+
+    - name: Write VNet firewall config on pve-test
+      ansible.builtin.shell: |
+        cat > /etc/pve/sdn/firewall/{{ network_vnet_firewall_vnet }}.fw <<'EOF'
+        {{ network_vnet_firewall_rendered_config }}
+        EOF
+        chmod 0640 /etc/pve/sdn/firewall/{{ network_vnet_firewall_vnet }}.fw
+      args:
+        executable: /bin/bash
+      delegate_to: "{{ network_vnet_firewall_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_vnet_firewall_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true
+
+    - name: Validate Proxmox firewall compilation on pve-test
+      ansible.builtin.command:
+        cmd: /usr/libexec/proxmox/proxmox-firewall compile
+      delegate_to: "{{ network_vnet_firewall_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_vnet_firewall_ssh_key }}"
+        ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: false

--- a/terraform/lxc/ansible/playbooks/validate-network-layer.yml
+++ b/terraform/lxc/ansible/playbooks/validate-network-layer.yml
@@ -1,0 +1,100 @@
+---
+- name: Validate network-layer policy via pct exec on pve-test
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    network_validation_allowed_port_value: "{{ network_validation_allowed_port | default(8080) | int }}"
+    network_validation_denied_port_value: "{{ network_validation_denied_port | default(8081) | int }}"
+    network_validation_service_ip: "{{ hostvars[network_validation_service_host].ansible_host }}"
+    network_validation_service_vmid: "{{ hostvars[network_validation_service_host].vmid }}"
+    network_validation_client_vmid: "{{ hostvars[network_validation_client_host].vmid }}"
+    network_validation_pve_host: "{{ hostvars[network_validation_service_host].pve_host }}"
+    network_validation_ssh_key: "{{ hostvars[network_validation_service_host].ansible_ssh_private_key_file }}"
+
+  tasks:
+    - name: Start temporary HTTP listeners inside the service validation LXC
+      ansible.builtin.shell: |
+        if [ -f /tmp/net-layer-{{ item }}.hostpid ] && kill -0 "$(cat /tmp/net-layer-{{ item }}.hostpid)" 2>/dev/null; then
+          kill "$(cat /tmp/net-layer-{{ item }}.hostpid)" || true
+          sleep 1
+        fi
+
+        nohup pct exec {{ network_validation_service_vmid }} -- \
+          python3 -m http.server {{ item }} --bind 0.0.0.0 --directory /tmp \
+          >/tmp/net-layer-{{ item }}.log 2>&1 &
+        echo $! > /tmp/net-layer-{{ item }}.hostpid
+      args:
+        executable: /bin/bash
+      loop:
+        - "{{ network_validation_allowed_port_value }}"
+        - "{{ network_validation_denied_port_value }}"
+      delegate_to: "{{ network_validation_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_validation_ssh_key }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true
+
+    - name: Give the temporary listeners a moment to bind
+      ansible.builtin.pause:
+        seconds: 2
+
+    - name: Confirm allowed port is reachable from the client validation LXC
+      ansible.builtin.command:
+        cmd: >-
+          pct exec {{ network_validation_client_vmid }} -- bash -lc
+          "timeout 3 bash -lc 'cat </dev/null >/dev/tcp/{{ network_validation_service_ip }}/{{ network_validation_allowed_port_value }}'"
+      delegate_to: "{{ network_validation_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_validation_ssh_key }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_validation_allowed_result
+      changed_when: false
+
+    - name: Confirm denied port is blocked from the client validation LXC
+      ansible.builtin.command:
+        cmd: >-
+          pct exec {{ network_validation_client_vmid }} -- bash -lc
+          "timeout 3 bash -lc 'cat </dev/null >/dev/tcp/{{ network_validation_service_ip }}/{{ network_validation_denied_port_value }}'"
+      delegate_to: "{{ network_validation_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_validation_ssh_key }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: network_validation_denied_result
+      ignore_errors: true
+      changed_when: false
+
+    - name: Assert expected firewall behavior
+      ansible.builtin.assert:
+        that:
+          - network_validation_allowed_result.rc == 0
+          - network_validation_denied_result is failed
+        fail_msg: >-
+          Expected tcp/{{ network_validation_allowed_port_value }} to be allowed and
+          tcp/{{ network_validation_denied_port_value }} to be denied from
+          {{ network_validation_client_host }} to {{ network_validation_service_host }}.
+        success_msg: >-
+          Validated tcp/{{ network_validation_allowed_port_value }} allowed and
+          tcp/{{ network_validation_denied_port_value }} denied from
+          {{ network_validation_client_host }} to {{ network_validation_service_host }}.
+
+    - name: Stop temporary HTTP listeners inside the service validation LXC
+      ansible.builtin.shell: |
+        if [ -f /tmp/net-layer-{{ item }}.hostpid ] && kill -0 "$(cat /tmp/net-layer-{{ item }}.hostpid)" 2>/dev/null; then
+          kill "$(cat /tmp/net-layer-{{ item }}.hostpid)" || true
+        fi
+        rm -f /tmp/net-layer-{{ item }}.hostpid
+      args:
+        executable: /bin/bash
+      loop:
+        - "{{ network_validation_allowed_port_value }}"
+        - "{{ network_validation_denied_port_value }}"
+      delegate_to: "{{ network_validation_pve_host }}"
+      vars:
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ network_validation_ssh_key }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      changed_when: true

--- a/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
+++ b/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
@@ -1,0 +1,323 @@
+---
+- name: Start network matrix listeners on pve-test
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars: &network_matrix_vars
+    ansible_remote_tmp: /tmp/.ansible/tmp
+    network_matrix_required_hosts:
+      - net-app-01
+      - net-svc-01
+      - net-client-01
+      - net-service-01
+      - net-client-02
+      - net-service-02
+      - net-isolated-01
+    network_matrix_reference_host: net-service-01
+    network_matrix_pve_host: "{{ hostvars[network_matrix_reference_host].pve_host }}"
+    network_matrix_ssh_key: >-
+      {{
+        hostvars[network_matrix_reference_host].ansible_ssh_private_key_file
+        | regex_replace('^~', lookup('env', 'HOME'))
+      }}
+    network_matrix_listener_targets:
+      - host: net-svc-01
+        port: 8080
+      - host: net-svc-01
+        port: 9000
+      - host: net-service-01
+        port: 8080
+      - host: net-service-02
+        port: 8080
+    network_matrix_test_cases:
+      - description: bridge allow net-app-01 to net-svc-01 tcp/8080
+        from_host: net-app-01
+        from_vmid: "{{ hostvars['net-app-01'].vmid }}"
+        to_host: net-svc-01
+        to_ip: "{{ hostvars['net-svc-01'].ansible_host }}"
+        port: 8080
+        expected: allow
+      - description: bridge allow net-app-01 to net-svc-01 tcp/9000
+        from_host: net-app-01
+        from_vmid: "{{ hostvars['net-app-01'].vmid }}"
+        to_host: net-svc-01
+        to_ip: "{{ hostvars['net-svc-01'].ansible_host }}"
+        port: 9000
+        expected: allow
+      - description: sdn1 allow net-client-01 to net-service-01 tcp/8080
+        from_host: net-client-01
+        from_vmid: "{{ hostvars['net-client-01'].vmid }}"
+        to_host: net-service-01
+        to_ip: "{{ hostvars['net-service-01'].ansible_host }}"
+        port: 8080
+        expected: allow
+      - description: sdn2 allow net-client-02 to net-service-02 tcp/8080
+        from_host: net-client-02
+        from_vmid: "{{ hostvars['net-client-02'].vmid }}"
+        to_host: net-service-02
+        to_ip: "{{ hostvars['net-service-02'].ansible_host }}"
+        port: 8080
+        expected: allow
+      - description: bridge deny reverse net-svc-01 to net-app-01 tcp/8080
+        from_host: net-svc-01
+        from_vmid: "{{ hostvars['net-svc-01'].vmid }}"
+        to_host: net-app-01
+        to_ip: "{{ hostvars['net-app-01'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: sdn1 deny reverse net-service-01 to net-client-01 tcp/8080
+        from_host: net-service-01
+        from_vmid: "{{ hostvars['net-service-01'].vmid }}"
+        to_host: net-client-01
+        to_ip: "{{ hostvars['net-client-01'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: sdn2 deny reverse net-service-02 to net-client-02 tcp/8080
+        from_host: net-service-02
+        from_vmid: "{{ hostvars['net-service-02'].vmid }}"
+        to_host: net-client-02
+        to_ip: "{{ hostvars['net-client-02'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: cross-vnet deny net-client-01 to net-service-02 tcp/8080
+        from_host: net-client-01
+        from_vmid: "{{ hostvars['net-client-01'].vmid }}"
+        to_host: net-service-02
+        to_ip: "{{ hostvars['net-service-02'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: cross-vnet deny net-client-02 to net-service-01 tcp/8080
+        from_host: net-client-02
+        from_vmid: "{{ hostvars['net-client-02'].vmid }}"
+        to_host: net-service-01
+        to_ip: "{{ hostvars['net-service-01'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: isolated deny net-app-01 to net-isolated-01 tcp/8080
+        from_host: net-app-01
+        from_vmid: "{{ hostvars['net-app-01'].vmid }}"
+        to_host: net-isolated-01
+        to_ip: "{{ hostvars['net-isolated-01'].ansible_host }}"
+        port: 8080
+        expected: deny
+      - description: isolated deny net-isolated-01 to net-svc-01 tcp/8080
+        from_host: net-isolated-01
+        from_vmid: "{{ hostvars['net-isolated-01'].vmid }}"
+        to_host: net-svc-01
+        to_ip: "{{ hostvars['net-svc-01'].ansible_host }}"
+        port: 8080
+        expected: deny
+
+  pre_tasks:
+    - name: Assert required hosts are present in inventory
+      ansible.builtin.assert:
+        that:
+          - item in hostvars
+        fail_msg: >-
+          Missing required host {{ item }} in inventory for validate-network-matrix.yml.
+          Deploy the dependent disposable test stacks and include their inventory.yml files.
+      loop: "{{ network_matrix_required_hosts }}"
+
+  tasks:
+    - name: Clear stale matrix listeners inside target containers
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -F
+          - /dev/null
+          - -i
+          - "{{ network_matrix_ssh_key }}"
+          - -o
+          - StrictHostKeyChecking=no
+          - -o
+          - UserKnownHostsFile=/dev/null
+          - -o
+          - LogLevel=ERROR
+          - "root@{{ network_matrix_pve_host }}"
+          - pct
+          - exec
+          - "{{ hostvars[item.host].vmid }}"
+          - --
+          - sh
+          - -lc
+          - pkill -f nc >/dev/null 2>&1 || true
+      loop: "{{ network_matrix_listener_targets }}"
+      loop_control:
+        label: "{{ item.host }}:{{ item.port }}"
+      ignore_errors: true
+      changed_when: false
+
+    - name: Start listener processes for matrix targets
+      ansible.builtin.shell: |
+        if [ -f /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid ] && kill -0 "$(cat /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid)" 2>/dev/null; then
+          kill "$(cat /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid)" || true
+          sleep 1
+        fi
+
+        nohup ssh -F /dev/null \
+          -i {{ network_matrix_ssh_key | quote }} \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          -o LogLevel=ERROR \
+          root@{{ network_matrix_pve_host }} \
+          pct exec {{ hostvars[item.host].vmid }} -- bash -lc \
+          {{ ("while true; do nc -l -p " ~ item.port ~ " >/dev/null; done") | quote }} \
+          >/tmp/network-matrix-{{ item.host }}-{{ item.port }}.log 2>&1 &
+        echo $! > /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid
+      args:
+        executable: /bin/bash
+      loop: "{{ network_matrix_listener_targets }}"
+      loop_control:
+        label: "{{ item.host }}:{{ item.port }}"
+      changed_when: true
+
+    - name: Give matrix listeners a moment to bind
+      ansible.builtin.pause:
+        seconds: 2
+
+- name: Run network matrix test cases on pve-test
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars: *network_matrix_vars
+
+  pre_tasks:
+    - name: Assert required hosts are present in inventory
+      ansible.builtin.assert:
+        that:
+          - item in hostvars
+      loop: "{{ network_matrix_required_hosts }}"
+
+  tasks:
+    - name: Execute network matrix test cases
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -F
+          - /dev/null
+          - -i
+          - "{{ network_matrix_ssh_key }}"
+          - -o
+          - StrictHostKeyChecking=no
+          - -o
+          - UserKnownHostsFile=/dev/null
+          - -o
+          - LogLevel=ERROR
+          - "root@{{ network_matrix_pve_host }}"
+          - pct
+          - exec
+          - "{{ item.from_vmid }}"
+          - --
+          - nc
+          - -z
+          - -w2
+          - "{{ item.to_ip }}"
+          - "{{ item.port | string }}"
+      loop: "{{ network_matrix_test_cases }}"
+      loop_control:
+        label: "{{ item.description }}"
+      register: network_matrix_case_commands
+      ignore_errors: true
+      changed_when: false
+
+    - name: Persist network matrix results for later plays
+      ansible.builtin.set_fact:
+        network_matrix_results: >-
+          {%- set results = [] -%}
+          {%- for result in network_matrix_case_commands.results -%}
+          {%- set passed = (result.item.expected == 'allow' and result.rc == 0) or (result.item.expected == 'deny' and result.rc != 0) -%}
+          {%- set _ = results.append({
+            'description': result.item.description,
+            'from_host': result.item.from_host,
+            'to_host': result.item.to_host,
+            'to_ip': result.item.to_ip,
+            'port': result.item.port,
+            'expected': result.item.expected,
+            'rc': result.rc,
+            'passed': passed
+          }) -%}
+          {%- endfor -%}
+          {{ results }}
+
+- name: Stop network matrix listeners on pve-test
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars: *network_matrix_vars
+
+  tasks:
+    - name: Stop listener processes inside target containers
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -F
+          - /dev/null
+          - -i
+          - "{{ network_matrix_ssh_key }}"
+          - -o
+          - StrictHostKeyChecking=no
+          - -o
+          - UserKnownHostsFile=/dev/null
+          - -o
+          - LogLevel=ERROR
+          - "root@{{ network_matrix_pve_host }}"
+          - pct
+          - exec
+          - "{{ hostvars[item.host].vmid }}"
+          - --
+          - sh
+          - -lc
+          - pkill -f nc >/dev/null 2>&1 || true
+      loop: "{{ network_matrix_listener_targets }}"
+      loop_control:
+        label: "{{ item.host }}:{{ item.port }}"
+      ignore_errors: true
+      changed_when: true
+
+    - name: Stop host-side ssh wrapper processes
+      ansible.builtin.shell: |
+        if [ -f /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid ] && kill -0 "$(cat /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid)" 2>/dev/null; then
+          kill "$(cat /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid)" || true
+        fi
+        rm -f /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid
+      args:
+        executable: /bin/bash
+      loop: "{{ network_matrix_listener_targets }}"
+      loop_control:
+        label: "{{ item.host }}:{{ item.port }}"
+      changed_when: true
+
+- name: Report network matrix results
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Print per-case matrix results
+      ansible.builtin.debug:
+        msg: >-
+          [{{ 'PASS' if item.passed else 'FAIL' }}]
+          {{ item.description }}
+          ({{ item.from_host }} -> {{ item.to_host }}:{{ item.port }},
+          expected={{ item.expected }}, rc={{ item.rc }})
+      loop: "{{ hostvars['localhost'].network_matrix_results | default([]) }}"
+
+    - name: Assert all matrix cases passed
+      ansible.builtin.assert:
+        that:
+          - (hostvars['localhost'].network_matrix_results | rejectattr('passed', 'equalto', true) | list | length) == 0
+        fail_msg: >-
+          Network matrix validation failed for:
+          {{
+            hostvars['localhost'].network_matrix_results
+            | rejectattr('passed', 'equalto', true)
+            | map(attribute='description')
+            | join('; ')
+          }}
+        success_msg: >-
+          Validated {{
+            hostvars['localhost'].network_matrix_results | length
+          }} network matrix cases on pve-test.

--- a/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
+++ b/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
@@ -31,77 +31,77 @@
       - host: net-service-02
         port: 8080
     network_matrix_test_cases:
-      - description: bridge allow net-app-01 to net-svc-01 tcp/8080
+      - description: "policy: app -> services tcp/8080 ALLOW"
         from_host: net-app-01
         from_vmid: "{{ hostvars['net-app-01'].vmid }}"
         to_host: net-svc-01
         to_ip: "{{ hostvars['net-svc-01'].ansible_host }}"
         port: 8080
         expected: allow
-      - description: bridge allow net-app-01 to net-svc-01 tcp/9000
+      - description: "policy: app -> services tcp/9000 ALLOW"
         from_host: net-app-01
         from_vmid: "{{ hostvars['net-app-01'].vmid }}"
         to_host: net-svc-01
         to_ip: "{{ hostvars['net-svc-01'].ansible_host }}"
         port: 9000
         expected: allow
-      - description: sdn1 allow net-client-01 to net-service-01 tcp/8080
+      - description: "policy: app_vnet1 -> svc_vnet1 tcp/8080 ALLOW"
         from_host: net-client-01
         from_vmid: "{{ hostvars['net-client-01'].vmid }}"
         to_host: net-service-01
         to_ip: "{{ hostvars['net-service-01'].ansible_host }}"
         port: 8080
         expected: allow
-      - description: sdn2 allow net-client-02 to net-service-02 tcp/8080
+      - description: "policy: app_vnet2 -> svc_vnet2 tcp/8080 ALLOW"
         from_host: net-client-02
         from_vmid: "{{ hostvars['net-client-02'].vmid }}"
         to_host: net-service-02
         to_ip: "{{ hostvars['net-service-02'].ansible_host }}"
         port: 8080
         expected: allow
-      - description: bridge deny reverse net-svc-01 to net-app-01 tcp/8080
+      - description: "policy: services -> app tcp/8080 DENY (no return rule)"
         from_host: net-svc-01
         from_vmid: "{{ hostvars['net-svc-01'].vmid }}"
         to_host: net-app-01
         to_ip: "{{ hostvars['net-app-01'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: sdn1 deny reverse net-service-01 to net-client-01 tcp/8080
+      - description: "policy: svc_vnet1 -> app_vnet1 tcp/8080 DENY (no return rule)"
         from_host: net-service-01
         from_vmid: "{{ hostvars['net-service-01'].vmid }}"
         to_host: net-client-01
         to_ip: "{{ hostvars['net-client-01'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: sdn2 deny reverse net-service-02 to net-client-02 tcp/8080
+      - description: "policy: svc_vnet2 -> app_vnet2 tcp/8080 DENY (no return rule)"
         from_host: net-service-02
         from_vmid: "{{ hostvars['net-service-02'].vmid }}"
         to_host: net-client-02
         to_ip: "{{ hostvars['net-client-02'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: cross-vnet deny net-client-01 to net-service-02 tcp/8080
+      - description: "policy: app_vnet1 -> svc_vnet2 tcp/8080 DENY (no cross-vnet rule)"
         from_host: net-client-01
         from_vmid: "{{ hostvars['net-client-01'].vmid }}"
         to_host: net-service-02
         to_ip: "{{ hostvars['net-service-02'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: cross-vnet deny net-client-02 to net-service-01 tcp/8080
+      - description: "policy: app_vnet2 -> svc_vnet1 tcp/8080 DENY (no cross-vnet rule)"
         from_host: net-client-02
         from_vmid: "{{ hostvars['net-client-02'].vmid }}"
         to_host: net-service-01
         to_ip: "{{ hostvars['net-service-01'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: isolated deny net-app-01 to net-isolated-01 tcp/8080
+      - description: "policy: app -> isolated tcp/8080 DENY (no isolated allow rule)"
         from_host: net-app-01
         from_vmid: "{{ hostvars['net-app-01'].vmid }}"
         to_host: net-isolated-01
         to_ip: "{{ hostvars['net-isolated-01'].ansible_host }}"
         port: 8080
         expected: deny
-      - description: isolated deny net-isolated-01 to net-svc-01 tcp/8080
+      - description: "policy: isolated -> services tcp/8080 DENY (no isolated allow rule)"
         from_host: net-isolated-01
         from_vmid: "{{ hostvars['net-isolated-01'].vmid }}"
         to_host: net-svc-01

--- a/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
+++ b/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
@@ -161,8 +161,7 @@
           -o UserKnownHostsFile=/dev/null \
           -o LogLevel=ERROR \
           root@{{ network_matrix_pve_host }} \
-          pct exec {{ hostvars[item.host].vmid }} -- bash -lc \
-          {{ ("while true; do nc -l -p " ~ item.port ~ " >/dev/null; done") | quote }} \
+          "pct exec {{ hostvars[item.host].vmid }} -- sh -lc 'while true; do nc -l -p {{ item.port }} >/dev/null; done'" \
           >/tmp/network-matrix-{{ item.host }}-{{ item.port }}.log 2>&1 &
         echo $! > /tmp/network-matrix-{{ item.host }}-{{ item.port }}.hostpid
       args:
@@ -219,8 +218,8 @@
       loop_control:
         label: "{{ item.description }}"
       register: network_matrix_case_commands
-      ignore_errors: true
       changed_when: false
+      failed_when: false
 
     - name: Persist network matrix results for later plays
       ansible.builtin.set_fact:

--- a/terraform/lxc/ansible/templates/lxc-container-firewall.fw.j2
+++ b/terraform/lxc/ansible/templates/lxc-container-firewall.fw.j2
@@ -1,0 +1,9 @@
+[OPTIONS]
+enable: {{ 1 if network_firewall_enable else 0 }}
+policy_in: {{ network_firewall_policy_in }}
+policy_out: {{ network_firewall_policy_out }}
+
+[RULES]
+{% for rule in network_firewall_rules %}
+{{ rule.type | upper }} {{ rule.action | upper }} -source {{ rule.source }} -p {{ rule.protocol }} -dport {{ rule.destination }}
+{% endfor %}

--- a/terraform/lxc/ansible/templates/vnet-firewall.fw.j2
+++ b/terraform/lxc/ansible/templates/vnet-firewall.fw.j2
@@ -1,0 +1,8 @@
+[OPTIONS]
+enable: {{ 1 if network_vnet_firewall_enable else 0 }}
+policy_forward: {{ network_vnet_firewall_policy_forward }}
+
+[RULES]
+{% for rule in network_vnet_firewall_rules %}
+FORWARD {{ rule.action | upper }} -source {{ rule.source }} -dest {{ rule.destination }} -p {{ rule.protocol }} -{{ rule.port_direction }}port {{ rule.port }}
+{% endfor %}

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -26,6 +26,185 @@ locals {
   stack_dir   = dirname(var.stack_yaml_path)      # …/stacks/<name>
   lxc_root    = dirname(dirname(local.stack_dir)) # …/terraform/lxc
   ansible_dir = "${local.lxc_root}/ansible"
+
+  # Optional declarative network intent. Existing stacks continue to use the
+  # current bridge defaults unless they opt in with stack.network.zone.
+  stack_network               = try(local.stack.network, null)
+  stack_network_zone          = try(local.stack.network.zone, null)
+  network_intent_default_path = "${local.lxc_root}/network/pve-test.yaml"
+  effective_network_intent_path = coalesce(
+    var.network_intent_path,
+    local.network_intent_default_path
+  )
+
+  network_intent = local.stack_network_zone != null ? yamldecode(file(local.effective_network_intent_path)) : null
+
+  resolved_zone_attachment_name = local.stack_network_zone != null ? local.network_intent.zones[local.stack_network_zone].attachment : null
+  resolved_zone_attachment      = local.resolved_zone_attachment_name != null ? local.network_intent.attachments[local.resolved_zone_attachment_name] : null
+  resolved_attachment_type      = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.type, "bridge") : "bridge"
+  resolved_sdn_attachment       = local.resolved_attachment_type == "sdn_vnet" ? try(local.resolved_zone_attachment.sdn, null) : null
+
+  effective_target_node = local.stack_network_zone != null ? local.network_intent.proxmox.target_node : try(local.stack.target_node, var.proxmox_node)
+  effective_pve_host    = local.stack_network_zone != null ? local.network_intent.proxmox.pve_host : try(local.stack.proxmox_host, var.proxmox_host)
+
+  effective_network_bridge = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.bridge, "vmbr0") : try(local.stack.network_bridge, "vmbr0")
+  effective_vlan_tag       = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.vlan_tag, null) : null
+  effective_firewall       = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.firewall, null) : null
+
+  all_stack_yaml_paths = fileset(local.lxc_root, "stacks/*/stack.yaml")
+  all_zone_members = [
+    for relpath in local.all_stack_yaml_paths : {
+      stack_name  = basename(dirname(relpath))
+      zone        = try(yamldecode(file("${local.lxc_root}/${relpath}")).network.zone, null)
+      ip_address  = split("/", yamldecode(file("${local.lxc_root}/${relpath}")).ip_address)[0]
+      description = try(yamldecode(file("${local.lxc_root}/${relpath}")).hostname, basename(dirname(relpath)))
+    }
+  ]
+
+  zone_members = try(tomap({
+    for zone_name, _zone in local.network_intent.zones :
+    zone_name => [
+      for member in local.all_zone_members : {
+        stack_name  = member.stack_name
+        ip_address  = member.ip_address
+        description = member.description
+      }
+      if member.zone == zone_name
+    ]
+  }), tomap({}))
+
+  inbound_zone_policies = try([
+    for policy in local.network_intent.policies : policy
+    if try(policy.to, null) == local.stack_network_zone
+  ], tolist([]))
+
+  vnet_policy_candidates = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? try([
+    for policy in local.network_intent.policies : merge(policy, {
+      from_attachment_name = try(local.network_intent.zones[policy.from].attachment, null)
+      to_attachment_name   = try(local.network_intent.zones[policy.to].attachment, null)
+    })
+    if try(local.network_intent.attachments[local.network_intent.zones[policy.from].attachment].type, "bridge") == "sdn_vnet" &&
+    try(local.network_intent.attachments[local.network_intent.zones[policy.to].attachment].type, "bridge") == "sdn_vnet" &&
+    try(local.network_intent.attachments[local.network_intent.zones[policy.from].attachment].sdn.vnet, null) == try(local.resolved_sdn_attachment.vnet, null) &&
+    try(local.network_intent.attachments[local.network_intent.zones[policy.to].attachment].sdn.vnet, null) == try(local.resolved_sdn_attachment.vnet, null)
+  ], tolist([])) : tolist([])
+
+  effective_firewall_rules = local.stack_network_zone != null && local.effective_firewall == true ? tolist(flatten([
+    for policy in local.inbound_zone_policies : [
+      for member in lookup(local.zone_members, policy.from, []) : {
+        type        = "in"
+        action      = "ACCEPT"
+        source      = member.ip_address
+        protocol    = lower(policy.protocol)
+        destination = join(",", [for port in try(policy.ports, []) : tostring(port)])
+        comment     = "${policy.from}-to-${policy.to}:${member.description}"
+      }
+    ]
+  ])) : tolist([])
+
+  effective_vnet_firewall_rules = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && local.effective_firewall == true ? tolist(flatten([
+    for policy in local.vnet_policy_candidates : flatten([
+      for source_member in lookup(local.zone_members, policy.from, []) : [
+        for dest_member in lookup(local.zone_members, policy.to, []) : [
+          for port in try(policy.ports, []) : [
+            {
+              action         = "ACCEPT"
+              source         = source_member.ip_address
+              destination    = dest_member.ip_address
+              protocol       = lower(policy.protocol)
+              port_direction = "d"
+              port           = tostring(port)
+            },
+            {
+              action         = "ACCEPT"
+              source         = dest_member.ip_address
+              destination    = source_member.ip_address
+              protocol       = lower(policy.protocol)
+              port_direction = "s"
+              port           = tostring(port)
+            }
+          ]
+        ]
+      ]
+    ])
+  ])) : tolist([])
+}
+
+check "network_layer_runs_only_on_pve_test" {
+  assert {
+    condition = local.stack_network_zone == null || (
+      local.effective_target_node == "pve-test" &&
+      local.effective_pve_host == "pve-test.gibbsgreatly.xyz"
+    )
+    error_message = "Stacks using stack.network.zone must target pve-test (node pve-test, host pve-test.gibbsgreatly.xyz) and must not run on pve."
+  }
+}
+
+check "network_layer_attachment_type_is_supported" {
+  assert {
+    condition     = local.stack_network_zone == null || contains(["bridge", "sdn_vnet"], local.resolved_attachment_type)
+    error_message = "Network intent attachments must use type 'bridge' or 'sdn_vnet'."
+  }
+}
+
+check "network_layer_sdn_attachment_is_complete" {
+  assert {
+    condition = local.stack_network_zone == null || local.resolved_attachment_type != "sdn_vnet" || (
+      local.resolved_sdn_attachment != null &&
+      try(local.resolved_sdn_attachment.zone, "") != "" &&
+      try(local.resolved_sdn_attachment.zone_type, "") != "" &&
+      length(try(local.resolved_sdn_attachment.nodes, [])) > 0 &&
+      try(local.resolved_sdn_attachment.vnet, "") != ""
+    )
+    error_message = "Attachments of type 'sdn_vnet' must define sdn.zone, sdn.zone_type, sdn.nodes, and sdn.vnet."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Proxmox SDN vars (only if network intent selects an SDN VNet attachment)
+# Ensures the attachment exists on pve-test before the LXC is created.
+# ---------------------------------------------------------------------------
+resource "local_file" "network_sdn_vars" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? 1 : 0
+
+  filename = "${local.stack_dir}/network-sdn-vars.yml"
+  content = yamlencode({
+    network_sdn_enable     = true
+    network_sdn_target     = local.effective_target_node
+    network_sdn_pve_host   = local.effective_pve_host
+    network_sdn_zone       = try(local.resolved_sdn_attachment.zone, null)
+    network_sdn_zone_type  = try(local.resolved_sdn_attachment.zone_type, null)
+    network_sdn_nodes      = try(local.resolved_sdn_attachment.nodes, [])
+    network_sdn_vnet       = try(local.resolved_sdn_attachment.vnet, null)
+    network_sdn_vnet_alias = try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet)
+    network_sdn_ssh_key    = pathexpand(var.ssh_private_key_path)
+  })
+}
+
+resource "null_resource" "configure_network_sdn_attachment" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? 1 : 0
+
+  triggers = {
+    sdn_vars = local_file.network_sdn_vars[0].content
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      ansible-playbook \
+        -i localhost, \
+        playbooks/configure-network-sdn-vnet.yml \
+        -e '@${local.stack_dir}/network-sdn-vars.yml'
+    EOT
+    working_dir = local.ansible_dir
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING    = "False"
+      ANSIBLE_LOCAL_TEMP           = "/tmp/.ansible/tmp"
+      ANSIBLE_SSH_CONTROL_PATH_DIR = "/tmp/.ansible/cp"
+    }
+  }
+
+  depends_on = [local_file.network_sdn_vars]
 }
 
 # ---------------------------------------------------------------------------
@@ -34,7 +213,7 @@ locals {
 module "lxc" {
   source = "./modules/lxc-docker-host"
 
-  target_node  = try(local.stack.target_node, var.proxmox_node)
+  target_node  = local.effective_target_node
   hostname     = coalesce(var.stack_hostname, local.stack.hostname)
   vmid         = try(local.stack.vmid, null)
   ip_address   = coalesce(var.stack_ip_address, local.stack.ip_address)
@@ -48,13 +227,17 @@ module "lxc" {
   rootfs_storage      = try(local.stack.rootfs_storage, var.default_storage)
   docker_storage_size = try(local.stack.docker_storage_size, "20G")
 
-  ostemplate      = try(local.stack.ostemplate, "local:vztmpl/debian-docker-template.tar.gz")
-  ssh_public_keys = file(pathexpand(var.ssh_public_key_path))
-  tags            = try(local.stack.tags, [local.stack_name])
+  ostemplate       = try(local.stack.ostemplate, "local:vztmpl/debian-docker-template.tar.gz")
+  ssh_public_keys  = file(pathexpand(var.ssh_public_key_path))
+  tags             = try(local.stack.tags, [local.stack_name])
+  network_bridge   = local.effective_network_bridge
+  network_firewall = local.effective_firewall == true
 
   extra_mount_path    = try(local.stack.extra_mount_path, null)
   extra_mount_size    = try(local.stack.extra_mount_size, null)
   extra_mount_storage = try(local.stack.extra_mount_storage, null)
+
+  depends_on = [null_resource.configure_network_sdn_attachment]
 }
 
 # ---------------------------------------------------------------------------
@@ -71,7 +254,7 @@ resource "local_file" "ansible_inventory" {
     portainer_server_ip = try(local.stack.portainer_server_ip, var.portainer_server_ip)
     app_stack_name      = coalesce(var.stack_app_name, try(local.stack.app_stack_name, null), local.stack_name)
     vmid                = module.lxc.container_id
-    pve_host            = try(local.stack.proxmox_host, var.proxmox_host)
+    pve_host            = local.effective_pve_host
   })
 }
 
@@ -95,11 +278,33 @@ resource "null_resource" "configure_keyctl" {
     working_dir = local.ansible_dir
 
     environment = {
-      ANSIBLE_HOST_KEY_CHECKING = "False"
+      ANSIBLE_HOST_KEY_CHECKING    = "False"
+      ANSIBLE_LOCAL_TEMP           = "/tmp/.ansible/tmp"
+      ANSIBLE_SSH_CONTROL_PATH_DIR = "/tmp/.ansible/cp"
     }
   }
 
   depends_on = [local_file.ansible_inventory]
+}
+
+# ---------------------------------------------------------------------------
+# Proxmox firewall vars (only if network intent enables firewall for this zone)
+# ---------------------------------------------------------------------------
+resource "local_file" "network_firewall_vars" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "bridge" && local.effective_firewall == true ? 1 : 0
+
+  filename = "${local.stack_dir}/network-firewall-vars.yml"
+  content = yamlencode({
+    network_firewall_enable     = true
+    network_firewall_policy_in  = "DROP"
+    network_firewall_policy_out = "ACCEPT"
+    network_firewall_rules      = local.effective_firewall_rules
+    network_firewall_vmid       = module.lxc.container_id
+    network_firewall_target     = local.effective_target_node
+    network_firewall_pve_host   = local.effective_pve_host
+  })
+
+  depends_on = [module.lxc]
 }
 
 # ---------------------------------------------------------------------------
@@ -129,6 +334,94 @@ resource "null_resource" "ansible_provision" {
   }
 
   depends_on = [local_file.ansible_inventory, null_resource.configure_keyctl]
+}
+
+# ---------------------------------------------------------------------------
+# Proxmox firewall policy apply (only if network intent enables firewall)
+# Applies after any guest provisioning to avoid disrupting the existing flow.
+# ---------------------------------------------------------------------------
+resource "null_resource" "configure_network_firewall" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "bridge" && local.effective_firewall == true ? 1 : 0
+
+  triggers = {
+    container_id      = module.lxc.container_id
+    inventory_content = local_file.ansible_inventory.content
+    firewall_vars     = local_file.network_firewall_vars[0].content
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      ansible-playbook \
+        -i '${local.stack_dir}/inventory.yml' \
+        playbooks/configure-network-firewall.yml \
+        -e '@${local.stack_dir}/network-firewall-vars.yml'
+    EOT
+    working_dir = local.ansible_dir
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING    = "False"
+      ANSIBLE_LOCAL_TEMP           = "/tmp/.ansible/tmp"
+      ANSIBLE_SSH_CONTROL_PATH_DIR = "/tmp/.ansible/cp"
+    }
+  }
+
+  depends_on = [
+    local_file.ansible_inventory,
+    local_file.network_firewall_vars,
+    null_resource.configure_keyctl,
+    null_resource.ansible_provision,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Proxmox VNet firewall vars (only if network intent enables SDN VNet firewall)
+# Applies a single VNet-level forward policy for the shared SDN attachment.
+# ---------------------------------------------------------------------------
+resource "local_file" "network_vnet_firewall_vars" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && local.effective_firewall == true ? 1 : 0
+
+  filename = "${local.stack_dir}/network-vnet-firewall-vars.yml"
+  content = yamlencode({
+    network_vnet_firewall_enable         = true
+    network_vnet_firewall_policy_forward = "DROP"
+    network_vnet_firewall_rules          = local.effective_vnet_firewall_rules
+    network_vnet_firewall_vnet           = try(local.resolved_sdn_attachment.vnet, null)
+    network_vnet_firewall_vmid           = module.lxc.container_id
+    network_vnet_firewall_target         = local.effective_target_node
+    network_vnet_firewall_pve_host       = local.effective_pve_host
+    network_vnet_firewall_ssh_key        = pathexpand(var.ssh_private_key_path)
+  })
+
+  depends_on = [module.lxc]
+}
+
+resource "null_resource" "configure_network_vnet_firewall" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && local.effective_firewall == true ? 1 : 0
+
+  triggers = {
+    container_id       = module.lxc.container_id
+    vnet_firewall_vars = local_file.network_vnet_firewall_vars[0].content
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      ansible-playbook \
+        -i localhost, \
+        playbooks/configure-network-vnet-firewall.yml \
+        -e '@${local.stack_dir}/network-vnet-firewall-vars.yml'
+    EOT
+    working_dir = local.ansible_dir
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING = "False"
+    }
+  }
+
+  depends_on = [
+    local_file.network_vnet_firewall_vars,
+    null_resource.configure_keyctl,
+    null_resource.ansible_provision,
+  ]
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -97,7 +97,7 @@ locals {
         source      = member.ip_address
         protocol    = lower(policy.protocol)
         destination = join(",", [for port in try(policy.ports, []) : tostring(port)])
-        comment     = "${policy.from}-to-${policy.to}:${member.description}"
+        comment     = "${try(local.network_intent.zones[policy.from].description, policy.from)} -> ${try(local.network_intent.zones[policy.to].description, policy.to)} (${member.description})"
       }
     ]
   ])) : tolist([])
@@ -176,7 +176,7 @@ resource "local_file" "network_sdn_vars" {
     network_sdn_zone_type  = try(local.resolved_sdn_attachment.zone_type, null)
     network_sdn_nodes      = try(local.resolved_sdn_attachment.nodes, [])
     network_sdn_vnet       = try(local.resolved_sdn_attachment.vnet, null)
-    network_sdn_vnet_alias = try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet)
+    network_sdn_vnet_alias = try(local.resolved_zone_attachment.description, try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet))
     network_sdn_ssh_key    = pathexpand(var.ssh_private_key_path)
   })
 }

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -91,7 +91,7 @@ locals {
 
   effective_firewall_rules = local.stack_network_zone != null && local.effective_firewall == true ? tolist(flatten([
     for policy in local.inbound_zone_policies : [
-      for member in lookup(local.zone_members, policy.from, []) : {
+      for member in try(local.zone_members[policy.from], []) : {
         type        = "in"
         action      = "ACCEPT"
         source      = member.ip_address
@@ -104,8 +104,8 @@ locals {
 
   effective_vnet_firewall_rules = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && local.effective_firewall == true ? tolist(flatten([
     for policy in local.vnet_policy_candidates : flatten([
-      for source_member in lookup(local.zone_members, policy.from, []) : [
-        for dest_member in lookup(local.zone_members, policy.to, []) : [
+      for source_member in try(local.zone_members[policy.from], []) : [
+        for dest_member in try(local.zone_members[policy.to], []) : [
           for port in try(policy.ports, []) : [
             {
               action         = "ACCEPT"

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -169,17 +169,15 @@ resource "local_file" "network_sdn_vars" {
 
   filename = "${local.stack_dir}/network-sdn-vars.yml"
   content = yamlencode({
-    network_sdn_enable      = true
-    network_sdn_target      = local.effective_target_node
-    network_sdn_pve_host    = local.effective_pve_host
-    network_sdn_zone        = try(local.resolved_sdn_attachment.zone, null)
-    network_sdn_legacy_zone = try(local.resolved_sdn_attachment.legacy_zone, null)
-    network_sdn_zone_type   = try(local.resolved_sdn_attachment.zone_type, null)
-    network_sdn_nodes       = try(local.resolved_sdn_attachment.nodes, [])
-    network_sdn_vnet        = try(local.resolved_sdn_attachment.vnet, null)
-    network_sdn_legacy_vnet = try(local.resolved_sdn_attachment.legacy_vnet, null)
-    network_sdn_vnet_alias  = try(local.resolved_zone_attachment.description, try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet))
-    network_sdn_ssh_key     = pathexpand(var.ssh_private_key_path)
+    network_sdn_enable     = true
+    network_sdn_target     = local.effective_target_node
+    network_sdn_pve_host   = local.effective_pve_host
+    network_sdn_zone       = try(local.resolved_sdn_attachment.zone, null)
+    network_sdn_zone_type  = try(local.resolved_sdn_attachment.zone_type, null)
+    network_sdn_nodes      = try(local.resolved_sdn_attachment.nodes, [])
+    network_sdn_vnet       = try(local.resolved_sdn_attachment.vnet, null)
+    network_sdn_vnet_alias = try(local.resolved_zone_attachment.description, try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet))
+    network_sdn_ssh_key    = pathexpand(var.ssh_private_key_path)
   })
 }
 
@@ -207,36 +205,6 @@ resource "null_resource" "configure_network_sdn_attachment" {
   }
 
   depends_on = [local_file.network_sdn_vars]
-}
-
-resource "null_resource" "cleanup_network_sdn_attachment_legacy" {
-  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? 1 : 0
-
-  triggers = {
-    container_id = module.lxc.container_id
-    sdn_vars     = local_file.network_sdn_vars[0].content
-  }
-
-  provisioner "local-exec" {
-    command     = <<-EOT
-      ansible-playbook \
-        -i localhost, \
-        playbooks/configure-network-sdn-vnet.yml \
-        -e '@${local.stack_dir}/network-sdn-vars.yml'
-    EOT
-    working_dir = local.ansible_dir
-
-    environment = {
-      ANSIBLE_HOST_KEY_CHECKING    = "False"
-      ANSIBLE_LOCAL_TEMP           = "/tmp/.ansible/tmp"
-      ANSIBLE_SSH_CONTROL_PATH_DIR = "/tmp/.ansible/cp"
-    }
-  }
-
-  depends_on = [
-    local_file.network_sdn_vars,
-    module.lxc,
-  ]
 }
 
 # ---------------------------------------------------------------------------
@@ -450,7 +418,6 @@ resource "null_resource" "configure_network_vnet_firewall" {
   }
 
   depends_on = [
-    null_resource.cleanup_network_sdn_attachment_legacy,
     local_file.network_vnet_firewall_vars,
     null_resource.configure_keyctl,
     null_resource.ansible_provision,

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -169,15 +169,17 @@ resource "local_file" "network_sdn_vars" {
 
   filename = "${local.stack_dir}/network-sdn-vars.yml"
   content = yamlencode({
-    network_sdn_enable     = true
-    network_sdn_target     = local.effective_target_node
-    network_sdn_pve_host   = local.effective_pve_host
-    network_sdn_zone       = try(local.resolved_sdn_attachment.zone, null)
-    network_sdn_zone_type  = try(local.resolved_sdn_attachment.zone_type, null)
-    network_sdn_nodes      = try(local.resolved_sdn_attachment.nodes, [])
-    network_sdn_vnet       = try(local.resolved_sdn_attachment.vnet, null)
-    network_sdn_vnet_alias = try(local.resolved_zone_attachment.description, try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet))
-    network_sdn_ssh_key    = pathexpand(var.ssh_private_key_path)
+    network_sdn_enable      = true
+    network_sdn_target      = local.effective_target_node
+    network_sdn_pve_host    = local.effective_pve_host
+    network_sdn_zone        = try(local.resolved_sdn_attachment.zone, null)
+    network_sdn_legacy_zone = try(local.resolved_sdn_attachment.legacy_zone, null)
+    network_sdn_zone_type   = try(local.resolved_sdn_attachment.zone_type, null)
+    network_sdn_nodes       = try(local.resolved_sdn_attachment.nodes, [])
+    network_sdn_vnet        = try(local.resolved_sdn_attachment.vnet, null)
+    network_sdn_legacy_vnet = try(local.resolved_sdn_attachment.legacy_vnet, null)
+    network_sdn_vnet_alias  = try(local.resolved_zone_attachment.description, try(local.resolved_sdn_attachment.alias, local.resolved_sdn_attachment.vnet))
+    network_sdn_ssh_key     = pathexpand(var.ssh_private_key_path)
   })
 }
 
@@ -205,6 +207,36 @@ resource "null_resource" "configure_network_sdn_attachment" {
   }
 
   depends_on = [local_file.network_sdn_vars]
+}
+
+resource "null_resource" "cleanup_network_sdn_attachment_legacy" {
+  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? 1 : 0
+
+  triggers = {
+    container_id = module.lxc.container_id
+    sdn_vars     = local_file.network_sdn_vars[0].content
+  }
+
+  provisioner "local-exec" {
+    command     = <<-EOT
+      ansible-playbook \
+        -i localhost, \
+        playbooks/configure-network-sdn-vnet.yml \
+        -e '@${local.stack_dir}/network-sdn-vars.yml'
+    EOT
+    working_dir = local.ansible_dir
+
+    environment = {
+      ANSIBLE_HOST_KEY_CHECKING    = "False"
+      ANSIBLE_LOCAL_TEMP           = "/tmp/.ansible/tmp"
+      ANSIBLE_SSH_CONTROL_PATH_DIR = "/tmp/.ansible/cp"
+    }
+  }
+
+  depends_on = [
+    local_file.network_sdn_vars,
+    module.lxc,
+  ]
 }
 
 # ---------------------------------------------------------------------------
@@ -418,6 +450,7 @@ resource "null_resource" "configure_network_vnet_firewall" {
   }
 
   depends_on = [
+    null_resource.cleanup_network_sdn_attachment_legacy,
     local_file.network_vnet_firewall_vars,
     null_resource.configure_keyctl,
     null_resource.ansible_provision,

--- a/terraform/lxc/modules/lxc-docker-host/main.tf
+++ b/terraform/lxc/modules/lxc-docker-host/main.tf
@@ -70,7 +70,8 @@ resource "proxmox_virtual_environment_container" "docker_host" {
   }
 
   network_interface {
-    name   = "eth0"
-    bridge = var.network_bridge
+    name     = "eth0"
+    bridge   = var.network_bridge
+    firewall = var.network_firewall
   }
 }

--- a/terraform/lxc/modules/lxc-docker-host/variables.tf
+++ b/terraform/lxc/modules/lxc-docker-host/variables.tf
@@ -98,6 +98,12 @@ variable "network_bridge" {
   default     = "vmbr0"
 }
 
+variable "network_firewall" {
+  description = "Enable the Proxmox firewall flag on the LXC network interface"
+  type        = bool
+  default     = false
+}
+
 variable "ip_address" {
   description = "Static IP address with CIDR notation (e.g., 192.168.1.100/24)"
   type        = string

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -23,27 +23,47 @@ attachments:
         - pve-test
       vnet: ptsv0
       alias: pve-test network layer
+  sdn_microseg_2:
+    type: sdn_vnet
+    bridge: ptsv1
+    firewall: true
+    sdn:
+      zone: pts1
+      zone_type: simple
+      nodes:
+        - pve-test
+      vnet: ptsv1
+      alias: pve-test network layer 2
 
 zones:
   app:
     attachment: default_lan
   services:
     attachment: default_lan
+  isolated:
+    attachment: default_lan
   app_test:
     attachment: sdn_microseg
   services_test:
     attachment: sdn_microseg
-  isolated:
-    attachment: default_lan
+  app_test2:
+    attachment: sdn_microseg_2
+  services_test2:
+    attachment: sdn_microseg_2
 
 policies:
   - from: app
     to: services
     protocol: tcp
-    ports: [8080]
-    description: app can reach test services on tcp/8080
+    ports: [8080, 9000]
+    description: app can reach services on tcp/8080 and tcp/9000
   - from: app_test
     to: services_test
     protocol: tcp
     ports: [8080]
     description: app_test can reach services_test on tcp/8080
+  - from: app_test2
+    to: services_test2
+    protocol: tcp
+    ports: [8080]
+    description: app_test2 can reach services_test2 on tcp/8080

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -16,27 +16,31 @@ attachments:
   vnet1:
     description: First SDN VNet attachment for microsegmentation validation on pve-test
     type: sdn_vnet
-    bridge: ptsv0
+    bridge: tvn1
     firewall: true
     sdn:
-      zone: pts0
+      zone: tvz1
       zone_type: simple
       nodes:
         - pve-test
-      vnet: ptsv0
+      vnet: tvn1
       alias: pve-test network layer
+      legacy_zone: pts0
+      legacy_vnet: ptsv0
   vnet2:
     description: Second SDN VNet attachment for independent microsegmentation validation
     type: sdn_vnet
-    bridge: ptsv1
+    bridge: tvn2
     firewall: true
     sdn:
-      zone: pts1
+      zone: tvz2
       zone_type: simple
       nodes:
         - pve-test
-      vnet: ptsv1
+      vnet: tvn2
       alias: pve-test network layer 2
+      legacy_zone: pts1
+      legacy_vnet: ptsv1
 
 zones:
   app:

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -1,0 +1,49 @@
+# Proxmox-only network intent for the pve-test environment.
+# This file is declarative only for now; later steps will wire it into
+# Terraform NIC attachment and Proxmox firewall policy generation.
+
+proxmox:
+  target_node: pve-test
+  pve_host: pve-test.gibbsgreatly.xyz
+
+attachments:
+  default_lan:
+    type: bridge
+    bridge: vmbr0
+    vlan_tag: null
+    firewall: true
+  sdn_microseg:
+    type: sdn_vnet
+    bridge: ptsv0
+    firewall: true
+    sdn:
+      zone: pts0
+      zone_type: simple
+      nodes:
+        - pve-test
+      vnet: ptsv0
+      alias: pve-test network layer
+
+zones:
+  app:
+    attachment: default_lan
+  services:
+    attachment: default_lan
+  app_test:
+    attachment: sdn_microseg
+  services_test:
+    attachment: sdn_microseg
+  isolated:
+    attachment: default_lan
+
+policies:
+  - from: app
+    to: services
+    protocol: tcp
+    ports: [8080]
+    description: app can reach test services on tcp/8080
+  - from: app_test
+    to: services_test
+    protocol: tcp
+    ports: [8080]
+    description: app_test can reach services_test on tcp/8080

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -25,8 +25,6 @@ attachments:
         - pve-test
       vnet: tvn1
       alias: pve-test network layer
-      legacy_zone: pts0
-      legacy_vnet: ptsv0
   vnet2:
     description: Second SDN VNet attachment for independent microsegmentation validation
     type: sdn_vnet
@@ -39,8 +37,6 @@ attachments:
         - pve-test
       vnet: tvn2
       alias: pve-test network layer 2
-      legacy_zone: pts1
-      legacy_vnet: ptsv1
 
 zones:
   app:

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -8,11 +8,13 @@ proxmox:
 
 attachments:
   default_lan:
+    description: Default LAN bridge for bridge-based validation zones on pve-test
     type: bridge
     bridge: vmbr0
     vlan_tag: null
     firewall: true
-  sdn_microseg:
+  vnet1:
+    description: First SDN VNet attachment for microsegmentation validation on pve-test
     type: sdn_vnet
     bridge: ptsv0
     firewall: true
@@ -23,7 +25,8 @@ attachments:
         - pve-test
       vnet: ptsv0
       alias: pve-test network layer
-  sdn_microseg_2:
+  vnet2:
+    description: Second SDN VNet attachment for independent microsegmentation validation
     type: sdn_vnet
     bridge: ptsv1
     firewall: true
@@ -37,19 +40,26 @@ attachments:
 
 zones:
   app:
+    description: Application workload zone on the default LAN bridge
     attachment: default_lan
   services:
+    description: Service endpoint zone on the default LAN bridge
     attachment: default_lan
   isolated:
+    description: Bridge-attached isolated zone with no inbound policy overrides
     attachment: default_lan
-  app_test:
-    attachment: sdn_microseg
-  services_test:
-    attachment: sdn_microseg
-  app_test2:
-    attachment: sdn_microseg_2
-  services_test2:
-    attachment: sdn_microseg_2
+  app_vnet1:
+    description: Application workload zone on the first SDN VNet
+    attachment: vnet1
+  svc_vnet1:
+    description: Service endpoint zone on the first SDN VNet
+    attachment: vnet1
+  app_vnet2:
+    description: Application workload zone on the second SDN VNet
+    attachment: vnet2
+  svc_vnet2:
+    description: Service endpoint zone on the second SDN VNet
+    attachment: vnet2
 
 policies:
   - from: app
@@ -57,13 +67,13 @@ policies:
     protocol: tcp
     ports: [8080, 9000]
     description: app can reach services on tcp/8080 and tcp/9000
-  - from: app_test
-    to: services_test
+  - from: app_vnet1
+    to: svc_vnet1
     protocol: tcp
     ports: [8080]
-    description: app_test can reach services_test on tcp/8080
-  - from: app_test2
-    to: services_test2
+    description: app_vnet1 can reach svc_vnet1 on tcp/8080
+  - from: app_vnet2
+    to: svc_vnet2
     protocol: tcp
     ports: [8080]
-    description: app_test2 can reach services_test2 on tcp/8080
+    description: app_vnet2 can reach svc_vnet2 on tcp/8080

--- a/terraform/lxc/outputs.tf
+++ b/terraform/lxc/outputs.tf
@@ -5,5 +5,16 @@ output "stack" {
     ip_address   = module.lxc.ip_address
     container_id = module.lxc.container_id
     target_node  = module.lxc.target_node
+    pve_host     = local.effective_pve_host
+    network = {
+      zone            = local.stack_network_zone
+      attachment_name = local.resolved_zone_attachment_name
+      attachment_type = local.resolved_attachment_type
+      bridge          = local.effective_network_bridge
+      vlan_tag        = local.effective_vlan_tag
+      firewall        = local.effective_firewall
+      sdn_vnet        = local.resolved_attachment_type == "sdn_vnet" ? try(local.resolved_sdn_attachment.vnet, null) : null
+      intent          = local.stack_network_zone != null ? local.effective_network_intent_path : null
+    }
   }
 }

--- a/terraform/lxc/stacks/net-app-01/stack.yaml
+++ b/terraform/lxc/stacks/net-app-01/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation client for the bridge-path network layer test
+hostname: net-app-01
+ip_address: "192.168.1.71/24"
+gateway: "192.168.1.1"
+vmid: 134
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: app

--- a/terraform/lxc/stacks/net-app-01/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-app-01/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-client-01/stack.yaml
+++ b/terraform/lxc/stacks/net-client-01/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation client for the pve-test network layer
+hostname: net-client-01
+ip_address: "10.55.0.61/24"
+gateway: "10.55.0.1"
+vmid: 132
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: app_test

--- a/terraform/lxc/stacks/net-client-01/stack.yaml
+++ b/terraform/lxc/stacks/net-client-01/stack.yaml
@@ -11,4 +11,4 @@ docker_storage_size: "4G"
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
 network:
-  zone: app_test
+  zone: app_vnet1

--- a/terraform/lxc/stacks/net-client-01/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-client-01/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-client-02/stack.yaml
+++ b/terraform/lxc/stacks/net-client-02/stack.yaml
@@ -11,4 +11,4 @@ docker_storage_size: "4G"
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
 network:
-  zone: app_test2
+  zone: app_vnet2

--- a/terraform/lxc/stacks/net-client-02/stack.yaml
+++ b/terraform/lxc/stacks/net-client-02/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation client for SDN2 network layer test
+hostname: net-client-02
+ip_address: "10.56.0.61/24"
+gateway: "10.56.0.1"
+vmid: 137
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: app_test2

--- a/terraform/lxc/stacks/net-client-02/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-client-02/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-isolated-01/stack.yaml
+++ b/terraform/lxc/stacks/net-isolated-01/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation container for the isolated zone (bridge, no inbound policy)
+hostname: net-isolated-01
+ip_address: "192.168.1.73/24"
+gateway: "192.168.1.1"
+vmid: 136
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: isolated

--- a/terraform/lxc/stacks/net-isolated-01/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-isolated-01/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-service-01/stack.yaml
+++ b/terraform/lxc/stacks/net-service-01/stack.yaml
@@ -11,4 +11,4 @@ docker_storage_size: "4G"
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
 network:
-  zone: services_test
+  zone: svc_vnet1

--- a/terraform/lxc/stacks/net-service-01/stack.yaml
+++ b/terraform/lxc/stacks/net-service-01/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation service for the pve-test network layer
+hostname: net-service-01
+ip_address: "10.55.0.62/24"
+gateway: "10.55.0.1"
+vmid: 133
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: services_test

--- a/terraform/lxc/stacks/net-service-01/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-service-01/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-service-02/stack.yaml
+++ b/terraform/lxc/stacks/net-service-02/stack.yaml
@@ -11,4 +11,4 @@ docker_storage_size: "4G"
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
 network:
-  zone: services_test2
+  zone: svc_vnet2

--- a/terraform/lxc/stacks/net-service-02/stack.yaml
+++ b/terraform/lxc/stacks/net-service-02/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation service for SDN2 network layer test
+hostname: net-service-02
+ip_address: "10.56.0.62/24"
+gateway: "10.56.0.1"
+vmid: 138
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: services_test2

--- a/terraform/lxc/stacks/net-service-02/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-service-02/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/net-svc-01/stack.yaml
+++ b/terraform/lxc/stacks/net-svc-01/stack.yaml
@@ -1,0 +1,14 @@
+# Disposable validation service for the bridge-path network layer test
+hostname: net-svc-01
+ip_address: "192.168.1.72/24"
+gateway: "192.168.1.1"
+vmid: 135
+cores: 1
+memory: 512
+rootfs_size: 4
+rootfs_storage: "storage-containers"
+docker_storage_size: "4G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: services

--- a/terraform/lxc/stacks/net-svc-01/terragrunt.hcl
+++ b/terraform/lxc/stacks/net-svc-01/terragrunt.hcl
@@ -1,0 +1,12 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+}

--- a/terraform/lxc/stacks/test-docker/stack.yaml
+++ b/terraform/lxc/stacks/test-docker/stack.yaml
@@ -7,6 +7,9 @@ memory: 2048
 rootfs_size: 8
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
+network:
+  zone: services
+
 # Deployment
 ansible_playbook: "deploy-stack"
 portainer_agent: true

--- a/terraform/lxc/stacks/test-docker/stack.yaml
+++ b/terraform/lxc/stacks/test-docker/stack.yaml
@@ -7,9 +7,6 @@ memory: 2048
 rootfs_size: 8
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
-network:
-  zone: services
-
 # Deployment
 ansible_playbook: "deploy-stack"
 portainer_agent: true

--- a/terraform/lxc/stacks/test-lxc/stack.yaml
+++ b/terraform/lxc/stacks/test-lxc/stack.yaml
@@ -6,3 +6,6 @@ cores: 2
 memory: 2048
 rootfs_size: 8
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+
+network:
+  zone: app

--- a/terraform/lxc/stacks/test-lxc/stack.yaml
+++ b/terraform/lxc/stacks/test-lxc/stack.yaml
@@ -7,5 +7,3 @@ memory: 2048
 rootfs_size: 8
 ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
 
-network:
-  zone: app

--- a/terraform/lxc/validate-network-matrix.sh
+++ b/terraform/lxc/validate-network-matrix.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run the full disposable network matrix validation on pve-test.
+# Usage: ./validate-network-matrix.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLAYBOOK_PATH="${SCRIPT_DIR}/ansible/playbooks/validate-network-matrix.yml"
+
+mkdir -p /tmp/.ansible/tmp /tmp/.ansible/cp
+
+INVENTORIES=(
+  "${SCRIPT_DIR}/stacks/net-app-01/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-svc-01/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-client-01/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-service-01/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-client-02/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-service-02/inventory.yml"
+  "${SCRIPT_DIR}/stacks/net-isolated-01/inventory.yml"
+)
+
+for inventory in "${INVENTORIES[@]}"; do
+  if [[ ! -f "${inventory}" ]]; then
+    printf 'Missing inventory: %s\n' "${inventory}" >&2
+    exit 1
+  fi
+done
+
+ANSIBLE_LOCAL_TEMP=/tmp/.ansible/tmp \
+ANSIBLE_SSH_CONTROL_PATH_DIR=/tmp/.ansible/cp \
+ansible-playbook \
+  -i "${INVENTORIES[0]}" \
+  -i "${INVENTORIES[1]}" \
+  -i "${INVENTORIES[2]}" \
+  -i "${INVENTORIES[3]}" \
+  -i "${INVENTORIES[4]}" \
+  -i "${INVENTORIES[5]}" \
+  -i "${INVENTORIES[6]}" \
+  "${PLAYBOOK_PATH}"

--- a/terraform/lxc/validate-network.sh
+++ b/terraform/lxc/validate-network.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run the network-layer validation playbook against a client/service pair.
+# Usage: ./validate-network.sh [service-host] [client-host]
+# Defaults to net-service-01 and net-client-01.
+set -euo pipefail
+
+SERVICE_HOST="${1:-net-service-01}"
+CLIENT_HOST="${2:-net-client-01}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANSIBLE_DIR="${SCRIPT_DIR}/ansible"
+
+ansible-playbook \
+  -i "${SCRIPT_DIR}/stacks/${SERVICE_HOST}/inventory.yml" \
+  -i "${SCRIPT_DIR}/stacks/${CLIENT_HOST}/inventory.yml" \
+  -e "network_validation_service_host=${SERVICE_HOST}" \
+  -e "network_validation_client_host=${CLIENT_HOST}" \
+  "${ANSIBLE_DIR}/playbooks/validate-network-layer.yml"

--- a/terraform/lxc/variables.tf
+++ b/terraform/lxc/variables.tf
@@ -11,6 +11,12 @@ variable "stack_yaml_path" {
   type        = string
 }
 
+variable "network_intent_path" {
+  description = "Optional override path for the shared network intent YAML file"
+  type        = string
+  default     = null
+}
+
 # ---------------------------------------------------------------------------
 # Proxmox connection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the validated pve-test Proxmox network layer with declarative network intent, Terraform resolution, and Ansible enforcement
- include bridge firewall and SDN VNet firewall generation plus the pve-test-only guardrails
- add the disposable validation stacks and the full network matrix runner with 11/11 cases passing on April 9, 2026
- include the final cleanup from #50 removing one-time legacy SDN rename fields after the verified migration

## Validation
- targeted reapply of the four SDN validation stacks on pve-test after #50
- `./validate-network-matrix.sh` passed 11/11 on pve-test on April 9, 2026

## Out of scope
- production promotion to `pve` (#52)
- teardown lifecycle for the `net-*` disposable validation stacks (#53)
- NetBox bug fixes (#48, #49)