### PR TITLE
feat(phase04): implement missing Traefik, step-ca trust, and monitoring artifacts

### DIFF
--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -201,7 +201,6 @@ pve-test is wiped before each development pass. On a fresh node, bring up servic
 |---|---|---|
 | VNet firewall cross-zone rule bug | `terraform/lxc/main.tf:86-95` | `vnet_policy_candidates` requires both `from` and `to` to match the current container's VNet — impossible for cross-zone policies. No ACCEPT rules are generated. Proxmox firewall disabled for dev passes as a workaround. |
 | SDN VLAN zone support in Terraform | `configure-network-sdn-vnet.yml` | Playbook handles Simple zone creation only. Must be updated for `zone_type: vlan` before VLAN zones can be applied via `terragrunt apply`. Use `ansible/00-initial-setup/proxmox-sdn-setup.yml` until that gap is closed. |
-| Phase 04 delivery artifact gap | `terraform/lxc/stacks/` and `terraform/lxc/ansible/playbooks/` | Traefik and monitoring stack directories/playbooks are not present, and `step-ca-stack` references `deploy-step-ca` without a corresponding playbook. Task docs remain authoritative target state until these artifacts are implemented. |
 
 ## Notes
 

--- a/docs/plan/phase-04-core-shared-services.md
+++ b/docs/plan/phase-04-core-shared-services.md
@@ -21,9 +21,10 @@ Deploy in this order. Authentik must be running before Traefik (auth middleware 
 ## Current implementation status (2026-04-17)
 
 - Authentik stack intent exists in `terraform/lxc/stacks/authentik-stack/stack.yaml` and corresponding playbook `terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml`.
-- Traefik and monitoring stack artifacts are not yet present in `terraform/lxc/stacks/` and `terraform/lxc/ansible/playbooks/`.
-- `step-ca-stack` exists, but it references `deploy-step-ca` and no matching playbook exists yet.
-- Treat this phase document and its task docs as target state until the missing artifacts are implemented and validated.
+- Traefik stack artifacts now exist at `terraform/lxc/stacks/proxy-stack/` with playbook `terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml`.
+- step-ca stack/playbook wiring is present (`terraform/lxc/stacks/step-ca-stack/stack.yaml` -> `terraform/lxc/ansible/playbooks/deploy-step-ca.yml`) and CA trust distribution playbook exists at `terraform/lxc/ansible/playbooks/trust-homelab-ca.yml`.
+- Monitoring stack artifacts now exist at `terraform/lxc/stacks/monitoring-stack/` with playbook `terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml`.
+- Validate and execute task acceptance checks per service docs before marking Phase 04 complete.
 
 ## Certificate strategy
 

--- a/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
@@ -1,0 +1,256 @@
+---
+- name: Configure Docker base and Portainer Agent
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    docker_registry_host: "{{ registry_host | default('10.57.3.10') }}"
+  roles:
+    - lxc_base
+    - docker_base
+    - portainer_agent
+
+  tasks:
+    - name: Trust Harbor HTTP registry in Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "insecure-registries": ["{{ docker_registry_host }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "3"
+            },
+            "storage-driver": "overlay2"
+          }
+      notify: Restart Docker
+
+    - name: Flush handlers to apply Docker daemon config before stack deploy
+      ansible.builtin.meta: flush_handlers
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted
+
+- name: Deploy monitoring compose stack
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    monitoring_compose_dir: /opt/monitoring-stack
+    vm_version: "v1.102.1"
+    grafana_version: "11.1.4"
+    loki_version: "3.0.0"
+    promtail_version: "3.0.0"
+    vm_image: "{{ registry_host | default('10.57.3.10') }}/dockerhub/victoriametrics/victoria-metrics:{{ vm_version }}"
+    grafana_image: "{{ registry_host | default('10.57.3.10') }}/dockerhub/grafana/grafana-oss:{{ grafana_version }}"
+    loki_image: "{{ registry_host | default('10.57.3.10') }}/dockerhub/grafana/loki:{{ loki_version }}"
+    promtail_image: "{{ registry_host | default('10.57.3.10') }}/dockerhub/grafana/promtail:{{ promtail_version }}"
+    grafana_admin_password: "{{ lookup('env', 'GRAFANA_ADMIN_PASSWORD') | mandatory('GRAFANA_ADMIN_PASSWORD env var is not set') }}"
+    grafana_oauth_client_id: "{{ lookup('env', 'GRAFANA_OAUTH_CLIENT_ID') | mandatory('GRAFANA_OAUTH_CLIENT_ID env var is not set') }}"
+    grafana_oauth_client_secret: "{{ lookup('env', 'GRAFANA_OAUTH_CLIENT_SECRET') | mandatory('GRAFANA_OAUTH_CLIENT_SECRET env var is not set') }}"
+
+  tasks:
+    - name: Create monitoring directory structure
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        mode: "{{ item.mode }}"
+      loop:
+        - { path: "{{ monitoring_compose_dir }}", mode: "0750" }
+        - { path: "{{ monitoring_compose_dir }}/grafana", mode: "0750" }
+        - { path: "{{ monitoring_compose_dir }}/grafana/provisioning", mode: "0750" }
+        - { path: "{{ monitoring_compose_dir }}/grafana/provisioning/datasources", mode: "0750" }
+        - { path: "{{ monitoring_compose_dir }}/loki", mode: "0750" }
+
+    - name: Write Loki configuration
+      ansible.builtin.copy:
+        dest: "{{ monitoring_compose_dir }}/loki/config.yml"
+        mode: "0640"
+        content: |
+          auth_enabled: false
+          server:
+            http_listen_port: 3100
+          common:
+            path_prefix: /loki
+            storage:
+              filesystem:
+                chunks_directory: /loki/chunks
+                rules_directory: /loki/rules
+            replication_factor: 1
+            ring:
+              kvstore:
+                store: inmemory
+          schema_config:
+            configs:
+              - from: 2024-01-01
+                store: tsdb
+                object_store: filesystem
+                schema: v13
+                index:
+                  prefix: index_
+                  period: 24h
+          limits_config:
+            allow_structured_metadata: false
+            volume_enabled: true
+
+    - name: Write Promtail configuration
+      ansible.builtin.copy:
+        dest: "{{ monitoring_compose_dir }}/promtail-config.yml"
+        mode: "0640"
+        content: |
+          server:
+            http_listen_port: 9080
+            grpc_listen_port: 0
+
+          positions:
+            filename: /tmp/positions.yaml
+
+          clients:
+            - url: http://loki:3100/loki/api/v1/push
+
+          scrape_configs:
+            - job_name: varlogs
+              static_configs:
+                - targets:
+                    - localhost
+                  labels:
+                    job: varlogs
+                    host: monitoring-stack
+                    __path__: /var/log/**/*.log
+
+    - name: Write Grafana datasource provisioning
+      ansible.builtin.copy:
+        dest: "{{ monitoring_compose_dir }}/grafana/provisioning/datasources/datasources.yml"
+        mode: "0640"
+        content: |
+          apiVersion: 1
+          datasources:
+            - name: VictoriaMetrics
+              type: prometheus
+              access: proxy
+              url: http://victoriametrics:8428
+              isDefault: true
+              editable: true
+            - name: Loki
+              type: loki
+              access: proxy
+              url: http://loki:3100
+              editable: true
+
+    - name: Write monitoring compose definition
+      ansible.builtin.copy:
+        dest: "{{ monitoring_compose_dir }}/docker-compose.yml"
+        mode: "0640"
+        content: |
+          services:
+            victoriametrics:
+              image: {{ vm_image }}
+              container_name: victoriametrics
+              restart: unless-stopped
+              ports:
+                - "8428:8428"
+              volumes:
+                - vm-data:/storage
+              command:
+                - "--storageDataPath=/storage"
+                - "--retentionPeriod=90d"
+
+            grafana:
+              image: {{ grafana_image }}
+              container_name: grafana
+              restart: unless-stopped
+              ports:
+                - "3000:3000"
+              environment:
+                GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_admin_password }}"
+                GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+                GF_AUTH_GENERIC_OAUTH_NAME: "Authentik"
+                GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ grafana_oauth_client_id }}"
+                GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ grafana_oauth_client_secret }}"
+                GF_AUTH_GENERIC_OAUTH_SCOPES: "openid profile email"
+                GF_AUTH_GENERIC_OAUTH_AUTH_URL: "http://10.57.1.10:9000/application/o/authorize/"
+                GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "http://10.57.1.10:9000/application/o/token/"
+                GF_AUTH_GENERIC_OAUTH_API_URL: "http://10.57.1.10:9000/application/o/userinfo/"
+                GF_AUTH_SIGNOUT_REDIRECT_URL: "http://10.57.1.10:9000/application/o/grafana/end-session/"
+                GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Viewer"
+              volumes:
+                - grafana-data:/var/lib/grafana
+                - ./grafana/provisioning:/etc/grafana/provisioning:ro
+              depends_on:
+                - victoriametrics
+                - loki
+
+            loki:
+              image: {{ loki_image }}
+              container_name: loki
+              restart: unless-stopped
+              ports:
+                - "3100:3100"
+              command: -config.file=/etc/loki/config.yml
+              volumes:
+                - loki-data:/loki
+                - ./loki/config.yml:/etc/loki/config.yml:ro
+
+            promtail:
+              image: {{ promtail_image }}
+              container_name: promtail
+              restart: unless-stopped
+              command: -config.file=/etc/promtail/config.yml
+              volumes:
+                - /var/log:/var/log:ro
+                - ./promtail-config.yml:/etc/promtail/config.yml:ro
+              depends_on:
+                - loki
+
+          volumes:
+            vm-data: {}
+            grafana-data: {}
+            loki-data: {}
+      no_log: true
+
+    - name: Validate monitoring compose configuration
+      ansible.builtin.command:
+        cmd: docker compose -f "{{ monitoring_compose_dir }}/docker-compose.yml" config -q
+        chdir: "{{ monitoring_compose_dir }}"
+      changed_when: false
+
+    - name: Start monitoring stack via compose
+      community.docker.docker_compose_v2:
+        project_src: "{{ monitoring_compose_dir }}"
+        state: present
+
+    - name: Wait for Grafana health endpoint
+      ansible.builtin.uri:
+        url: "http://{{ ansible_host }}:3000/api/health"
+        method: GET
+        status_code: 200
+      register: grafana_health
+      retries: 30
+      delay: 10
+      until: grafana_health.status == 200
+
+    - name: Wait for VictoriaMetrics endpoint
+      ansible.builtin.uri:
+        url: "http://{{ ansible_host }}:8428/metrics"
+        method: GET
+        status_code: 200
+      register: vm_health
+      retries: 30
+      delay: 10
+      until: vm_health.status == 200
+
+    - name: Wait for Loki readiness endpoint
+      ansible.builtin.uri:
+        url: "http://{{ ansible_host }}:3100/ready"
+        method: GET
+        status_code: 200
+      register: loki_health
+      retries: 30
+      delay: 10
+      until: loki_health.status == 200

