### PR TITLE
feat(ci): add Terraform fmt/validate workflow (Phase 2 #61)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,54 @@
+name: Validate
+
+on:
+  push:
+    branches:
+      - main
+      - 'dev/pve-test'
+      - 'dev/**'
+      - 'feat/**'
+      - 'fix/**'
+  pull_request:
+    branches:
+      - main
+      - 'dev/pve-test'
+
+jobs:
+  terraform-fmt:
+    name: Terraform format check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive terraform/
+
+  terraform-validate:
+    name: Terraform validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Cache Terraform providers
+        uses: actions/cache@v4
+        with:
+          path: ~/.terraform.d/plugin-cache
+          key: terraform-providers-${{ runner.os }}-${{ hashFiles('terraform/lxc/.terraform.lock.hcl') }}
+          restore-keys: terraform-providers-${{ runner.os }}-
+
+      - name: Init (no backend)
+        working-directory: terraform/lxc
+        run: |
+          mkdir -p ~/.terraform.d/plugin-cache
+          TF_PLUGIN_CACHE_DIR=~/.terraform.d/plugin-cache \
+            terraform init -backend=false
+
+      - name: Validate
+        working-directory: terraform/lxc
+        run: terraform validate -var-file=ci-validate.tfvars

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,4 +51,13 @@ jobs:
 
       - name: Validate
         working-directory: terraform/lxc
-        run: terraform validate -var-file=ci-validate.tfvars
+        # terraform validate does not accept -var-file; supply required
+        # variables via TF_VAR_ environment variables instead.
+        env:
+          TF_VAR_stack_name: ci-validate
+          TF_VAR_stack_yaml_path: /dev/null
+          TF_VAR_proxmox_api_url: https://localhost:8006
+          TF_VAR_pm_api_token_id: ci@pve!token
+          TF_VAR_pm_api_token_secret: dummy-secret-for-ci-validate-only
+          TF_VAR_lxc_password: dummy-password-for-ci-validate-only
+        run: terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ crash.log
 crash.*.log
 *.tfvars
 *.tfvars.json
+!terraform/lxc/ci-validate.tfvars
 override.tf
 override.tf.json
 *_override.tf

--- a/terraform/lxc/ci-validate.tfvars
+++ b/terraform/lxc/ci-validate.tfvars
@@ -1,0 +1,12 @@
+# CI-only dummy values for `terraform validate`.
+# Contains no real credentials — exists solely to satisfy required variable
+# declarations so `terraform validate -backend=false` can run without Terragrunt
+# or a real Proxmox environment.
+# Do NOT use these values for any actual apply.
+
+stack_name          = "ci-validate"
+stack_yaml_path     = "/dev/null"
+proxmox_api_url     = "https://localhost:8006"
+pm_api_token_id     = "ci@pve!token"
+pm_api_token_secret = "dummy-secret-for-ci-validate-only"
+lxc_password        = "dummy-password-for-ci-validate-only"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate.yml` with two jobs:
  - **terraform-fmt**: runs `terraform fmt -check -recursive terraform/` — fails on any formatting violation
  - **terraform-validate**: runs `terraform init -backend=false` + `terraform validate` using dummy var values — no real credentials or Proxmox access needed in CI
- Adds `terraform/lxc/ci-validate.tfvars` with dummy values for all required variables (no secrets)
- Adds `.gitignore` negation exception so `ci-validate.tfvars` is committed

## Test plan

- [ ] Workflow runs appear in Actions tab on this PR
- [ ] `terraform-fmt` job passes (all `.tf` files already formatted)
- [ ] `terraform-validate` job passes with "The configuration is valid."
- [ ] Provider cache step shows cache miss on first run, hit on second
- [ ] Introduce deliberate fmt violation on branch → `terraform-fmt` fails
- [ ] `ci-validate.tfvars` visible in repo (not gitignored)

## Notes

- `stack_yaml_path` set to `/dev/null` — Terraform `file()` calls on this path will fail validation if any locals reference the file eagerly. If validate fails for this reason, the tfvars path may need a real (but dummy) YAML file committed alongside it.
- `trivy-action`, `codeql-action` pinning tracked in #71 — out of scope here.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)