### PR TITLE
feat(edge): unified edge reconciler dry-run-first orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ override.tf.json
 # Generated Terraform outputs in stack dirs
 **/stacks/*/inventory.yml
 **/stacks/*/network-*-vars.yml
+terraform/lxc/.generated/
 
 # Ansible
 *.retry

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ At a high level, the current workflow is:
 4. Run Terraform/Terragrunt from `terraform/lxc/`
 5. Let Terraform create LXCs and invoke Ansible-based provisioning
 
+## Edge Reconciler
+
+For stack-owned browser ingress manifests under `terraform/lxc/stacks/*/edge.yaml`,
+use the dry-run-first unified reconciler:
+
+```bash
+# Dry-run (default)
+python3 terraform/lxc/reconcile-edge.py --json
+
+# Apply mode (requires pve-test preflight + service health checks)
+./with-secrets python3 terraform/lxc/reconcile-edge.py --apply --json
+```
+
+Detailed command options and expected behavior are documented in
+`terraform/lxc/README.md`.
+
 ## Key documents
 
 ### Architecture and planning

--- a/docs/provisioning-refactor/prompts/08-coredns-renderer.yaml
+++ b/docs/provisioning-refactor/prompts/08-coredns-renderer.yaml
@@ -2,7 +2,7 @@
 id: pr-08-coredns-renderer
 title: "Implement CoreDNS renderer"
 type: development
-status: pending
+status: complete
 depends_on:
   - pr-05-manifest-validator
 task_doc: docs/provisioning-refactor/tasks/08-coredns-renderer.md

--- a/docs/provisioning-refactor/prompts/11-edge-reconciler.yaml
+++ b/docs/provisioning-refactor/prompts/11-edge-reconciler.yaml
@@ -2,7 +2,7 @@
 id: pr-11-edge-reconciler
 title: "Implement edge reconciler"
 type: development
-status: pending
+status: complete
 depends_on:
   - pr-07-traefik-renderer
   - pr-08-coredns-renderer

--- a/docs/provisioning-refactor/prompts/index.yaml
+++ b/docs/provisioning-refactor/prompts/index.yaml
@@ -78,7 +78,7 @@ prompts:
     file: 08-coredns-renderer.yaml
     title: "Implement CoreDNS renderer"
     type: development
-    status: pending
+    status: complete
     depends_on: [pr-05-manifest-validator]
     task_doc: docs/provisioning-refactor/tasks/08-coredns-renderer.md
 
@@ -102,7 +102,7 @@ prompts:
     file: 11-edge-reconciler.yaml
     title: "Implement edge reconciler"
     type: development
-    status: pending
+    status: complete
     depends_on:
       - pr-07-traefik-renderer
       - pr-08-coredns-renderer

--- a/terraform/lxc/README.md
+++ b/terraform/lxc/README.md
@@ -315,6 +315,36 @@ Expected behavior:
 - invalid manifests fail with stable error codes (for example: `EMV001`-`EMV008`)
 - duplicate-host detection is cross-manifest (run with multiple manifests together)
 
+### Edge Reconciler
+
+Use the unified edge reconciler to run validation, render output generation,
+and Authentik discovery/reconciliation planning in one command. The command is
+dry-run first by default and only mutates Authentik objects when `--apply` is
+explicitly set.
+
+```bash
+# Dry-run (default): validate + render + Authentik plan/discovery (when needed)
+python3 terraform/lxc/reconcile-edge.py --json
+
+# Dry-run with explicit migration replacement host
+python3 terraform/lxc/reconcile-edge.py \
+  terraform/lxc/stacks/traefik-stack/edge.yaml \
+  --intended-replacement-host traefik.lab.gibbsgreatly.xyz \
+  --json
+
+# Apply mode: requires pve-test targeting preflight and healthy CoreDNS/Traefik checks
+./with-secrets python3 terraform/lxc/reconcile-edge.py --apply --json
+```
+
+Behavior summary:
+- defaults to dry-run; `--apply` is required for mutation
+- validates manifests before any render/reconcile action
+- renders Traefik and CoreDNS generated outputs
+- runs Authentik discovery/reconcile only when selected manifests include
+  `auth.mode: forwardAuth`
+- requires Authentik token only when Authentik objects are needed
+- never mutates Terraform state
+
 `validate-stack-metadata.sh` checks the active platform stacks added in the
 boundary-strengthening work. It currently validates only metadata shape:
 - `depends_on` exists, is a list, uses non-empty stack names, does not self-reference,

--- a/terraform/lxc/reconcile-authentik-edge.py
+++ b/terraform/lxc/reconcile-authentik-edge.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Create/update-only Authentik reconciliation for EdgeManifest auth intent."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import ssl
+from typing import Any
+from urllib.parse import urljoin
+import urllib.request
+
+
+DEFAULT_AUTHENTIK_URL = "https://authentik.lab.gibbsgreatly.xyz"
+DEFAULT_TOKEN_ENV = "AUTHENTIK_SUPERUSER_API_TOKEN"
+COOKIE_DOMAIN = ".lab.gibbsgreatly.xyz"
+SHARED_OUTPOST_TYPE = "proxy"
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DISCOVER_MODULE_PATH = SCRIPT_DIR / "discover-authentik-edge.py"
+
+_DISCOVER_SPEC = importlib.util.spec_from_file_location("discover_authentik_edge", DISCOVER_MODULE_PATH)
+if _DISCOVER_SPEC is None or _DISCOVER_SPEC.loader is None:
+    raise RuntimeError("failed to load discover-authentik-edge.py")
+_DISCOVER = importlib.util.module_from_spec(_DISCOVER_SPEC)
+_DISCOVER_SPEC.loader.exec_module(_DISCOVER)
+
+RouteIntent = _DISCOVER.RouteIntent
+DiscoveryIssue = _DISCOVER.DiscoveryIssue
+OWNED_NAME_PREFIX = _DISCOVER.OWNED_NAME_PREFIX
+SHARED_FORWARD_OUTPOST = _DISCOVER.SHARED_FORWARD_OUTPOST
+
+
+@dataclass(frozen=True)
+class ReconcileIssue:
+    """Machine-readable reconciliation issue."""
+
+    code: str
+    message: str
+    manifest: str | None = None
+    route: str | None = None
+    object_kind: str | None = None
+    object_name: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass(frozen=True)
+class ReconcileAction:
+    """Planned or applied reconciliation operation."""
+
+    stack: str
+    route: str
+    object_kind: str
+    object_name: str
+    operation: str
+    reason: str
+    object_id: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Full reconciliation result."""
+
+    apply: bool
+    actions: tuple[ReconcileAction, ...]
+    issues: tuple[ReconcileIssue, ...]
+    stop_conditions: tuple[str, ...]
+    request_methods: tuple[str, ...]
+    write_count: int
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues and not self.stop_conditions
+
+    def to_dict(self) -> dict[str, object]:
+        counts: dict[str, int] = {}
+        for action in self.actions:
+            counts.setdefault(action.operation, 0)
+            counts[action.operation] += 1
+        return {
+            "status": "passed" if self.ok else "failed",
+            "mode": "apply" if self.apply else "dry-run",
+            "write_count": self.write_count,
+            "action_count": len(self.actions),
+            "action_counts": counts,
+            "issue_count": len(self.issues),
+            "stop_condition_count": len(self.stop_conditions),
+            "actions": [action.to_dict() for action in self.actions],
+            "issues": [issue.to_dict() for issue in self.issues],
+            "stop_conditions": list(self.stop_conditions),
+            "request_methods": list(self.request_methods),
+        }
+
+
+class AuthentikApiClient:
+    """Minimal Authentik client with read + create/update support."""
+
+    def __init__(self, base_url: str, token: str, verify_tls: bool = True) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.verify_tls = verify_tls
+        self.request_methods: list[str] = []
+
+    def fetch_applications(self) -> list[dict[str, Any]]:
+        return self._get_paginated("/api/v3/core/applications/")
+
+    def fetch_proxy_providers(self) -> list[dict[str, Any]]:
+        return self._get_paginated("/api/v3/providers/proxy/")
+
+    def fetch_outposts(self) -> list[dict[str, Any]]:
+        return self._get_paginated("/api/v3/outposts/instances/")
+
+    def create_proxy_provider(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(f"{self.base_url}/api/v3/providers/proxy/", "POST", payload)
+
+    def update_proxy_provider(self, provider_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(
+            f"{self.base_url}/api/v3/providers/proxy/{provider_id}/",
+            "PATCH",
+            payload,
+        )
+
+    def create_application(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(f"{self.base_url}/api/v3/core/applications/", "POST", payload)
+
+    def update_application(self, application_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(
+            f"{self.base_url}/api/v3/core/applications/{application_id}/",
+            "PATCH",
+            payload,
+        )
+
+    def create_outpost(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(f"{self.base_url}/api/v3/outposts/instances/", "POST", payload)
+
+    def update_outpost(self, outpost_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request_json(
+            f"{self.base_url}/api/v3/outposts/instances/{outpost_id}/",
+            "PATCH",
+            payload,
+        )
+
+    def _get_paginated(self, path: str) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        next_url: str | None = f"{self.base_url}{path}?page_size=200"
+        while next_url:
+            payload = self._request_json(next_url, "GET")
+            if isinstance(payload, dict) and isinstance(payload.get("results"), list):
+                results.extend(item for item in payload["results"] if isinstance(item, dict))
+                raw_next = payload.get("next")
+                if isinstance(raw_next, str) and raw_next:
+                    next_url = urljoin(self.base_url + "/", raw_next)
+                else:
+                    next_url = None
+                continue
+
+            if isinstance(payload, list):
+                results.extend(item for item in payload if isinstance(item, dict))
+                break
+
+            raise RuntimeError(f"unexpected Authentik response shape for {path}")
+        return results
+
+    def _request_json(self, url: str, method: str, payload: dict[str, Any] | None = None) -> Any:
+        self.request_methods.append(method)
+        body = None
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url,
+            data=body,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+
+        context = None
+        if not self.verify_tls:
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+        with urllib.request.urlopen(request, context=context) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create/update-only Authentik reconciliation for stack-owned edge manifests. "
+            "Defaults to dry-run plan; use --apply to write."
+        )
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="*",
+        type=Path,
+        help=(
+            "Optional explicit manifest files to reconcile. "
+            "If omitted, discover stacks/*/edge.yaml under --stacks-dir."
+        ),
+    )
+    parser.add_argument(
+        "--stacks-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent / "stacks",
+        help="Stacks directory used for discovery mode.",
+    )
+    parser.add_argument(
+        "--authentik-url",
+        default=DEFAULT_AUTHENTIK_URL,
+        help="Base Authentik URL used for API calls.",
+    )
+    parser.add_argument(
+        "--token-env",
+        default=DEFAULT_TOKEN_ENV,
+        help="Environment variable name containing the Authentik API token.",
+    )
+    parser.add_argument(
+        "--no-verify-tls",
+        action="store_true",
+        help="Disable TLS certificate verification.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply create/update actions. Default behavior is dry-run planning only.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_manifest_paths(args: argparse.Namespace) -> list[Path]:
+    if args.manifests:
+        return sorted(path.resolve() for path in args.manifests)
+    return _DISCOVER.discover_edge_manifests(args.stacks_dir.resolve())
+
+
+def _resolve_token(token_env: str) -> tuple[str | None, ReconcileIssue | None]:
+    token = os.environ.get(token_env, "").strip()
+    if token:
+        return token, None
+    return None, ReconcileIssue(
+        code="AKR001",
+        message=(
+            f"missing Authentik token in environment variable {token_env}. "
+            "Run with ./with-secrets so SOPS-backed secrets are injected "
+            "(example: ./with-secrets terraform/lxc/reconcile-authentik-edge.py --json)."
+        ),
+    )
+
+
+def _as_issue(issue: DiscoveryIssue) -> ReconcileIssue:
+    return ReconcileIssue(
+        code=issue.code,
+        message=issue.message,
+        manifest=issue.manifest,
+        route=issue.route,
+        object_kind=issue.object_kind,
+        object_name=issue.object_name,
+    )
+
+
+def _as_id(item: dict[str, Any]) -> str | None:
+    return _DISCOVER._as_id(item.get("pk") or item.get("id"))
+
+
+def _existing_by_name(items: list[dict[str, Any]], name: str) -> list[dict[str, Any]]:
+    return [item for item in items if _DISCOVER._get_name(item) == name]
+
+
+def _resolve_single_owned_candidate(
+    *,
+    object_kind: str,
+    expected_name: str,
+    alternates: list[dict[str, Any]],
+    inventory_items: list[dict[str, Any]],
+    stack: str,
+    route: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    by_name = _existing_by_name(inventory_items, expected_name)
+    if len(by_name) > 1:
+        return None, f"{stack}/{route}: multiple {object_kind} objects named {expected_name}"
+    if len(by_name) == 1:
+        return by_name[0], None
+
+    alt = [item for item in alternates if item not in by_name]
+    if not alt:
+        return None, None
+    if len(alt) > 1:
+        return None, f"{stack}/{route}: multiple candidate {object_kind} objects matched"
+
+    candidate = alt[0]
+    candidate_name = _DISCOVER._get_name(candidate)
+    if not _DISCOVER._is_owned_object(candidate_name):
+        return (
+            None,
+            (
+                f"{stack}/{route}: candidate {object_kind} {candidate_name} is unmanaged "
+                "(missing owned prefix); refusing to guess"
+            ),
+        )
+    return candidate, None
+
+
+def _provider_payload(intent: RouteIntent) -> dict[str, Any]:
+    return {
+        "name": intent.provider_name,
+        "external_host": f"https://{intent.host}",
+        "cookie_domain": COOKIE_DOMAIN,
+    }
+
+
+def _application_payload(intent: RouteIntent, provider_id: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": intent.app_name,
+        "slug": intent.app_slug,
+        "meta_launch_url": f"https://{intent.host}/",
+    }
+    if provider_id:
+        payload["provider"] = provider_id
+    return payload
+
+
+def _patch_from_existing(existing: dict[str, Any], desired: dict[str, Any]) -> dict[str, Any]:
+    patch: dict[str, Any] = {}
+    for key, value in desired.items():
+        current = existing.get(key)
+        if key == "meta_launch_url":
+            current_host = _DISCOVER._normalize_url_host(current)
+            desired_host = _DISCOVER._normalize_url_host(value)
+            if current_host != desired_host:
+                patch[key] = value
+            continue
+        if key == "external_host":
+            current_host = _DISCOVER._normalize_url_host(current)
+            desired_host = _DISCOVER._normalize_url_host(value)
+            if current_host != desired_host:
+                patch[key] = value
+            continue
+        if current != value:
+            patch[key] = value
+    return patch
+
+
+def _resolve_forwardauth_candidates(
+    intent: RouteIntent,
+    applications: list[dict[str, Any]],
+    providers: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[str]]:
+    host = intent.host.lower()
+    provider_alternates = _DISCOVER._pick_candidates(
+        providers,
+        [
+            lambda item, expected_host=host: _DISCOVER._normalize_url_host(item.get("external_host"))
+            == expected_host,
+        ],
+    )
+    provider_obj, provider_stop = _resolve_single_owned_candidate(
+        object_kind="provider",
+        expected_name=intent.provider_name,
+        alternates=provider_alternates,
+        inventory_items=providers,
+        stack=intent.stack,
+        route=intent.route,
+    )
+
+    app_alternates = _DISCOVER._pick_candidates(
+        applications,
+        [
+            lambda item, expected_slug=intent.app_slug: str(item.get("slug", "")) == expected_slug,
+            lambda item, expected_host=host: _DISCOVER._normalize_url_host(
+                item.get("meta_launch_url") or item.get("launch_url")
+            )
+            == expected_host,
+        ],
+    )
+    app_obj, app_stop = _resolve_single_owned_candidate(
+        object_kind="application",
+        expected_name=intent.app_name,
+        alternates=app_alternates,
+        inventory_items=applications,
+        stack=intent.stack,
+        route=intent.route,
+    )
+
+    stops = [msg for msg in (provider_stop, app_stop) if msg]
+    return app_obj, provider_obj, stops
+
+
+def _resolve_delete_reports(
+    intent: RouteIntent,
+    applications: list[dict[str, Any]],
+    providers: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    host = intent.host.lower()
+
+    app_matches = _DISCOVER._pick_candidates(
+        applications,
+        [
+            lambda item, expected_name=intent.app_name: _DISCOVER._get_name(item) == expected_name,
+            lambda item, expected_slug=intent.app_slug: str(item.get("slug", "")) == expected_slug,
+            lambda item, expected_host=host: _DISCOVER._normalize_url_host(
+                item.get("meta_launch_url") or item.get("launch_url")
+            )
+            == expected_host,
+        ],
+    )
+    provider_matches = _DISCOVER._pick_candidates(
+        providers,
+        [
+            lambda item, expected_name=intent.provider_name: _DISCOVER._get_name(item) == expected_name,
+            lambda item, expected_host=host: _DISCOVER._normalize_url_host(item.get("external_host"))
+            == expected_host,
+        ],
+    )
+
+    stops: list[str] = []
+    for object_kind, matches in (("application", app_matches), ("provider", provider_matches)):
+        unmanaged = [
+            item
+            for item in matches
+            if not _DISCOVER._is_owned_object(_DISCOVER._get_name(item))
+        ]
+        if unmanaged:
+            names = ", ".join(sorted(_DISCOVER._get_name(item) for item in unmanaged))
+            stops.append(
+                f"{intent.stack}/{intent.route}: unmanaged {object_kind} objects match route ({names})"
+            )
+
+    return app_matches, provider_matches, stops
+
+
+def _find_single_shared_outpost(
+    outposts: list[dict[str, Any]],
+) -> tuple[dict[str, Any] | None, str | None]:
+    by_name = [outpost for outpost in outposts if _DISCOVER._get_name(outpost) == SHARED_FORWARD_OUTPOST]
+    if len(by_name) > 1:
+        return None, f"multiple outposts named {SHARED_FORWARD_OUTPOST}"
+    if len(by_name) == 1:
+        return by_name[0], None
+    return None, None
+
+
+def reconcile_authentik(
+    manifest_paths: list[Path],
+    client: Any,
+    *,
+    apply: bool,
+) -> ReconcileResult:
+    intents, validation_issues = _DISCOVER._build_route_intents(manifest_paths)
+    if validation_issues:
+        return ReconcileResult(
+            apply=apply,
+            actions=(),
+            issues=tuple(_as_issue(issue) for issue in validation_issues),
+            stop_conditions=(),
+            request_methods=tuple(client.request_methods),
+            write_count=0,
+        )
+
+    inventory, fetch_issue = _DISCOVER._fetch_authentik_inventory(client)
+    if fetch_issue is not None:
+        return ReconcileResult(
+            apply=apply,
+            actions=(),
+            issues=(_as_issue(fetch_issue),),
+            stop_conditions=(),
+            request_methods=tuple(client.request_methods),
+            write_count=0,
+        )
+
+    assert inventory is not None
+    applications = list(inventory.applications)
+    providers = list(inventory.providers)
+    outposts = list(inventory.outposts)
+
+    actions: list[ReconcileAction] = []
+    stop_conditions: list[str] = []
+    write_count = 0
+    consumed: dict[str, set[str]] = {"application": set(), "provider": set(), "outpost": set()}
+    required_provider_ids: set[str] = set()
+    has_forwardauth = False
+
+    intents = sorted(intents, key=lambda item: (item.stack, item.route, item.host))
+    for intent in intents:
+        if intent.stack == "authentik-stack" and intent.auth_mode == "forwardAuth":
+            stop_conditions.append(
+                f"{intent.stack}/{intent.route}: Authentik self-route must not use forwardAuth"
+            )
+            continue
+
+        if intent.auth_mode != "forwardAuth":
+            app_matches, provider_matches, route_stops = _resolve_delete_reports(
+                intent,
+                applications,
+                providers,
+            )
+            stop_conditions.extend(route_stops)
+            for app in app_matches:
+                app_id = _as_id(app)
+                if app_id:
+                    consumed["application"].add(app_id)
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="application",
+                        object_name=_DISCOVER._get_name(app),
+                        operation="delete-report",
+                        reason="route auth mode is not forwardAuth; object would be deleted in cleanup task",
+                        object_id=app_id,
+                    )
+                )
+            for provider in provider_matches:
+                provider_id = _as_id(provider)
+                if provider_id:
+                    consumed["provider"].add(provider_id)
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="provider",
+                        object_name=_DISCOVER._get_name(provider),
+                        operation="delete-report",
+                        reason="route auth mode is not forwardAuth; object would be deleted in cleanup task",
+                        object_id=provider_id,
+                    )
+                )
+            continue
+
+        has_forwardauth = True
+        app_obj, provider_obj, route_stops = _resolve_forwardauth_candidates(intent, applications, providers)
+        stop_conditions.extend(route_stops)
+
+        provider_payload = _provider_payload(intent)
+        provider_id: str | None = None
+
+        if provider_obj is None:
+            actions.append(
+                ReconcileAction(
+                    stack=intent.stack,
+                    route=intent.route,
+                    object_kind="provider",
+                    object_name=intent.provider_name,
+                    operation="create",
+                    reason="owned provider is missing",
+                )
+            )
+            if apply and not route_stops and not stop_conditions:
+                created = client.create_proxy_provider(provider_payload)
+                write_count += 1
+                providers.append(created)
+                provider_obj = created
+        else:
+            provider_id = _as_id(provider_obj)
+            if provider_id:
+                consumed["provider"].add(provider_id)
+            provider_patch = _patch_from_existing(provider_obj, provider_payload)
+            if provider_patch:
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="provider",
+                        object_name=intent.provider_name,
+                        operation="update",
+                        reason="owned provider differs from desired state",
+                        object_id=provider_id,
+                    )
+                )
+                if apply and not route_stops and not stop_conditions and provider_id:
+                    updated = client.update_proxy_provider(provider_id, provider_patch)
+                    write_count += 1
+                    provider_obj.update(updated)
+            else:
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="provider",
+                        object_name=intent.provider_name,
+                        operation="noop",
+                        reason="owned provider already matches desired state",
+                        object_id=provider_id,
+                    )
+                )
+
+        provider_id = _as_id(provider_obj) if provider_obj is not None else provider_id
+        if provider_id:
+            required_provider_ids.add(provider_id)
+            consumed["provider"].add(provider_id)
+
+        if app_obj is not None:
+            app_id = _as_id(app_obj)
+            if app_id:
+                consumed["application"].add(app_id)
+            linked_provider = _DISCOVER._get_provider_id_from_application(app_obj)
+            if linked_provider and provider_id and linked_provider != provider_id:
+                stop_conditions.append(
+                    f"{intent.stack}/{intent.route}: application links a different provider id"
+                )
+
+        app_payload = _application_payload(intent, provider_id)
+        if app_obj is None:
+            actions.append(
+                ReconcileAction(
+                    stack=intent.stack,
+                    route=intent.route,
+                    object_kind="application",
+                    object_name=intent.app_name,
+                    operation="create",
+                    reason="owned application is missing",
+                )
+            )
+            if apply and not route_stops and not stop_conditions:
+                created = client.create_application(app_payload)
+                write_count += 1
+                applications.append(created)
+                created_id = _as_id(created)
+                if created_id:
+                    consumed["application"].add(created_id)
+        else:
+            app_id = _as_id(app_obj)
+            app_patch = _patch_from_existing(app_obj, app_payload)
+            if app_patch:
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="application",
+                        object_name=intent.app_name,
+                        operation="update",
+                        reason="owned application differs from desired state",
+                        object_id=app_id,
+                    )
+                )
+                if apply and not route_stops and not stop_conditions and app_id:
+                    updated = client.update_application(app_id, app_patch)
+                    write_count += 1
+                    app_obj.update(updated)
+            else:
+                actions.append(
+                    ReconcileAction(
+                        stack=intent.stack,
+                        route=intent.route,
+                        object_kind="application",
+                        object_name=intent.app_name,
+                        operation="noop",
+                        reason="owned application already matches desired state",
+                        object_id=app_id,
+                    )
+                )
+
+    if has_forwardauth:
+        shared_outpost, outpost_stop = _find_single_shared_outpost(outposts)
+        if outpost_stop:
+            stop_conditions.append(outpost_stop)
+        elif shared_outpost is None:
+            actions.append(
+                ReconcileAction(
+                    stack="_shared",
+                    route="forwardAuth",
+                    object_kind="outpost",
+                    object_name=SHARED_FORWARD_OUTPOST,
+                    operation="create",
+                    reason="shared forward-auth outpost is missing",
+                )
+            )
+            if apply and not stop_conditions:
+                payload = {
+                    "name": SHARED_FORWARD_OUTPOST,
+                    "type": SHARED_OUTPOST_TYPE,
+                    "providers": sorted(required_provider_ids),
+                }
+                created = client.create_outpost(payload)
+                write_count += 1
+                outposts.append(created)
+        else:
+            outpost_id = _as_id(shared_outpost)
+            if outpost_id:
+                consumed["outpost"].add(outpost_id)
+            linked = _DISCOVER._provider_references(shared_outpost)
+            missing_links = sorted(required_provider_ids - linked)
+            if missing_links:
+                desired_links = sorted(linked | required_provider_ids)
+                actions.append(
+                    ReconcileAction(
+                        stack="_shared",
+                        route="forwardAuth",
+                        object_kind="outpost",
+                        object_name=SHARED_FORWARD_OUTPOST,
+                        operation="update",
+                        reason="shared outpost missing provider links",
+                        object_id=outpost_id,
+                    )
+                )
+                if apply and not stop_conditions and outpost_id:
+                    updated = client.update_outpost(outpost_id, {"providers": desired_links})
+                    write_count += 1
+                    shared_outpost.update(updated)
+            else:
+                actions.append(
+                    ReconcileAction(
+                        stack="_shared",
+                        route="forwardAuth",
+                        object_kind="outpost",
+                        object_name=SHARED_FORWARD_OUTPOST,
+                        operation="noop",
+                        reason="shared outpost already linked to all managed providers",
+                        object_id=outpost_id,
+                    )
+                )
+
+    for item in applications:
+        item_id = _as_id(item)
+        if not item_id or item_id in consumed["application"]:
+            continue
+        name = _DISCOVER._get_name(item)
+        if _DISCOVER._is_owned_object(name):
+            stop_conditions.append(f"unmanaged owned application detected: {name}")
+    for item in providers:
+        item_id = _as_id(item)
+        if not item_id or item_id in consumed["provider"]:
+            continue
+        name = _DISCOVER._get_name(item)
+        if _DISCOVER._is_owned_object(name):
+            stop_conditions.append(f"unmanaged owned provider detected: {name}")
+
+    stop_conditions = sorted(set(stop_conditions))
+    if stop_conditions:
+        # Applies must fail closed; do not permit partial writes after stop detection.
+        # Writes are prevented by guarded apply branches above.
+        pass
+
+    actions.sort(key=lambda action: (action.stack, action.route, action.object_kind, action.object_name, action.operation))
+    return ReconcileResult(
+        apply=apply,
+        actions=tuple(actions),
+        issues=(),
+        stop_conditions=tuple(stop_conditions),
+        request_methods=tuple(client.request_methods),
+        write_count=write_count,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_paths = _resolve_manifest_paths(args)
+
+    token, token_issue = _resolve_token(args.token_env)
+    if token_issue is not None:
+        result = ReconcileResult(
+            apply=args.apply,
+            actions=(),
+            issues=(token_issue,),
+            stop_conditions=(),
+            request_methods=(),
+            write_count=0,
+        )
+        if args.json:
+            print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        else:
+            print("Authentik reconciliation failed.")
+            print(f"- [{token_issue.code}] {token_issue.message}")
+        return 1
+
+    client = AuthentikApiClient(
+        base_url=args.authentik_url,
+        token=token,
+        verify_tls=not args.no_verify_tls,
+    )
+    result = reconcile_authentik(manifest_paths, client, apply=args.apply)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        return 0 if result.ok else 1
+
+    mode = "apply" if args.apply else "dry-run"
+    print(f"Authentik reconciliation {mode} completed.")
+    print(f"Actions: {len(result.actions)} (writes={result.write_count})")
+    if result.issues:
+        print(f"Issues: {len(result.issues)}")
+        for issue in result.issues:
+            print(f"- [{issue.code}] {issue.message}")
+    if result.stop_conditions:
+        print(f"Stop conditions: {len(result.stop_conditions)}")
+        for stop in result.stop_conditions:
+            print(f"- [STOP] {stop}")
+
+    for action in result.actions:
+        if action.operation == "noop":
+            continue
+        print(
+            f"- [{action.operation}] {action.stack}/{action.route} "
+            f"{action.object_kind} {action.object_name}: {action.reason}"
+        )
+
+    if any(action.operation == "delete-report" for action in result.actions):
+        print("Note: delete actions are reported only and never applied by this tool.")
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/lxc/reconcile-edge.py
+++ b/terraform/lxc/reconcile-edge.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Unified dry-run-first edge reconciliation for manifests, renderers, and Authentik."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import ssl
+import subprocess
+import sys
+import tempfile
+from typing import Any
+import urllib.request
+
+import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from edge_manifest import discover_edge_manifests, load_manifest, validate_manifests
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+RENDER_TRAEFIK = _load_module("render_edge_traefik", SCRIPT_DIR / "render-edge-traefik.py")
+RENDER_COREDNS = _load_module("render_edge_coredns", SCRIPT_DIR / "render-edge-coredns.py")
+DISCOVER_AUTHENTIK = _load_module("discover_authentik_edge", SCRIPT_DIR / "discover-authentik-edge.py")
+RECONCILE_AUTHENTIK = _load_module("reconcile_authentik_edge", SCRIPT_DIR / "reconcile-authentik-edge.py")
+
+
+TARGET_PREFLIGHT_COMMAND: tuple[str, ...] = ("./with-secrets", "bash", "-c", "echo $TF_VAR_proxmox_node")
+DEFAULT_TRAEFIK_HEALTH_URL = "http://10.57.2.10:8080/ping"
+DEFAULT_COREDNS_HEALTH_URL = "http://10.57.2.11:8080/health"
+NOT_RUN_DRY_RUN = "not run (dry-run mode)"
+
+
+@dataclass(frozen=True)
+class EdgeIssue:
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"code": self.code, "message": self.message}
+
+
+@dataclass(frozen=True)
+class HealthCheckResult:
+    name: str
+    url: str
+    ok: bool
+    status_code: int | None
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "name": self.name,
+            "url": self.url,
+            "ok": self.ok,
+            "detail": self.detail,
+        }
+        if self.status_code is not None:
+            payload["status_code"] = self.status_code
+        return payload
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Unified edge reconciliation entrypoint. "
+            "Defaults to dry-run and performs no live mutation unless --apply is set."
+        )
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="*",
+        type=Path,
+        help=(
+            "Optional explicit manifest files to reconcile. "
+            "If omitted, discover stacks/*/edge.yaml under --stacks-dir."
+        ),
+    )
+    parser.add_argument(
+        "--stacks-dir",
+        type=Path,
+        default=SCRIPT_DIR / "stacks",
+        help="Stacks directory used for discovery mode.",
+    )
+    parser.add_argument(
+        "--legacy-playbook",
+        type=Path,
+        default=SCRIPT_DIR / "ansible" / "playbooks" / "deploy-proxy-stack.yml",
+        help="Path to legacy central proxy playbook used by Traefik collision checks.",
+    )
+    parser.add_argument(
+        "--traefik-output-dir",
+        type=Path,
+        default=SCRIPT_DIR / ".generated" / "traefik",
+        help="Output directory for rendered Traefik dynamic files.",
+    )
+    parser.add_argument(
+        "--seed-zone",
+        type=Path,
+        default=SCRIPT_DIR / "ansible" / "files" / "coredns-lab.zone",
+        help="Path to the seed CoreDNS zone file.",
+    )
+    parser.add_argument(
+        "--coredns-output-zone",
+        type=Path,
+        default=SCRIPT_DIR / ".generated" / "coredns" / "coredns-lab.zone",
+        help="Output file for rendered CoreDNS zone.",
+    )
+    parser.add_argument(
+        "--intended-replacement-host",
+        help=(
+            "Optional single migration host to inject as intendedReplacement for exactly "
+            "one selected manifest route."
+        ),
+    )
+    parser.add_argument(
+        "--authentik-url",
+        default=DISCOVER_AUTHENTIK.DEFAULT_AUTHENTIK_URL,
+        help="Base Authentik URL used for discovery/reconciliation.",
+    )
+    parser.add_argument(
+        "--token-env",
+        default=DISCOVER_AUTHENTIK.DEFAULT_TOKEN_ENV,
+        help="Environment variable containing the Authentik API token.",
+    )
+    parser.add_argument(
+        "--no-verify-tls",
+        action="store_true",
+        help="Disable TLS verification for Authentik and health checks.",
+    )
+    parser.add_argument(
+        "--traefik-health-url",
+        default=DEFAULT_TRAEFIK_HEALTH_URL,
+        help="Traefik health endpoint required in apply mode.",
+    )
+    parser.add_argument(
+        "--coredns-health-url",
+        default=DEFAULT_COREDNS_HEALTH_URL,
+        help="CoreDNS health endpoint required in apply mode.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply create/update reconciliation. Default behavior is dry-run.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_manifest_paths(args: argparse.Namespace) -> list[Path]:
+    if args.manifests:
+        return sorted(path.resolve() for path in args.manifests)
+    return discover_edge_manifests(args.stacks_dir.resolve())
+
+
+def _manifest_requires_authentik(manifest_path: Path) -> bool:
+    document = load_manifest(manifest_path)
+    if not isinstance(document, dict):
+        return False
+    spec = document.get("spec")
+    if not isinstance(spec, dict):
+        return False
+    routes = spec.get("routes")
+    if not isinstance(routes, list):
+        return False
+
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        auth = route.get("auth")
+        if not isinstance(auth, dict):
+            continue
+        if str(auth.get("mode", "")).strip() == "forwardAuth":
+            return True
+    return False
+
+
+def _selected_manifests_require_authentik(manifest_paths: list[Path]) -> bool:
+    return any(_manifest_requires_authentik(path) for path in manifest_paths)
+
+
+def _route_host_matches(document: dict[str, object], host: str) -> bool:
+    spec = document.get("spec")
+    if not isinstance(spec, dict):
+        return False
+    routes = spec.get("routes")
+    if not isinstance(routes, list):
+        return False
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        route_host = str(route.get("host", "")).strip().rstrip(".")
+        if route_host == host:
+            return True
+    return False
+
+
+def _load_documents(manifest_paths: list[Path]) -> dict[Path, dict[str, object]]:
+    docs: dict[Path, dict[str, object]] = {}
+    for path in manifest_paths:
+        document = load_manifest(path)
+        if isinstance(document, dict):
+            docs[path] = document
+    return docs
+
+
+def _inject_intended_replacement(
+    manifest_paths: list[Path],
+    intended_replacement_host: str,
+) -> tuple[list[Path] | None, tempfile.TemporaryDirectory[str] | None, EdgeIssue | None]:
+    host = intended_replacement_host.strip().rstrip(".")
+    if not host:
+        return None, None, EdgeIssue(
+            code="EGR110",
+            message="--intended-replacement-host must be a non-empty hostname",
+        )
+
+    documents = _load_documents(manifest_paths)
+    matches = [path for path, document in documents.items() if _route_host_matches(document, host)]
+
+    if not matches:
+        return None, None, EdgeIssue(
+            code="EGR111",
+            message=(
+                f"--intended-replacement-host {host} does not match any selected manifest route"
+            ),
+        )
+
+    if len(matches) > 1:
+        return None, None, EdgeIssue(
+            code="EGR112",
+            message=(
+                f"--intended-replacement-host {host} matches multiple manifests; "
+                "select only one migration target at a time"
+            ),
+        )
+
+    replacement_manifest = matches[0]
+    temp_dir: tempfile.TemporaryDirectory[str] = tempfile.TemporaryDirectory(prefix="edge-reconcile-")
+    rewritten_paths: list[Path] = []
+
+    for path in manifest_paths:
+        doc = documents.get(path)
+        if doc is None:
+            doc = load_manifest(path)
+        if path == replacement_manifest:
+            doc["intendedReplacement"] = [{"hostname": host}]
+
+        output_path = Path(temp_dir.name) / path.name
+        output_path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+        rewritten_paths.append(output_path.resolve())
+
+    return sorted(rewritten_paths), temp_dir, None
+
+
+def _resolve_selected_manifests(
+    args: argparse.Namespace,
+) -> tuple[list[Path] | None, tempfile.TemporaryDirectory[str] | None, EdgeIssue | None]:
+    manifest_paths = _resolve_manifest_paths(args)
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+
+    if not args.intended_replacement_host:
+        return manifest_paths, temp_dir, None
+
+    rewritten, temp_dir, replacement_issue = _inject_intended_replacement(
+        manifest_paths,
+        args.intended_replacement_host,
+    )
+    if replacement_issue is not None:
+        return None, temp_dir, replacement_issue
+    assert rewritten is not None
+    return rewritten, temp_dir, None
+
+
+def _render_outputs(
+    args: argparse.Namespace,
+    manifest_paths: list[Path],
+) -> tuple[Any, Any, list[EdgeIssue]]:
+    issues: list[EdgeIssue] = []
+    traefik_result = RENDER_TRAEFIK.render_traefik_dry_run(
+        manifest_paths,
+        args.legacy_playbook.resolve(),
+    )
+    coredns_result = RENDER_COREDNS.render_coredns_dry_run(
+        manifest_paths=manifest_paths,
+        seed_zone_path=args.seed_zone.resolve(),
+        output_zone_path=args.coredns_output_zone.resolve(),
+        validate_live_forwarding=False,
+    )
+
+    if not traefik_result.ok:
+        issues.append(EdgeIssue(code="EGR130", message="Traefik render failed"))
+    if not coredns_result.ok:
+        issues.append(EdgeIssue(code="EGR131", message="CoreDNS render failed"))
+    return traefik_result, coredns_result, issues
+
+
+def _run_pve_target_preflight() -> tuple[bool, str]:
+    repo_root = SCRIPT_DIR.parents[1]
+    result = subprocess.run(
+        list(TARGET_PREFLIGHT_COMMAND),
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = (
+            f"target preflight command failed with exit code {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip() or '<no output>'}"
+        )
+        return False, message
+
+    target = result.stdout.strip()
+    if target != "pve-test":
+        return False, f"target preflight reported {target!r}, expected 'pve-test'"
+    return True, "target preflight passed (pve-test)"
+
+
+def _http_health_check(url: str) -> HealthCheckResult:
+    request = urllib.request.Request(url, method="GET")
+
+    try:
+        with urllib.request.urlopen(request, timeout=8) as response:
+            status = response.getcode()
+            if 200 <= status < 300:
+                return HealthCheckResult(
+                    name="",
+                    url=url,
+                    ok=True,
+                    status_code=status,
+                    detail="health probe succeeded",
+                )
+            return HealthCheckResult(
+                name="",
+                url=url,
+                ok=False,
+                status_code=status,
+                detail=f"unexpected status code {status}",
+            )
+    except Exception as exc:
+        return HealthCheckResult(
+            name="",
+            url=url,
+            ok=False,
+            status_code=None,
+            detail=f"health probe failed: {exc}",
+        )
+
+
+def _build_failed_result(
+    *,
+    applied: bool,
+    manifest_paths: list[Path] | None = None,
+    validation: dict[str, object] | None = None,
+    traefik: dict[str, object] | None = None,
+    coredns: dict[str, object] | None = None,
+    issues: list[EdgeIssue],
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "status": "failed",
+        "mode": "apply" if applied else "dry-run",
+        "terraform_state_mutation": False,
+        "issues": [issue.to_dict() for issue in issues],
+    }
+    if manifest_paths is not None:
+        payload["manifests"] = [str(path) for path in manifest_paths]
+    if validation is not None:
+        payload["validation"] = validation
+    if traefik is not None:
+        payload["traefik"] = traefik
+    if coredns is not None:
+        payload["coredns"] = coredns
+    return payload
+
+
+def _run_apply_preflights(args: argparse.Namespace) -> tuple[str, HealthCheckResult, HealthCheckResult, list[EdgeIssue]]:
+    issues: list[EdgeIssue] = []
+    target_ok, target_detail = _run_pve_target_preflight()
+    if not target_ok:
+        issues.append(EdgeIssue(code="EGR200", message=target_detail))
+
+    traefik_probe = _http_health_check(args.traefik_health_url)
+    traefik_health = HealthCheckResult(
+        name="traefik",
+        url=traefik_probe.url,
+        ok=traefik_probe.ok,
+        status_code=traefik_probe.status_code,
+        detail=traefik_probe.detail,
+    )
+    if not traefik_health.ok:
+        issues.append(EdgeIssue(code="EGR201", message=f"Traefik health check failed: {traefik_health.detail}"))
+
+    coredns_probe = _http_health_check(args.coredns_health_url)
+    coredns_health = HealthCheckResult(
+        name="coredns",
+        url=coredns_probe.url,
+        ok=coredns_probe.ok,
+        status_code=coredns_probe.status_code,
+        detail=coredns_probe.detail,
+    )
+    if not coredns_health.ok:
+        issues.append(EdgeIssue(code="EGR202", message=f"CoreDNS health check failed: {coredns_health.detail}"))
+
+    return target_detail, traefik_health, coredns_health, issues
+
+
+def _run_authentik_phase(
+    *,
+    manifest_paths: list[Path],
+    args: argparse.Namespace,
+    applied: bool,
+    has_preflight_issues: bool,
+) -> tuple[dict[str, object] | None, dict[str, object] | None, list[EdgeIssue]]:
+    issues: list[EdgeIssue] = []
+    token = os.environ.get(args.token_env, "").strip()
+    if not token:
+        return (
+            None,
+            None,
+            [
+                EdgeIssue(
+                    code="EGR210",
+                    message=(
+                        f"selected manifests require Authentik objects but {args.token_env} is missing"
+                    ),
+                )
+            ],
+        )
+
+    discovery_client = DISCOVER_AUTHENTIK.AuthentikApiClient(
+        base_url=args.authentik_url,
+        token=token,
+        verify_tls=not args.no_verify_tls,
+    )
+    discovery = DISCOVER_AUTHENTIK.discover_authentik_drift(manifest_paths, discovery_client)
+    discovery_dict = discovery.to_dict()
+
+    reconcile_client = RECONCILE_AUTHENTIK.AuthentikApiClient(
+        base_url=args.authentik_url,
+        token=token,
+        verify_tls=not args.no_verify_tls,
+    )
+    reconcile = RECONCILE_AUTHENTIK.reconcile_authentik(
+        manifest_paths,
+        reconcile_client,
+        apply=applied and not has_preflight_issues,
+    )
+    reconcile_dict = reconcile.to_dict()
+
+    if not discovery.ok:
+        issues.append(EdgeIssue(code="EGR211", message="Authentik discovery reported drift/issues"))
+    if not reconcile.ok:
+        issues.append(EdgeIssue(code="EGR212", message="Authentik reconcile plan/apply failed"))
+
+    return discovery_dict, reconcile_dict, issues
+
+
+def reconcile_edge(args: argparse.Namespace) -> dict[str, object]:
+    issues: list[EdgeIssue] = []
+    applied = bool(args.apply)
+    manifest_paths, temp_dir, replacement_issue = _resolve_selected_manifests(args)
+    if replacement_issue is not None:
+        return _build_failed_result(applied=applied, issues=[replacement_issue])
+    assert manifest_paths is not None
+
+    validation = validate_manifests(manifest_paths)
+    if not validation.ok:
+        result = _build_failed_result(
+            applied=applied,
+            manifest_paths=manifest_paths,
+            validation=validation.to_dict(),
+            issues=[EdgeIssue(code="EGR120", message="edge manifest validation failed")],
+        )
+        if temp_dir is not None:
+            temp_dir.cleanup()
+        return result
+
+    traefik_result, coredns_result, render_issues = _render_outputs(args, manifest_paths)
+    issues.extend(render_issues)
+
+    if issues:
+        result = _build_failed_result(
+            applied=applied,
+            manifest_paths=manifest_paths,
+            validation=validation.to_dict(),
+            traefik=traefik_result.to_dict(),
+            coredns=coredns_result.to_dict(),
+            issues=issues,
+        )
+        if temp_dir is not None:
+            temp_dir.cleanup()
+        return result
+
+    traefik_output_dir = args.traefik_output_dir.resolve()
+    coredns_output_zone = args.coredns_output_zone.resolve()
+    rendered_files = [str(path) for path in RENDER_TRAEFIK.write_rendered_files(traefik_result.rendered, traefik_output_dir)]
+    rendered_zone = str(RENDER_COREDNS.write_rendered_zone(coredns_result.rendered_zone, coredns_output_zone))
+
+    needs_authentik = _selected_manifests_require_authentik(manifest_paths)
+    discovery_dict: dict[str, object] | None = None
+    reconcile_dict: dict[str, object] | None = None
+
+    if applied:
+        target_detail, traefik_health, coredns_health, preflight_issues = _run_apply_preflights(args)
+        issues.extend(preflight_issues)
+    else:
+        target_detail = NOT_RUN_DRY_RUN
+        traefik_health = HealthCheckResult(
+            name="traefik",
+            url=args.traefik_health_url,
+            ok=True,
+            status_code=None,
+            detail=NOT_RUN_DRY_RUN,
+        )
+        coredns_health = HealthCheckResult(
+            name="coredns",
+            url=args.coredns_health_url,
+            ok=True,
+            status_code=None,
+            detail=NOT_RUN_DRY_RUN,
+        )
+
+    if needs_authentik:
+        discovery_dict, reconcile_dict, auth_issues = _run_authentik_phase(
+            manifest_paths=manifest_paths,
+            args=args,
+            applied=applied,
+            has_preflight_issues=bool(issues),
+        )
+        issues.extend(auth_issues)
+
+    payload: dict[str, object] = {
+        "status": "passed" if not issues else "failed",
+        "mode": "apply" if applied else "dry-run",
+        "terraform_state_mutation": False,
+        "manifests": [str(path) for path in manifest_paths],
+        "validation": validation.to_dict(),
+        "preflight": {
+            "targeting": {
+                "command": " ".join(TARGET_PREFLIGHT_COMMAND),
+                "detail": target_detail,
+                "ok": not applied or not any(issue.code == "EGR200" for issue in issues),
+            },
+            "health": {
+                "traefik": traefik_health.to_dict(),
+                "coredns": coredns_health.to_dict(),
+            },
+        },
+        "traefik": {
+            **traefik_result.to_dict(),
+            "output_dir": str(traefik_output_dir),
+            "files": rendered_files,
+        },
+        "coredns": {
+            **coredns_result.to_dict(),
+            "output_zone": rendered_zone,
+        },
+        "authentik": {
+            "required": needs_authentik,
+            "discovery": discovery_dict,
+            "reconcile": reconcile_dict,
+        },
+        "issues": [issue.to_dict() for issue in issues],
+    }
+
+    if temp_dir is not None:
+        temp_dir.cleanup()
+    return payload
+
+
+def _print_validation_summary(validation: dict[str, object]) -> None:
+    print(
+        "Validation: "
+        f"{validation.get('status')} "
+        f"(manifests={validation.get('manifest_count')}, issues={validation.get('issue_count')})"
+    )
+
+
+def _print_traefik_summary(traefik: dict[str, object]) -> None:
+    print(
+        "Traefik render: "
+        f"{traefik.get('status')} "
+        f"(stacks={traefik.get('stack_count')}, issues={traefik.get('issue_count')})"
+    )
+    files = traefik.get("files")
+    if not isinstance(files, list):
+        return
+    for file_path in files:
+        print(f"- wrote: {file_path}")
+
+
+def _print_coredns_summary(coredns: dict[str, object]) -> None:
+    print(
+        "CoreDNS render: "
+        f"{coredns.get('status')} "
+        f"(records={coredns.get('generated_record_count')}, issues={coredns.get('issue_count')})"
+    )
+    output_zone = coredns.get("output_zone")
+    if output_zone:
+        print(f"- wrote: {output_zone}")
+
+
+def _print_authentik_summary(auth: dict[str, object]) -> None:
+    if not auth.get("required"):
+        print("Authentik: not required by selected manifests.")
+        return
+
+    discovery = auth.get("discovery")
+    if isinstance(discovery, dict):
+        print(
+            "Authentik discovery: "
+            f"{discovery.get('status')} "
+            f"(routes={discovery.get('route_count')}, issues={discovery.get('issue_count')})"
+        )
+
+    reconcile = auth.get("reconcile")
+    if isinstance(reconcile, dict):
+        print(
+            "Authentik reconcile: "
+            f"{reconcile.get('status')} "
+            f"(actions={reconcile.get('action_count')}, writes={reconcile.get('write_count')})"
+        )
+
+
+def _print_issue_summary(issues: list[dict[str, object]]) -> None:
+    if not issues:
+        return
+    print(f"Issues: {len(issues)}")
+    for issue in issues:
+        print(f"- [{issue.get('code')}] {issue.get('message')}")
+
+
+def _print_human_result(result: dict[str, object]) -> None:
+    mode = str(result.get("mode", "dry-run"))
+    print(f"Edge reconciliation {mode} completed.")
+    print(f"Status: {result.get('status')}")
+
+    validation = result.get("validation")
+    if isinstance(validation, dict):
+        _print_validation_summary(validation)
+
+    traefik = result.get("traefik")
+    if isinstance(traefik, dict):
+        _print_traefik_summary(traefik)
+
+    coredns = result.get("coredns")
+    if isinstance(coredns, dict):
+        _print_coredns_summary(coredns)
+
+    auth = result.get("authentik")
+    if isinstance(auth, dict):
+        _print_authentik_summary(auth)
+
+    issues = result.get("issues")
+    if isinstance(issues, list) and issues:
+        _print_issue_summary([issue for issue in issues if isinstance(issue, dict)])
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = reconcile_edge(args)
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        _print_human_result(result)
+
+    return 0 if result.get("status") == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/lxc/test_reconcile_authentik_edge.py
+++ b/terraform/lxc/test_reconcile_authentik_edge.py
@@ -1,0 +1,283 @@
+"""Tests for create/update-only Authentik reconciliation behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "reconcile-authentik-edge.py"
+SPEC = importlib.util.spec_from_file_location("reconcile_authentik_edge", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+reconcile_authentik = MODULE.reconcile_authentik
+
+
+def _write_manifest(path: Path, stack: str, route: str, host: str, mode: str) -> None:
+    path.write_text(
+        f"""apiVersion: homelab.gibbsgreatly.xyz/v1alpha1
+kind: EdgeManifest
+metadata:
+  name: {stack}-edge
+  stack: {stack}
+spec:
+  routes:
+    - name: {route}
+      host: {host}
+      backend:
+        type: url
+        url: http://10.57.1.20:9000
+      dns:
+        enabled: true
+        target: 10.57.2.10
+        ttl: 5m
+      tls:
+        resolver: letsencrypt
+      auth:
+        mode: {mode}
+""",
+        encoding="utf-8",
+    )
+
+
+class FakeClient:
+    def __init__(
+        self,
+        *,
+        applications: list[dict] | None = None,
+        providers: list[dict] | None = None,
+        outposts: list[dict] | None = None,
+    ) -> None:
+        self.applications = list(applications or [])
+        self.providers = list(providers or [])
+        self.outposts = list(outposts or [])
+        self.request_methods: list[str] = []
+        self.writes: list[tuple[str, str, dict]] = []
+        self._next_id = 1000
+
+    def _new_id(self) -> int:
+        self._next_id += 1
+        return self._next_id
+
+    def fetch_applications(self):
+        self.request_methods.append("GET")
+        return self.applications
+
+    def fetch_proxy_providers(self):
+        self.request_methods.append("GET")
+        return self.providers
+
+    def fetch_outposts(self):
+        self.request_methods.append("GET")
+        return self.outposts
+
+    def create_proxy_provider(self, payload: dict):
+        self.request_methods.append("POST")
+        self.writes.append(("provider", "create", dict(payload)))
+        obj = {"pk": self._new_id(), **payload}
+        self.providers.append(obj)
+        return obj
+
+    def update_proxy_provider(self, provider_id: str, payload: dict):
+        self.request_methods.append("PATCH")
+        self.writes.append(("provider", "update", dict(payload)))
+        for provider in self.providers:
+            if str(provider.get("pk")) == str(provider_id):
+                provider.update(payload)
+                return provider
+        raise AssertionError("provider not found")
+
+    def create_application(self, payload: dict):
+        self.request_methods.append("POST")
+        self.writes.append(("application", "create", dict(payload)))
+        obj = {"pk": self._new_id(), **payload}
+        self.applications.append(obj)
+        return obj
+
+    def update_application(self, application_id: str, payload: dict):
+        self.request_methods.append("PATCH")
+        self.writes.append(("application", "update", dict(payload)))
+        for app in self.applications:
+            if str(app.get("pk")) == str(application_id):
+                app.update(payload)
+                return app
+        raise AssertionError("application not found")
+
+    def create_outpost(self, payload: dict):
+        self.request_methods.append("POST")
+        self.writes.append(("outpost", "create", dict(payload)))
+        obj = {"pk": self._new_id(), **payload}
+        self.outposts.append(obj)
+        return obj
+
+    def update_outpost(self, outpost_id: str, payload: dict):
+        self.request_methods.append("PATCH")
+        self.writes.append(("outpost", "update", dict(payload)))
+        for outpost in self.outposts:
+            if str(outpost.get("pk")) == str(outpost_id):
+                outpost.update(payload)
+                return outpost
+        raise AssertionError("outpost not found")
+
+
+class TestReconcileAuthentikEdge(unittest.TestCase):
+    def test_dry_run_plans_create_without_writes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "portainer.yaml"
+            _write_manifest(
+                manifest,
+                stack="portainer-stack",
+                route="portainer",
+                host="portainer.lab.gibbsgreatly.xyz",
+                mode="forwardAuth",
+            )
+            client = FakeClient()
+            result = reconcile_authentik([manifest], client, apply=False)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(0, result.write_count)
+        self.assertEqual([], client.writes)
+        operations = [action.operation for action in result.actions]
+        self.assertIn("create", operations)
+        self.assertIn(("provider", "create"), [(a.object_kind, a.operation) for a in result.actions])
+        self.assertIn(("application", "create"), [(a.object_kind, a.operation) for a in result.actions])
+        self.assertIn(("outpost", "create"), [(a.object_kind, a.operation) for a in result.actions])
+
+    def test_apply_then_second_apply_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "grafana.yaml"
+            _write_manifest(
+                manifest,
+                stack="grafana-stack",
+                route="grafana",
+                host="grafana.lab.gibbsgreatly.xyz",
+                mode="forwardAuth",
+            )
+            client = FakeClient()
+
+            first = reconcile_authentik([manifest], client, apply=True)
+            second = reconcile_authentik([manifest], client, apply=True)
+
+        self.assertTrue(first.ok)
+        self.assertGreater(first.write_count, 0)
+        self.assertTrue(second.ok)
+        self.assertEqual(0, second.write_count)
+        self.assertTrue(all(action.operation == "noop" for action in second.actions))
+
+    def test_existing_owned_objects_with_drift_plan_updates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "netbox.yaml"
+            _write_manifest(
+                manifest,
+                stack="netbox-stack",
+                route="netbox",
+                host="netbox.lab.gibbsgreatly.xyz",
+                mode="forwardAuth",
+            )
+            client = FakeClient(
+                providers=[
+                    {
+                        "pk": 11,
+                        "name": "edge-netbox-stack-netbox-provider",
+                        "external_host": "https://old-netbox.lab.gibbsgreatly.xyz",
+                        "cookie_domain": ".example.local",
+                    }
+                ],
+                applications=[
+                    {
+                        "pk": 22,
+                        "name": "edge-netbox-stack-netbox-app",
+                        "slug": "edge-netbox-stack-netbox",
+                        "meta_launch_url": "https://old-netbox.lab.gibbsgreatly.xyz/",
+                        "provider": 11,
+                    }
+                ],
+                outposts=[
+                    {
+                        "pk": 33,
+                        "name": "edge-forwardauth-outpost",
+                        "type": "proxy",
+                        "providers": [],
+                    }
+                ],
+            )
+
+            result = reconcile_authentik([manifest], client, apply=False)
+
+        self.assertTrue(result.ok)
+        operations = {(action.object_kind, action.operation) for action in result.actions}
+        self.assertIn(("provider", "update"), operations)
+        self.assertIn(("application", "update"), operations)
+        self.assertIn(("outpost", "update"), operations)
+
+    def test_non_forwardauth_reports_delete_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "authentik.yaml"
+            _write_manifest(
+                manifest,
+                stack="authentik-stack",
+                route="authentik",
+                host="authentik.lab.gibbsgreatly.xyz",
+                mode="none",
+            )
+            client = FakeClient(
+                providers=[
+                    {
+                        "pk": 91,
+                        "name": "edge-authentik-stack-authentik-provider",
+                        "external_host": "https://authentik.lab.gibbsgreatly.xyz",
+                    }
+                ],
+                applications=[
+                    {
+                        "pk": 92,
+                        "name": "edge-authentik-stack-authentik-app",
+                        "slug": "edge-authentik-stack-authentik",
+                        "meta_launch_url": "https://authentik.lab.gibbsgreatly.xyz/",
+                    }
+                ],
+            )
+
+            result = reconcile_authentik([manifest], client, apply=True)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(0, result.write_count)
+        self.assertEqual([], client.writes)
+        self.assertTrue(all(action.operation == "delete-report" for action in result.actions))
+
+    def test_unmanaged_candidate_causes_stop(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "portainer.yaml"
+            _write_manifest(
+                manifest,
+                stack="portainer-stack",
+                route="portainer",
+                host="portainer.lab.gibbsgreatly.xyz",
+                mode="forwardAuth",
+            )
+            client = FakeClient(
+                providers=[
+                    {
+                        "pk": 201,
+                        "name": "legacy-portainer-provider",
+                        "external_host": "https://portainer.lab.gibbsgreatly.xyz",
+                    }
+                ]
+            )
+
+            result = reconcile_authentik([manifest], client, apply=True)
+
+        self.assertFalse(result.ok)
+        self.assertGreater(len(result.stop_conditions), 0)
+        self.assertEqual(0, result.write_count)
+        self.assertEqual([], client.writes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/lxc/test_reconcile_edge.py
+++ b/terraform/lxc/test_reconcile_edge.py
@@ -1,0 +1,92 @@
+"""Tests for unified edge reconciler orchestration behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_DIR = REPO_ROOT / "docs" / "provisioning-refactor" / "fixtures" / "valid"
+MODULE_PATH = Path(__file__).resolve().parent / "reconcile-edge.py"
+SPEC = importlib.util.spec_from_file_location("reconcile_edge", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class TestReconcileEdge(unittest.TestCase):
+    def test_parse_args_defaults_to_dry_run(self):
+        args = MODULE.parse_args([])
+        self.assertFalse(args.apply)
+
+    def test_apply_fails_on_target_preflight(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest = Path(tmpdir) / "authentik.yaml"
+            manifest.write_text((FIXTURES_DIR / "authentik.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+
+            args = MODULE.parse_args([str(manifest), "--apply", "--json"])
+
+            with mock.patch.object(MODULE, "_run_pve_target_preflight", return_value=(False, "wrong target")):
+                with mock.patch.object(MODULE, "_http_health_check") as probe_mock:
+                    probe_mock.return_value = MODULE.HealthCheckResult(
+                        name="stub",
+                        url="http://example.local",
+                        ok=True,
+                        status_code=200,
+                        detail="ok",
+                    )
+                    result = MODULE.reconcile_edge(args)
+
+        self.assertEqual("failed", result["status"])
+        self.assertTrue(any(issue["code"] == "EGR200" for issue in result["issues"]))
+
+    def test_noop_with_empty_manifest_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stacks_dir = Path(tmpdir) / "stacks"
+            stacks_dir.mkdir(parents=True, exist_ok=True)
+
+            args = MODULE.parse_args([
+                "--stacks-dir",
+                str(stacks_dir),
+                "--json",
+            ])
+            result = MODULE.reconcile_edge(args)
+
+        self.assertEqual("passed", result["status"])
+        self.assertEqual([], result["manifests"])
+        self.assertFalse(result["authentik"]["required"])
+        self.assertEqual(0, result["traefik"]["stack_count"])
+        self.assertEqual(0, result["coredns"]["generated_record_count"])
+
+    def test_intended_replacement_host_allows_migration_collision(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "traefik-dashboard.yaml"
+            document = yaml.safe_load((FIXTURES_DIR / "traefik-dashboard.yaml").read_text(encoding="utf-8"))
+            document["spec"]["routes"][0]["auth"]["mode"] = "none"
+            manifest_path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+            args = MODULE.parse_args(
+                [
+                    str(manifest_path),
+                    "--intended-replacement-host",
+                    "traefik.lab.gibbsgreatly.xyz",
+                    "--json",
+                ]
+            )
+            result = MODULE.reconcile_edge(args)
+
+        self.assertEqual("passed", result["status"])
+        self.assertEqual("passed", result["traefik"]["status"])
+        self.assertEqual([], result["issues"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- add terraform/lxc/reconcile-edge.py as unified dry-run-first edge command\n- add Task 11 tests for dry-run default, apply preflight failure, no-op, and intended replacement host\n- update README docs for command usage\n- mark prompt status for Task 08 and Task 11 complete\n\n## Validation\n- python3 -m unittest terraform/lxc/test_reconcile_edge.py\n- ./with-secrets /home/steve/.local/bin/sonar-scanner\n- snyk code scan on terraform/lxc (0 issues)