--- a/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
@@ -1,0 +1,193 @@
+---
+- name: Configure Docker base and Portainer Agent
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    docker_registry_host: "{{ registry_host | default('10.57.3.10') }}"
+  roles:
+    - lxc_base
+    - docker_base
+    - portainer_agent
+
+  tasks:
+    - name: Trust Harbor HTTP registry in Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "insecure-registries": ["{{ docker_registry_host }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "3"
+            },
+            "storage-driver": "overlay2"
+          }
+      notify: Restart Docker
+
+    - name: Flush handlers to apply Docker daemon config before stack deploy
+      ansible.builtin.meta: flush_handlers
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted
+
+- name: Deploy Traefik compose stack
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    proxy_compose_dir: /opt/proxy-stack
+    traefik_version: "v3.1.6"
+    traefik_image: "{{ registry_host | default('10.57.3.10') }}/dockerhub/library/traefik:{{ traefik_version }}"
+    cf_dns_api_token: "{{ lookup('env', 'CF_DNS_API_TOKEN') | mandatory('CF_DNS_API_TOKEN env var is not set') }}"
+
+  tasks:
+    - name: Create Traefik directory structure
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        mode: "{{ item.mode }}"
+      loop:
+        - { path: "{{ proxy_compose_dir }}", mode: "0750" }
+        - { path: "{{ proxy_compose_dir }}/dynamic", mode: "0750" }
+        - { path: "{{ proxy_compose_dir }}/certs", mode: "0750" }
+        - { path: "{{ proxy_compose_dir }}/certs/letsencrypt", mode: "0700" }
+        - { path: "{{ proxy_compose_dir }}/certs/step-ca", mode: "0700" }
+
+    - name: Create ACME storage files with strict permissions
+      ansible.builtin.copy:
+        dest: "{{ item }}"
+        content: ""
+        force: false
+        mode: "0600"
+      loop:
+        - "{{ proxy_compose_dir }}/certs/letsencrypt/acme.json"
+        - "{{ proxy_compose_dir }}/certs/step-ca/acme.json"
+
+    - name: Write Traefik static configuration
+      ansible.builtin.copy:
+        dest: "{{ proxy_compose_dir }}/traefik.yml"
+        mode: "0640"
+        content: |
+          api:
+            dashboard: true
+            insecure: false
+
+          entryPoints:
+            web:
+              address: ":80"
+              http:
+                redirections:
+                  entryPoint:
+                    to: websecure
+                    scheme: https
+            websecure:
+              address: ":443"
+
+          certificatesResolvers:
+            letsencrypt:
+              acme:
+                caServer: "https://acme-staging-v02.api.letsencrypt.org/directory"
+                email: "admin@gibbsgreatly.xyz"
+                storage: "/certs/letsencrypt/acme.json"
+                dnsChallenge:
+                  provider: cloudflare
+                  resolvers:
+                    - "1.1.1.1:53"
+                    - "8.8.8.8:53"
+            step-ca:
+              acme:
+                caServer: "https://10.57.1.11/acme/acme/directory"
+                email: "admin@gibbsgreatly.xyz"
+                storage: "/certs/step-ca/acme.json"
+                httpChallenge:
+                  entryPoint: web
+
+          providers:
+            docker:
+              exposedByDefault: false
+            file:
+              directory: "/etc/traefik/dynamic/"
+              watch: true
+
+          log:
+            level: INFO
+
+    - name: Write Authentik middleware and dashboard router config
+      ansible.builtin.copy:
+        dest: "{{ proxy_compose_dir }}/dynamic/authentik.yml"
+        mode: "0640"
+        content: |
+          http:
+            middlewares:
+              authentik:
+                forwardAuth:
+                  address: "http://10.57.1.10:9000/outpost.goauthentik.io/auth/traefik"
+                  trustForwardHeader: true
+                  authResponseHeaders:
+                    - X-authentik-username
+                    - X-authentik-groups
+                    - X-authentik-email
+            routers:
+              traefik-dashboard:
+                rule: "PathPrefix(`/dashboard`) || PathPrefix(`/api`)"
+                entryPoints:
+                  - websecure
+                service: api@internal
+                middlewares:
+                  - authentik
+                tls: {}
+
+    - name: Write wildcard certificate request config
+      ansible.builtin.copy:
+        dest: "{{ proxy_compose_dir }}/dynamic/certs.yml"
+        mode: "0640"
+        content: |
+          tls:
+            stores:
+              default:
+                defaultGeneratedCert:
+                  resolver: letsencrypt
+                  domain:
+                    main: "gibbsgreatly.xyz"
+                    sans:
+                      - "*.gibbsgreatly.xyz"
+
+    - name: Write Traefik compose definition
+      ansible.builtin.copy:
+        dest: "{{ proxy_compose_dir }}/docker-compose.yml"
+        mode: "0640"
+        content: |
+          services:
+            traefik:
+              image: {{ traefik_image }}
+              container_name: traefik
+              restart: unless-stopped
+              ports:
+                - "80:80"
+                - "443:443"
+              environment:
+                CF_DNS_API_TOKEN: "{{ cf_dns_api_token }}"
+              volumes:
+                - /var/run/docker.sock:/var/run/docker.sock:ro
+                - ./traefik.yml:/etc/traefik/traefik.yml:ro
+                - ./dynamic:/etc/traefik/dynamic:ro
+                - ./certs/letsencrypt:/certs/letsencrypt
+                - ./certs/step-ca:/certs/step-ca
+
+    - name: Validate Traefik compose configuration
+      ansible.builtin.command:
+        cmd: docker compose -f "{{ proxy_compose_dir }}/docker-compose.yml" config -q
+        chdir: "{{ proxy_compose_dir }}"
+      changed_when: false
+
+    - name: Start Traefik via compose
+      community.docker.docker_compose_v2:
+        project_src: "{{ proxy_compose_dir }}"
+        state: present

