### PR TITLE
docs(prompts): harden ansible execution context and SSH preflight

### DIFF
--- a/docs/prompts/deploy-01-authentik.yaml
+++ b/docs/prompts/deploy-01-authentik.yaml
@@ -89,6 +89,7 @@ workflow:
   tooling:
     note: |
       Use ./with-secrets for all terragrunt and ansible-playbook calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       Never source .env directly. No --extra-vars for secrets.
       This is a deployment session — make no code changes; report if code issues are found.
 
@@ -112,9 +113,11 @@ workflow:
     - id: 3
       name: Run Ansible playbook
       commands:
-        - cd /home/steve/git/proxmox-homelab
-        - "./with-secrets ansible-playbook -i '10.57.1.10,' terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.10,' playbooks/deploy-authentik-stack.yml"
       notes:
+        - If ping fails with UNREACHABLE, fix SSH auth/inventory before running the playbook
         - Playbook must complete without errors
         - If playbook fails due to secrets pattern, stop and fix rem-01-authentik-secrets first
 

--- a/docs/prompts/deploy-02-traefik.yaml
+++ b/docs/prompts/deploy-02-traefik.yaml
@@ -79,6 +79,7 @@ workflow:
   tooling:
     note: |
       Use ./with-secrets for all terragrunt and ansible-playbook calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       No --extra-vars for secrets.
       This is a deployment session — make no code changes.
 
@@ -103,8 +104,11 @@ workflow:
     - id: 3
       name: Run Ansible playbook
       commands:
-        - cd /home/steve/git/proxmox-homelab
-        - "./with-secrets ansible-playbook -i '10.57.2.10,' terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.2.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.2.10,' playbooks/deploy-proxy-stack.yml"
+      notes:
+        - If ping fails with UNREACHABLE, fix SSH auth/inventory before running the playbook
 
     - id: 4
       name: Validate redirect and TLS

--- a/docs/prompts/deploy-03-step-ca.yaml
+++ b/docs/prompts/deploy-03-step-ca.yaml
@@ -67,6 +67,7 @@ workflow:
   tooling:
     note: |
       Use ./with-secrets for all terragrunt and ansible-playbook calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       step-ca runs as a systemd service — there is no Docker Compose.
       trust-homelab-ca.yml runs against the IP of each already-deployed container.
 
@@ -90,9 +91,11 @@ workflow:
     - id: 3
       name: Run Ansible playbook
       commands:
-        - cd /home/steve/git/proxmox-homelab
-        - "./with-secrets ansible-playbook -i '10.57.1.11,' terraform/lxc/ansible/playbooks/deploy-step-ca.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.11,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.11,' playbooks/deploy-step-ca.yml"
       notes:
+        - If ping fails with UNREACHABLE, fix SSH auth/inventory before running the playbook
         - Playbook runs without --extra-vars for secrets
         - Wait for CA to be healthy (playbook should poll until ready)
 
@@ -123,9 +126,13 @@ workflow:
         Run trust-homelab-ca.yml against every already-deployed LXC and the Proxmox host.
         This is mandatory — containers deployed before step-ca will not trust the new CA.
       commands:
-        - "./with-secrets ansible-playbook -i '10.57.2.10,' terraform/lxc/ansible/playbooks/trust-homelab-ca.yml"
-        - "./with-secrets ansible-playbook -i '10.57.1.10,' terraform/lxc/ansible/playbooks/trust-homelab-ca.yml"
-        - "./with-secrets ansible-playbook -i '192.168.1.40,' terraform/lxc/ansible/playbooks/trust-homelab-ca.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.2.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.2.10,' playbooks/trust-homelab-ca.yml"
+        - "../../../with-secrets ansible -i '10.57.1.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.10,' playbooks/trust-homelab-ca.yml"
+        - "../../../with-secrets ansible -i '192.168.1.40,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '192.168.1.40,' playbooks/trust-homelab-ca.yml"
       notes:
         - Add any other LXC IPs that were deployed before step-ca
         - trust-homelab-ca.yml copies certs/homelab-root.crt and runs update-ca-certificates

--- a/docs/prompts/deploy-04-monitoring.yaml
+++ b/docs/prompts/deploy-04-monitoring.yaml
@@ -80,6 +80,7 @@ workflow:
   tooling:
     note: |
       Use ./with-secrets for all terragrunt and ansible-playbook calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       No --extra-vars for secrets.
       Grafana datasources are added manually via the UI after deploy.
 
@@ -108,8 +109,11 @@ workflow:
     - id: 3
       name: Run Ansible playbook
       commands:
-        - cd /home/steve/git/proxmox-homelab
-        - "./with-secrets ansible-playbook -i '10.57.1.12,' terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.12,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.12,' playbooks/deploy-monitoring-stack.yml"
+      notes:
+        - If ping fails with UNREACHABLE, fix SSH auth/inventory before running the playbook
 
     - id: 4
       name: Validate services

