### PR TITLE
feat(ci): add TruffleHog secret scanning (Phase 2 #63)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,3 +36,19 @@ jobs:
   # Removed terraform-security job (tfsec build fails in CI due to Go toolchain)
   # IaC scanning is now consolidated into the `sast-scan` job via Trivy.
 
+  trufflehog:
+    name: TruffleHog secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.94.3
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+


### PR DESCRIPTION
## Summary

Adds TruffleHog OSS job to \`security-scan.yml\` for verified secret detection across git history.

## Key decisions

- **Pinned at v3.94.3** — the version used in the pre-merge local audit
- **\`fetch-depth: 0\`** — required; TruffleHog walks commit history
- **Diff mode** (\`base: default_branch\`, \`head: HEAD\`) — scans only commits introduced since base branch, keeping CI fast; full history covered by the pre-merge audit
- **\`--only-verified\`** — calls real credential APIs to confirm liveness; eliminates false positives. Requires internet egress (stays on \`ubuntu-latest\` until Phase 8 egress policy defined for self-hosted runner)
- Kept separate from Trivy — Trivy scans working tree only; TruffleHog scans git history

## Pre-merge audit result

Full history scan run locally against the repo:
```
verified_secrets: 0
unverified_secrets: 0
chunks: 1487
scan_duration: 3.246s
trufflehog_version: 3.94.3
```

## Test plan

- [ ] TruffleHog job appears and passes in CI on this PR
- [ ] \`fetch-depth: 0\` confirmed in checkout step output
- [ ] Security Scan and Validate workflows still green (no regression)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)