--- a/terraform/lxc/ansible/playbooks/deploy-step-ca.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-step-ca.yml
@@ -11,7 +11,6 @@
     step_cli_install_dir: /tmp/step-cli-install
     step_ca_steppath: /etc/step-ca
     step_ca_root_cert_local: "{{ playbook_dir }}/../../../../certs/homelab-root.crt"
-    step_ca_trust_host: "{{ lookup('env', 'PROXMOX_HOST') | default('pve-test.gibbsgreatly.xyz', true) }}"
     step_ca_password: "{{ lookup('env', 'STEP_CA_PASSWORD') | mandatory('STEP_CA_PASSWORD env var is not set') }}"
     step_ca_provisioner_password: "{{ lookup('env', 'STEP_CA_PROVISIONER_PASSWORD') | mandatory('STEP_CA_PROVISIONER_PASSWORD env var is not set') }}"
 
@@ -169,6 +168,7 @@
           - "{{ step_ca_steppath }}/password.txt"
           - --provisioner-password-file
           - "{{ step_ca_steppath }}/provisioner-password.txt"
+          - --non-interactive
       args:
         chdir: "{{ step_ca_steppath }}"
       environment:
@@ -233,43 +233,24 @@
       become: false
       run_once: true
 
+    - name: Export root CA certificate for managed trust distribution
+      ansible.builtin.command:
+        argv:
+          - step
+          - ca
+          - root
+          - /tmp/homelab-root.crt
+          - --ca-url
+          - "https://{{ ansible_host }}"
+          - --root
+          - "{{ step_ca_steppath }}/certs/root_ca.crt"
+      environment:
+        STEPPATH: "{{ step_ca_steppath }}"
+      changed_when: false
+
     - name: Fetch root CA certificate to the repository
       ansible.builtin.fetch:
