### PR TITLE
Phase 04b: deploy internal authoritative CoreDNS stack on pve-test

### DIFF
--- a/terraform/lxc/ansible/files/coredns-lab.zone
+++ b/terraform/lxc/ansible/files/coredns-lab.zone
@@ -1,0 +1,26 @@
+$ORIGIN lab.gibbsgreatly.xyz.
+$TTL 5m
+
+@               IN  SOA ns1.lab.gibbsgreatly.xyz. admin.lab.gibbsgreatly.xyz. (
+					2026041801 ; serial
+					1h         ; refresh
+					15m        ; retry
+					30d        ; expire
+					5m         ; minimum
+)
+
+@               IN  NS  ns1.lab.gibbsgreatly.xyz.
+ns1             IN  A   10.57.1.13
+
+; Phase 04 core services (mgmt_seg)
+authentik       A   10.57.1.10          ; identity provider
+step-ca         A   10.57.1.11          ; internal CA
+monitoring      A   10.57.1.12          ; observability stack
+
+; Phase 04 edge services (edge_seg)
+traefik         A   10.57.2.10          ; reverse proxy
+
+; Phase 06 application services — populated during app migration
+; pihole       A   10.60.0.10          (Pi-hole, migrated in Phase 06)
+; arr          A   10.60.0.20          (arr stack, migrated in Phase 06)
+; jellyfin     A   10.60.0.30          (Jellyfin, migrated in Phase 06)

--- a/terraform/lxc/ansible/files/coredns.conf
+++ b/terraform/lxc/ansible/files/coredns.conf
@@ -1,0 +1,16 @@
+. {
+    # Serve lab.gibbsgreatly.xyz from zone file
+    file /etc/coredns/lab.zone lab.gibbsgreatly.xyz
+
+    # Non-lab queries: forward to MikroTik (upstream resolver)
+    forward . 10.57.1.1
+
+    # Logging (optional, disable for quiet operation)
+    log
+
+    # Health check endpoint (for monitoring)
+    health
+
+    # Prometheus metrics (optional)
+    prometheus 0.0.0.0:9153
+}

--- a/terraform/lxc/ansible/files/coredns.service
+++ b/terraform/lxc/ansible/files/coredns.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CoreDNS — Internal authoritative DNS server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/coredns -conf /etc/coredns/coredns.conf
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=coredns
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/lxc/ansible/playbooks/deploy-coredns.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-coredns.yml
@@ -1,0 +1,159 @@
+---
+- name: Deploy CoreDNS authoritative nameserver
+  hosts: dns_stack
+  become: true
+  gather_facts: false
+
+  vars:
+    coredns_version: "1.10.1"
+    coredns_binary: "/usr/local/bin/coredns"
+    coredns_config_dir: "/etc/coredns"
+    coredns_install_dir: "/tmp/coredns-install"
+
+  pre_tasks:
+    - name: Wait for SSH to become available after container creation
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+        delay: 2
+        sleep: 3
+
+    - name: Gather facts after the guest is reachable
+      ansible.builtin.setup:
+
+  roles:
+    - role: lxc_base
+
+  tasks:
+    - name: Check whether CoreDNS is already installed
+      ansible.builtin.stat:
+        path: "{{ coredns_binary }}"
+      register: coredns_binary_stat
+
+    - name: Install CoreDNS host dependencies
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - tar
+          - dnsutils
+        state: present
+        update_cache: true
+
+    - name: Download CoreDNS release
+      ansible.builtin.get_url:
+        url: "https://github.com/coredns/coredns/releases/download/v{{ coredns_version }}/coredns_{{ coredns_version }}_linux_amd64.tgz"
+        dest: "/tmp/coredns_{{ coredns_version }}_linux_amd64.tgz"
+        mode: "0644"
+      when: not coredns_binary_stat.stat.exists
+
+    - name: Create CoreDNS installation directory
+      ansible.builtin.file:
+        path: "{{ coredns_install_dir }}"
+        state: directory
+        mode: "0755"
+      when: not coredns_binary_stat.stat.exists
+
+    - name: Extract CoreDNS binary
+      ansible.builtin.unarchive:
+        src: "/tmp/coredns_{{ coredns_version }}_linux_amd64.tgz"
+        dest: "{{ coredns_install_dir }}"
+        remote_src: true
+      when: not coredns_binary_stat.stat.exists
+
+    - name: Copy CoreDNS binary to /usr/local/bin
+      ansible.builtin.copy:
+        src: "{{ coredns_install_dir }}/coredns"
+        dest: "{{ coredns_binary }}"
+        mode: "0755"
+        remote_src: true
+      when: not coredns_binary_stat.stat.exists
+
+    - name: Verify CoreDNS version
+      ansible.builtin.command: "{{ coredns_binary }} -version"
+      changed_when: false
+      register: coredns_version_output
+      failed_when: "'coredns' not in (coredns_version_output.stdout | lower)"
+
+    - name: Display CoreDNS version
+      ansible.builtin.debug:
+        msg: "CoreDNS installed: {{ coredns_version_output.stdout }}"
+
+    - name: Create CoreDNS configuration directory
+      ansible.builtin.file:
+        path: "{{ coredns_config_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy CoreDNS configuration file
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../files/coredns.conf"
+        dest: "{{ coredns_config_dir }}/coredns.conf"
+        mode: "0644"
+
+    - name: Copy CoreDNS zone file
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../files/coredns-lab.zone"
+        dest: "{{ coredns_config_dir }}/lab.zone"
+        mode: "0644"
+
+    - name: Copy CoreDNS systemd service file
+      ansible.builtin.copy:
+        src: "{{ playbook_dir }}/../files/coredns.service"
+        dest: /etc/systemd/system/coredns.service
+        mode: "0644"
+
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    - name: Enable CoreDNS service at boot
+      ansible.builtin.systemd:
+        name: coredns
+        enabled: true
+
+    - name: Start CoreDNS service
+      ansible.builtin.systemd:
+        name: coredns
+        state: started
+
+    - name: Wait for CoreDNS to be ready
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 53
+        timeout: 30
+
+    - name: Verify CoreDNS service is active
+      ansible.builtin.command: systemctl is-active coredns
+      register: coredns_service_state
+      changed_when: false
+      failed_when: coredns_service_state.stdout != "active"
+
+    - name: Test authority query for traefik.lab.gibbsgreatly.xyz
+      ansible.builtin.command: dig @127.0.0.1 +short traefik.lab.gibbsgreatly.xyz
+      register: coredns_authority_test
+      changed_when: false
+
+    - name: Verify authority query returns expected address
+      ansible.builtin.assert:
+        that:
+          - coredns_authority_test.stdout == "10.57.2.10"
+        fail_msg: "Authority query did not return expected IP 10.57.2.10"
+
+    - name: Test recursive query for github.com
+      ansible.builtin.command: dig @127.0.0.1 +short github.com
+      register: coredns_recursion_test
+      changed_when: false
+
+    - name: Verify recursive query returns records
+      ansible.builtin.assert:
+        that:
+          - coredns_recursion_test.stdout | length > 0
+        fail_msg: "Recursive query for github.com returned no records"
+
+    - name: Clean up temporary installation files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/tmp/coredns_{{ coredns_version }}_linux_amd64.tgz"
+        - "{{ coredns_install_dir }}"

