### PR TITLE
feat(ci): add Ansible lint job (Phase 2 #62)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,11 @@
+profile: moderate
+
+warn_list:
+  # Shell blocks embedded in YAML legitimately exceed 160 chars (pid-file
+  # paths with Jinja2 template vars). Downgrade to warning rather than error.
+  - yaml[line-length]
+
+  # harbor_installer role vars use harbor_ prefix rather than harbor_installer_
+  # prefix. Renaming requires updating defaults, tasks, templates, and all
+  # calling playbooks — tracked as a separate refactor issue.
+  - var-naming[no-role-prefix]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,3 +61,30 @@ jobs:
           TF_VAR_pm_api_token_secret: dummy-secret-for-ci-validate-only
           TF_VAR_lxc_password: dummy-password-for-ci-validate-only
         run: terraform validate
+
+  ansible-lint:
+    name: Ansible lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-ansible-lint-${{ hashFiles('requirements.txt') }}
+          restore-keys: pip-ansible-lint-
+
+      - name: Install ansible-lint
+        run: pip install ansible-lint
+
+      - name: Run ansible-lint
+        # Run from the ansible directory so ansible.cfg is discovered,
+        # which sets roles_path = roles (relative to this directory).
+        working-directory: terraform/lxc/ansible
+        run: ansible-lint playbooks/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Install ansible-lint
         run: pip install ansible-lint
 
+      - name: Install Ansible collections
+        working-directory: terraform/lxc/ansible
+        run: ansible-galaxy collection install -r requirements.yml
+
       - name: Run ansible-lint
         # Run from the ansible directory so ansible.cfg is discovered,
         # which sets roles_path = roles (relative to this directory).

--- a/terraform/lxc/ansible/playbooks/destroy-network-sdn-vnet.yml
+++ b/terraform/lxc/ansible/playbooks/destroy-network-sdn-vnet.yml
@@ -20,6 +20,7 @@
 
     - name: Inspect pve-test LXC configs for remaining VNet bridge usage
       ansible.builtin.shell: |
+        set -o pipefail
         grep -R "bridge={{ network_sdn_vnet }}\([, ]\|$\)" /etc/pve/lxc/*.conf 2>/dev/null \
           | grep -v "^/etc/pve/lxc/{{ network_sdn_vmid_exclude_effective }}.conf:" || true
       args:
@@ -62,7 +63,7 @@
       register: network_sdn_vnet_delete
       changed_when: true
 
-    - name: Remove VNet firewall config file when VNet is deleted
+    - name: Remove VNet firewall config file when VNet is deleted # noqa: no-handler
       ansible.builtin.command:
         cmd: rm -f /etc/pve/sdn/firewall/{{ network_sdn_vnet }}.fw
       delegate_to: "{{ network_sdn_pve_host }}"
@@ -73,7 +74,7 @@
       when: network_sdn_vnet_delete is changed
       changed_when: true
 
-    - name: Refresh SDN VNets after VNet deletion
+    - name: Refresh SDN VNets after VNet deletion # noqa: no-handler
       ansible.builtin.command:
         cmd: pvesh get /cluster/sdn/vnets --output-format json
       delegate_to: "{{ network_sdn_pve_host }}"

--- a/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
+++ b/terraform/lxc/ansible/playbooks/validate-network-matrix.yml
@@ -193,7 +193,7 @@
       loop: "{{ network_matrix_listener_targets }}"
       loop_control:
         label: "{{ item.host }}:{{ item.port }}"
-      ignore_errors: true
+      failed_when: false
       changed_when: false
 
     - name: Start listener processes for matrix targets
@@ -321,7 +321,7 @@
       loop: "{{ network_matrix_listener_targets }}"
       loop_control:
         label: "{{ item.host }}:{{ item.port }}"
-      ignore_errors: true
+      failed_when: false
       changed_when: true
 
     - name: Stop host-side ssh wrapper processes

--- a/terraform/lxc/ansible/requirements.yml
+++ b/terraform/lxc/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.docker


### PR DESCRIPTION
## Summary

- Adds `ansible-lint` job to `validate.yml`, running from `terraform/lxc/ansible/` so `ansible.cfg` is discovered and `roles_path = roles` resolves correctly
- Adds `.ansible-lint` (profile: moderate) with documented `warn_list` entries for `yaml[line-length]` and `var-naming[no-role-prefix]`
- Three code fixes to clear baseline violations:
  - `risky-shell-pipe`: added `set -o pipefail` to `destroy-network-sdn-vnet.yml`
  - `ignore-errors`: replaced with `failed_when: false` in `validate-network-matrix.yml` (two tasks)
  - `no-handler`: inline `# noqa: no-handler` on teardown tasks in `destroy-network-sdn-vnet.yml` (intentional when-changed pattern, not suitable for handlers)

## Baseline

Local run: **0 failures, 19 warnings** — all warnings are documented in `.ansible-lint` with rationale.

Warnings kept (not errors):
- `yaml[line-length]`: pid-file paths with Jinja2 vars in shell blocks — legitimately long
- `var-naming[no-role-prefix]`: `harbor_installer` role vars use `harbor_` prefix — full rename is a tracked refactor, not done here

## Test plan

- [ ] `ansible-lint` job passes in CI (0 failures)
- [ ] `terraform-fmt`, `terraform-validate` jobs still pass (no regression)
- [ ] Introduce a missing task name in a playbook → job fails
- [ ] Warnings visible in CI log but do not cause failure

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)