-        src: "{{ step_ca_steppath }}/certs/root_ca.crt"
+        src: /tmp/homelab-root.crt
         dest: "{{ step_ca_root_cert_local }}"
         flat: true
       run_once: true
-
-    - name: Copy root CA certificate to the pve-test host
-      ansible.builtin.command:
-        argv:
-          - scp
-          - -F
-          - /dev/null
-          - -o
-          - StrictHostKeyChecking=no
-          - -o
-          - UserKnownHostsFile=/dev/null
-          - "{{ step_ca_root_cert_local }}"
-          - "root@{{ step_ca_trust_host }}:/usr/local/share/ca-certificates/homelab-root.crt"
-      delegate_to: localhost
-      become: false
-      run_once: true
-      changed_when: false
-
-    - name: Trust the homelab root CA on the pve-test host
-      ansible.builtin.command:
-        argv:
-          - ssh
-          - -F
-          - /dev/null
-          - -o
-          - StrictHostKeyChecking=no
-          - -o
-          - UserKnownHostsFile=/dev/null
-          - "root@{{ step_ca_trust_host }}"
-          - update-ca-certificates
-      delegate_to: localhost
-      become: false
-      run_once: true
-      changed_when: false

--- a/terraform/lxc/ansible/playbooks/trust-homelab-ca.yml
+++ b/terraform/lxc/ansible/playbooks/trust-homelab-ca.yml
@@ -1,0 +1,39 @@
+---
+# WARNING: This playbook must only be run against managed service hosts.
+# Never run against end-user devices or browser endpoints.
+- name: Trust homelab root CA on managed hosts
+  hosts: all
+  become: true
+  gather_facts: false
+
+  vars:
+    homelab_root_cert_local: "{{ playbook_dir }}/../../../../certs/homelab-root.crt"
+    homelab_root_cert_remote: /usr/local/share/ca-certificates/homelab-root.crt
+
+  pre_tasks:
+    - name: Check that local homelab root cert exists
+      ansible.builtin.stat:
+        path: "{{ homelab_root_cert_local }}"
+      register: homelab_root_cert_stat
+      delegate_to: localhost
+      become: false
+      run_once: true
+
+    - name: Fail when local homelab root cert is missing
+      ansible.builtin.fail:
+        msg: "Local certificate {{ homelab_root_cert_local }} is required before trust distribution."
+      when: not homelab_root_cert_stat.stat.exists
+      run_once: true
+
+  tasks:
+    - name: Install homelab root certificate
+      ansible.builtin.copy:
+        src: "{{ homelab_root_cert_local }}"
+        dest: "{{ homelab_root_cert_remote }}"
+        mode: "0644"
+      register: cert_copy
+
+    - name: Refresh CA trust store when certificate changes
+      ansible.builtin.command:
+        cmd: update-ca-certificates
+      when: cert_copy.changed