--- a/terraform/lxc/ansible/playbooks/deploy-coredns.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-coredns.yml
@@ -122,11 +122,15 @@
         port: 53
         timeout: 30
 
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
     - name: Verify CoreDNS service is active
-      ansible.builtin.command: systemctl is-active coredns
-      register: coredns_service_state
-      changed_when: false
-      failed_when: coredns_service_state.stdout != "active"
+      ansible.builtin.assert:
+        that:
+          - "'coredns.service' in ansible_facts.services"
+          - ansible_facts.services['coredns.service'].state == "running"
+        fail_msg: "CoreDNS service is not running"
 
     - name: Test authority query for traefik.lab.gibbsgreatly.xyz
       ansible.builtin.command: dig @127.0.0.1 +short traefik.lab.gibbsgreatly.xyz

--- a/terraform/lxc/stacks/dns-stack/stack.yaml
+++ b/terraform/lxc/stacks/dns-stack/stack.yaml
@@ -1,0 +1,26 @@
+# CoreDNS internal authoritative nameserver for lab.gibbsgreatly.xyz — mgmt_seg zone
+hostname: dns-stack
+ip_address: "10.57.1.13/24"
+gateway: "10.57.1.1"
+proxmox_node: pve-test
+vmid: 151
+cores: 1
+memory: 256
+swap: 128
+rootfs_size: 8
+rootfs_storage: infrastructure-containers
+ostemplate: "storage-template:vztmpl/debian-13.1-2-docker-template.tar.gz"
+tags:
+  - dns-stack
+  - core-services
+  - infrastructure
+
+network:
+  zone: mgmt_seg
+
+ansible_playbook: "deploy-coredns"
+
+# pve-test service IPs (explicit — do not rely on variable defaults)
+portainer_server_ip: "10.57.1.20"
+registry_host: "10.57.3.10"
+apt_cacher_host: "10.57.3.11"

--- a/terraform/lxc/stacks/dns-stack/terragrunt.hcl
+++ b/terraform/lxc/stacks/dns-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_terragrunt_dir()}/stack.yaml"
+  proxmox_node    = "pve-test"
+}


### PR DESCRIPTION
## Summary\n- add dns-stack LXC deployment config for pve-test (VMID 151, 10.57.1.13)\n- add CoreDNS zone/config/systemd artifacts and deployment playbook\n- fix CoreDNS provisioning flow (asset paths, version check, service readiness)\n- add SOA/NS records required for CoreDNS zone load\n\n## Validation\n- terragrunt apply completed successfully for dns-stack\n- CoreDNS service active on 10.57.1.13\n- authority query returns 10.57.2.10 for traefik.lab.gibbsgreatly.xyz\n- recursion query works (github.com resolves)\n- cross-zone resolver checks return expected value from 10.57.0.1/1.1/2.1/3.1\n- Sonar scan passed via with-secrets\n- Snyk IaC scan: 0 issues\n