### PR TITLE
fix(authentik): enforce env_file secrets injection pattern

### DIFF
--- a/terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml
@@ -23,8 +23,7 @@
     authentik_registry_host: "{{ registry_host | default('10.57.3.10') }}"
     authentik_secret_key: "{{ lookup('env', 'AUTHENTIK_SECRET_KEY') | mandatory('AUTHENTIK_SECRET_KEY env var is not set') }}"
     authentik_postgres_password: "{{ lookup('env', 'AUTHENTIK_POSTGRES_PASSWORD') | mandatory('AUTHENTIK_POSTGRES_PASSWORD env var is not set') }}"
-    authentik_superuser_password: "{{ lookup('env', 'AUTHENTIK_SUPERUSER_PASSWORD') | default('', true) }}"
-    authentik_superuser_api_token: "{{ lookup('env', 'AUTHENTIK_SUPERUSER_API_TOKEN') | default('', true) }}"
+    authentik_superuser_password: "{{ lookup('env', 'AUTHENTIK_SUPERUSER_PASSWORD') | mandatory('AUTHENTIK_SUPERUSER_PASSWORD env var is not set') }}"
 
   tasks:
     - name: Create Authentik compose directory
@@ -46,6 +45,7 @@
         content: |
           AUTHENTIK_SECRET_KEY={{ authentik_secret_key }}
           AUTHENTIK_POSTGRES_PASSWORD={{ authentik_postgres_password }}
+          AUTHENTIK_SUPERUSER_PASSWORD={{ authentik_superuser_password }}
           REGISTRY_HOST={{ authentik_registry_host }}
       no_log: true
 

--- a/terraform/lxc/stacks/authentik-stack/docker-compose.yml
+++ b/terraform/lxc/stacks/authentik-stack/docker-compose.yml
@@ -7,6 +7,8 @@ services:
   postgresql:
     image: ${REGISTRY_HOST}/dockerhub/library/postgres:16-alpine
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       POSTGRES_DB: authentik
       POSTGRES_USER: authentik
@@ -28,6 +30,8 @@ services:
     image: ${REGISTRY_HOST}/ghcr/goauthentik/server:2024.12.3
     restart: unless-stopped
     command: server
+    env_file:
+      - .env
     environment: &authentik-env
       AUTHENTIK_REDIS__HOST: redis
       AUTHENTIK_POSTGRESQL__HOST: postgresql
@@ -51,6 +55,8 @@ services:
     image: ${REGISTRY_HOST}/ghcr/goauthentik/server:2024.12.3
     restart: unless-stopped
     command: worker
+    env_file:
+      - .env
     environment: *authentik-env
     depends_on:
       - postgresql


### PR DESCRIPTION
## Summary
- add AUTHENTIK_SUPERUSER_PASSWORD to generated /opt/authentik-stack/.env
- require AUTHENTIK_SUPERUSER_PASSWORD from environment at playbook runtime
- remove unused AUTHENTIK_SUPERUSER_API_TOKEN playbook var
- add explicit env_file: .env to Authentik compose services

## Validation
- ./with-secrets sonar-scanner (success)
- ansible-playbook --syntax-check (success)
- live run attempted but blocked by SSH auth to 10.57.1.10