--- a/terraform/lxc/ansible/roles/lxc_base/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/lxc_base/tasks/main.yml
@@ -28,3 +28,25 @@
   when: >-
     apt_cacher_host | default('', true) | string | length == 0
     or ansible_host | default('', true) | string == apt_cacher_host | string
+
+- name: Check whether homelab root CA exists on the control node
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../../../../certs/homelab-root.crt"
+  delegate_to: localhost
+  become: false
+  register: lxc_base_homelab_root_ca_local
+
+- name: Install homelab root CA on managed host
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../../../certs/homelab-root.crt"
+    dest: /usr/local/share/ca-certificates/homelab-root.crt
+    mode: "0644"
+  when: lxc_base_homelab_root_ca_local.stat.exists
+  register: lxc_base_homelab_root_ca_copy
+
+- name: Refresh CA trust store after root CA update
+  ansible.builtin.command:
+    cmd: update-ca-certificates
+  when:
+    - lxc_base_homelab_root_ca_local.stat.exists
+    - lxc_base_homelab_root_ca_copy.changed

--- a/terraform/lxc/stacks/monitoring-stack/stack.yaml
+++ b/terraform/lxc/stacks/monitoring-stack/stack.yaml
@@ -1,0 +1,45 @@
+# Monitoring stack (VictoriaMetrics + Grafana + Loki) — mgmt_seg zone
+hostname: monitoring-stack
+ip_address: "10.57.1.12/24"
+gateway: "10.57.1.1"
+proxmox_node: pve-test
+network:
+  zone: mgmt_seg
+vmid: 154
+cores: 2
+memory: 1536
+swap: 1024
+rootfs_size: 8
+rootfs_storage: infrastructure-containers
+docker_storage_size: "50G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+tags:
+  - monitoring
+  - grafana
+  - loki
+  - victoria-metrics
+  - infrastructure
+  - docker
+depends_on:
+  - harbor-stack
+  - apt-cacher-stack
+  - authentik-stack
+  - proxy-stack
+  - step-ca-stack
+provides:
+  - service: grafana-http
+    port: 3000
+    protocol: tcp
+  - service: victoriametrics-http
+    port: 8428
+    protocol: tcp
+  - service: loki-http
+    port: 3100
+    protocol: tcp
+ansible_playbook: "deploy-monitoring-stack"
+portainer_agent: true
+
+# pve-test service IPs (explicit — do not rely on variable defaults)
+portainer_server_ip: "10.57.1.20"
+registry_host: "10.57.3.10"
+apt_cacher_host: "10.57.3.11"