--- a/docs/prompts/remediation-01-authentik-secrets.yaml
+++ b/docs/prompts/remediation-01-authentik-secrets.yaml
@@ -56,6 +56,7 @@ workflow:
   tooling:
     note: |
       All commands that need secrets must be wrapped with ./with-secrets.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       Never use source .env directly. Never pass secrets via --extra-vars.
       Read/Edit/Write tools are used for code changes; Bash only for verification.
 
@@ -135,10 +136,13 @@ workflow:
         and verify the resulting .env file contains real values and the compose
         file contains no literal credentials.
       commands:
-        - "./with-secrets ansible-playbook -i '10.57.1.10,' terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.10,' playbooks/deploy-authentik-stack.yml"
         - "pct exec 150 -- cat /opt/authentik-stack/.env"
         - "pct exec 150 -- grep -c CHANGEME /opt/authentik-stack/docker-compose.yml"
       expected:
+        - ansible ping succeeds before playbook run
         - .env file contains real values (non-empty, non-CHANGEME)
         - grep returns 0 (no CHANGEME in compose)
         - .env file has mode 0600

--- a/docs/prompts/remediation-02-traefik-secrets.yaml
+++ b/docs/prompts/remediation-02-traefik-secrets.yaml
@@ -57,6 +57,7 @@ workflow:
   tooling:
     note: |
       All invocations: ./with-secrets ansible-playbook ... or ./with-secrets terragrunt ...
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       Never source .env directly. Never --extra-vars for secrets.
       stack.yaml changes require a terragrunt apply to take effect.
 
@@ -139,11 +140,14 @@ workflow:
     - id: 7
       name: Test run (if pve-test available)
       commands:
-        - "./with-secrets ansible-playbook -i '10.57.2.10,' terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.2.10,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.2.10,' playbooks/deploy-proxy-stack.yml"
         - "pct exec 153 -- cat /opt/proxy-stack/.env"
         - "pct exec 153 -- grep CF_DNS_API_TOKEN /opt/proxy-stack/docker-compose.yml"
         - "pct exec 153 -- grep caServer /opt/proxy-stack/traefik.yml"
       expected:
+        - ansible ping succeeds before playbook run
         - .env contains real CF_DNS_API_TOKEN value
         - docker-compose.yml has no literal token value
         - traefik.yml shows staging CA URL

--- a/docs/prompts/remediation-03-monitoring-secrets.yaml
+++ b/docs/prompts/remediation-03-monitoring-secrets.yaml
@@ -58,6 +58,7 @@ workflow:
   tooling:
     note: |
       ./with-secrets wraps all ansible-playbook and terragrunt calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       Never source .env directly. Never --extra-vars for secrets.
 
   steps:
@@ -125,11 +126,14 @@ workflow:
     - id: 6
       name: Test run (if pve-test available)
       commands:
-        - "./with-secrets ansible-playbook -i '10.57.1.12,' terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.12,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.12,' playbooks/deploy-monitoring-stack.yml"
         - "pct exec 154 -- cat /opt/monitoring-stack/.env"
         - "pct exec 154 -- grep -c 'GRAFANA_ADMIN_PASSWORD.*=' /opt/monitoring-stack/docker-compose.yml"
         - "curl -s http://10.57.1.12:3000/api/health | jq .database"
       expected:
+        - ansible ping succeeds before playbook run
         - .env exists with real values
         - compose file grep returns 0 (no literal password)
         - Grafana health returns "ok"

--- a/docs/prompts/remediation-04-step-ca-secrets.yaml
+++ b/docs/prompts/remediation-04-step-ca-secrets.yaml
@@ -52,6 +52,7 @@ workflow:
   tooling:
     note: |
       ./with-secrets wraps all ansible-playbook calls.
+      Run ansible commands from terraform/lxc/ansible so roles_path resolves correctly.
       The playbook uses lookup('env', ...) to read the password.
       No --extra-vars for any secret value.
 
@@ -115,9 +116,12 @@ workflow:
     - id: 5
       name: Test run (if pve-test available)
       commands:
-        - "./with-secrets ansible-playbook -i '10.57.1.11,' terraform/lxc/ansible/playbooks/deploy-step-ca.yml"
+        - cd /home/steve/git/proxmox-homelab/terraform/lxc/ansible
+        - "../../../with-secrets ansible -i '10.57.1.11,' all -m ping"
+        - "../../../with-secrets ansible-playbook -i '10.57.1.11,' playbooks/deploy-step-ca.yml"
         - "pct exec 152 -- curl -sk https://10.57.1.11/health"
       expected:
+        - ansible ping succeeds before playbook run
         - Playbook runs without --extra-vars
         - step-ca health returns 200
 


### PR DESCRIPTION
## Summary
- standardize ansible execution context to terraform/lxc/ansible
- add ansible ping preflight before ansible-playbook runs
- add explicit failure guidance for UNREACHABLE SSH/auth cases

## Scope
- deploy-01/02/03/04 prompts
- remediation-01/02/03/04 prompts