--- a/terraform/lxc/stacks/monitoring-stack/terragrunt.hcl
+++ b/terraform/lxc/stacks/monitoring-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+  proxmox_node    = "pve-test"
+}

--- a/terraform/lxc/stacks/proxy-stack/stack.yaml
+++ b/terraform/lxc/stacks/proxy-stack/stack.yaml
@@ -1,0 +1,38 @@
+# Traefik reverse proxy — edge_seg zone
+hostname: proxy-stack
+ip_address: "10.57.2.10/24"
+gateway: "10.57.2.1"
+proxmox_node: pve-test
+network:
+  zone: edge_seg
+vmid: 153
+cores: 1
+memory: 512
+swap: 256
+rootfs_size: 8
+rootfs_storage: infrastructure-containers
+docker_storage_size: "5G"
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+tags:
+  - traefik
+  - proxy
+  - edge
+  - docker
+depends_on:
+  - harbor-stack
+  - apt-cacher-stack
+  - authentik-stack
+provides:
+  - service: proxy-http
+    port: 80
+    protocol: tcp
+  - service: proxy-https
+    port: 443
+    protocol: tcp
+ansible_playbook: "deploy-proxy-stack"
+portainer_agent: true
+
+# pve-test service IPs (explicit — do not rely on variable defaults)
+portainer_server_ip: "10.57.1.20"
+registry_host: "10.57.3.10"
+apt_cacher_host: "10.57.3.11"

--- a/terraform/lxc/stacks/proxy-stack/terragrunt.hcl
+++ b/terraform/lxc/stacks/proxy-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+  proxmox_node    = "pve-test"
+}


### PR DESCRIPTION
## Summary\n- add missing Phase 04 stack artifacts for proxy and monitoring\n- add deploy playbooks for Traefik and monitoring plus managed-host CA trust playbook\n- reconcile step-ca delivery by refining deploy-step-ca and wiring homelab CA trust into lxc_base\n- update Phase 04 plan docs to reflect implemented artifacts\n\n## Validation\n- ANSIBLE_CONFIG=ansible/ansible.cfg ansible-lint terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml terraform/lxc/ansible/playbooks/deploy-step-ca.yml terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml terraform/lxc/ansible/playbooks/trust-homelab-ca.yml\n- for stack in proxy-stack step-ca-stack monitoring-stack; do (cd terraform/lxc/stacks/monitoring-stack && ../../../../with-secrets terragrunt validate); done\n- ./with-secrets sonar-scanner\n- /home/steve/.local/bin/snyk iac test terraform/\n\nCloses #106\nCloses #125\nCloses #107