### PR TITLE
Merge dev/pve-test: edge preflight fixes and Authentik route migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ python3 terraform/lxc/reconcile-edge.py --json
 Detailed command options and expected behavior are documented in
 `terraform/lxc/README.md`.
 
+For shared migration validation, rollback, and stop conditions used by the
+stack-owned edge route tasks, see
+`docs/provisioning-refactor/runbook.md`.
+
 ## Key documents
 
 ### Architecture and planning

--- a/docs/provisioning-refactor/README.md
+++ b/docs/provisioning-refactor/README.md
@@ -77,7 +77,8 @@ See [decisions.md](decisions.md) for details.
 - [prompts/index.yaml](prompts/index.yaml) is the ordered prompt registry for
    the full 22-task sequence.
 - [fixtures/](fixtures/) is reserved for EdgeManifest contract fixtures.
-- [runbook.md](runbook.md) will contain shared validation and rollback commands.
+- [runbook.md](runbook.md) is the shared validation and rollback contract for
+   Task 15 through Task 21 route migrations.
 
 ## How Agents Should Use This
 

--- a/docs/provisioning-refactor/runbook.md
+++ b/docs/provisioning-refactor/runbook.md
@@ -1,17 +1,329 @@
 # Stack-Owned Edge Validation Runbook
 
-This file is owned by Task 14. It intentionally starts as a placeholder so
-future agents can see the planned validation-runbook location before migration
-work begins.
+This runbook is the shared validation and rollback contract for Task 15 through
+Task 21 route migrations.
 
-Task 14 must replace this placeholder with copy-pasteable checks for:
+All migrations must use the same vocabulary, command patterns, expected
+outcomes, and stop conditions documented here.
 
-- pve-test targeting
-- CoreDNS health and delegated lab-zone answers
-- MikroTik conditional forwarding
-- Traefik file-provider and route validation
-- Authentik API/discovery/reconciliation health
-- route, certificate, and auth behavior
-- generated-state rollback
+## Scope and Safety
 
-Deployment migration tasks must not proceed until this runbook is complete.
+- Scope is pve-test only.
+- Dry-run is the default for edge reconciliation.
+- Do not run apply/mutation commands until all preflight checks pass.
+- Stop immediately and present options if a validation command would mutate live
+	infrastructure.
+
+## Shared Validation Vocabulary
+
+Use these exact terms in task notes, PR comments, and operator handoff.
+
+- Preflight: non-mutating target and health checks before apply.
+- Dry-run: manifest validation, render output, and reconciliation planning with
+	no live mutation.
+- Apply gate: explicit operator intent (`--apply`) plus healthy pve-test,
+	Traefik, and CoreDNS preflight state.
+- Pending changes: generated output or reconciliation actions still not
+	converged.
+- No-op: second dry-run after publish reports passed status, no issues, and no
+	remaining migration changes.
+- Generated snapshot: timestamped backup of generated files and live deployed
+	files taken before migration apply.
+- Rollback: restore previous generated snapshot, republish, and revalidate.
+
+## 1. Preflight (Required Before Every Migration)
+
+Run from repository root:
+
+```bash
+./with-secrets bash -c 'echo $TF_VAR_proxmox_node'
+```
+
+Expected outcome:
+- Output is exactly `pve-test`.
+
+Stop condition:
+- Any output other than `pve-test`.
+
+Run from repository root:
+
+```bash
+python3 terraform/lxc/validate-edge-manifests.py terraform/lxc/stacks/*/edge.yaml
+```
+
+Expected outcome:
+- Exit code `0`.
+- No edge-manifest schema/collision errors.
+
+Stop condition:
+- Any manifest validation failure.
+
+## 2. Shared Dry-Run Flow (Task 11 Reconciler Contract)
+
+### 2.1 Baseline dry-run (all manifests)
+
+Run from repository root:
+
+```bash
+python3 terraform/lxc/reconcile-edge.py --json | tee /tmp/reconcile-edge-dryrun.json
+```
+
+Expected outcome:
+- JSON includes `"mode": "dry-run"`.
+- JSON includes `"terraform_state_mutation": false`.
+- JSON includes `"status": "passed"`.
+
+### 2.2 Migration dry-run (single intended replacement host)
+
+Run from repository root (replace stack and host):
+
+```bash
+python3 terraform/lxc/reconcile-edge.py \
+	terraform/lxc/stacks/<stack>/edge.yaml \
+	--intended-replacement-host <host>.lab.gibbsgreatly.xyz \
+	--json | tee /tmp/reconcile-edge-migration-dryrun.json
+```
+
+Expected outcome:
+- Status is passed.
+- No accidental duplicate-host collision errors.
+- Renderer accepts only the one explicit intended replacement host.
+
+Stop condition:
+- Any failed status.
+- Any collision issue that is not the explicitly intended replacement host.
+
+## 3. Generated Snapshot (Take Before Any Publish)
+
+Run from repository root:
+
+```bash
+TS="$(date +%Y%m%d-%H%M%S)"
+SNAP_DIR="docs/provisioning-refactor/snapshots/$TS"
+mkdir -p "$SNAP_DIR/traefik" "$SNAP_DIR/coredns" "$SNAP_DIR/live"
+
+cp -a terraform/lxc/.generated/traefik/. "$SNAP_DIR/traefik/" 2>/dev/null || true
+cp -a terraform/lxc/.generated/coredns/coredns-lab.zone "$SNAP_DIR/coredns/" 2>/dev/null || true
+
+./with-secrets ansible -i '10.57.2.10,' -u root all -m fetch -a "src=/opt/proxy-stack/dynamic/authentik.yml dest=$SNAP_DIR/live/ flat=yes" || true
+./with-secrets ansible -i '10.57.2.10,' -u root all -m fetch -a "src=/opt/proxy-stack/dynamic/stacks dest=$SNAP_DIR/live/ flat=no" || true
+./with-secrets ansible -i '10.57.2.11,' -u root all -m fetch -a "src=/etc/coredns/lab.zone dest=$SNAP_DIR/live/coredns-lab.zone flat=yes" || true
+
+echo "snapshot=$SNAP_DIR"
+```
+
+Expected outcome:
+- Snapshot directory is created.
+- Generated and live files are captured where available.
+
+Stop condition:
+- Snapshot path is missing or empty for artifacts you are about to change.
+
+## 4. CoreDNS Publish and Validation (Task 12 Wiring)
+
+### 4.1 Connectivity precheck
+
+Run from `terraform/lxc/ansible`:
+
+```bash
+../../../with-secrets ansible -i '10.57.2.11,' -u root all -m ping
+```
+
+Expected outcome:
+- Host responds successfully.
+
+### 4.2 Publish generated zone
+
+Run from `terraform/lxc/ansible`:
+
+```bash
+../../../with-secrets ansible-playbook -i '10.57.2.11,' -u root playbooks/deploy-coredns.yml \
+	-e coredns_generated_zone_src=/home/steve/git/proxmox-homelab/terraform/lxc/.generated/coredns/coredns-lab.zone
+```
+
+Expected outcome:
+- Staged zone passes `named-checkzone`.
+- Bootstrap authority guardrails pass (SOA/NS/ns1 preserved).
+- CoreDNS service is running after handler flush.
+
+Stop condition:
+- Zone validation fails.
+- Bootstrap authority records are missing.
+
+### 4.3 Authoritative and delegated answer validation
+
+Run from repository root:
+
+```bash
+dig @10.57.2.11 +short traefik.lab.gibbsgreatly.xyz
+dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz
+dig @10.57.1.1 +short authentik.lab.gibbsgreatly.xyz
+```
+
+Expected outcome:
+- All browser hosts resolve to `10.57.2.10`.
+- MikroTik delegated forwarding returns the same answer path as CoreDNS.
+
+Stop condition:
+- Any browser host does not resolve to `10.57.2.10`.
+- Delegated forwarding is inconsistent with CoreDNS answers.
+
+## 5. Traefik Generated-File Validation and Deploy (Task 13 Wiring)
+
+### 5.1 Local compose and generated-file sanity
+
+Run from repository root:
+
+```bash
+test -d terraform/lxc/.generated/traefik
+ls -1 terraform/lxc/.generated/traefik/*.yml
+```
+
+Expected outcome:
+- Generated per-stack files exist for the migration target.
+
+### 5.2 Real-context playbook check (required before live deploy)
+
+Run from `terraform/lxc/ansible`:
+
+```bash
+../../../with-secrets ansible -i '10.57.2.10,' -u root all -m ping
+../../../with-secrets ansible-playbook -i '10.57.2.10,' -u root --check playbooks/deploy-proxy-stack.yml
+```
+
+Expected outcome:
+- Target host is reachable.
+- Playbook check mode completes without syntax/runtime validation errors.
+
+Stop condition:
+- Check mode reports a failure.
+
+### 5.3 Live deploy and Traefik runtime validation
+
+Run from `terraform/lxc/ansible`:
+
+```bash
+../../../with-secrets ansible-playbook -i '10.57.2.10,' -u root playbooks/deploy-proxy-stack.yml
+../../../with-secrets ansible -i '10.57.2.10,' -u root all -a "docker compose -f /opt/proxy-stack/docker-compose.yml config -q"
+```
+
+Expected outcome:
+- Deploy succeeds.
+- `docker compose ... config -q` passes.
+- Traefik file provider remains healthy and watching `/etc/traefik/dynamic/`.
+
+Stop condition:
+- Compose config validation fails.
+- Traefik cannot parse dynamic files.
+
+## 6. Route, HTTPS, Certificate, and Auth Validation
+
+Run from repository root:
+
+```bash
+for h in traefik grafana authentik portainer harbor netbox; do
+	echo "== $h.lab.gibbsgreatly.xyz =="
+	curl -skI --resolve "$h.lab.gibbsgreatly.xyz:443:10.57.2.10" "https://$h.lab.gibbsgreatly.xyz" | grep -E 'HTTP/|location:|server:'
+done
+```
+
+Expected outcome:
+- Each route returns an HTTP response via Traefik.
+- Protected routes redirect to/through Authentik as designed.
+- Authentik route itself does not self-protect (no forward-auth recursion).
+
+Run from repository root:
+
+```bash
+curl -sk -o /dev/null -w '%{http_code}\n' http://10.57.1.10:9000/-/health/live/
+curl -sk -o /dev/null -w '%{http_code}\n' https://authentik.lab.gibbsgreatly.xyz/application/o/
+```
+
+Expected outcome:
+- Direct Authentik liveness is healthy (typically `204`).
+- Authentik discovery/OIDC endpoint is reachable over routed HTTPS.
+
+Stop condition:
+- Redirect loops.
+- Any route returns no response over Traefik.
+- Authentik API/discovery is unavailable.
+
+## 7. Post-Apply Convergence Check
+
+Re-run dry-run after every migration publish.
+
+Run from repository root:
+
+```bash
+python3 terraform/lxc/reconcile-edge.py --json | tee /tmp/reconcile-edge-post-apply.json
+```
+
+Expected outcome:
+- Passed status.
+- No remaining accidental duplicate-host issues.
+- No migration residue; run is functionally no-op for the completed migration.
+
+Stop condition:
+- Any pending migration drift remains.
+
+## 8. Rollback from Generated Snapshot
+
+Use the latest snapshot created in Section 3.
+
+### 8.1 Roll back CoreDNS zone
+
+Run from `terraform/lxc/ansible` (replace snapshot path):
+
+```bash
+SNAP_DIR=/home/steve/git/proxmox-homelab/docs/provisioning-refactor/snapshots/<timestamp>
+../../../with-secrets ansible-playbook -i '10.57.2.11,' -u root playbooks/deploy-coredns.yml \
+	-e coredns_generated_zone_src="$SNAP_DIR/live/coredns-lab.zone"
+```
+
+Expected outcome:
+- Previous zone is republished and validated by the same CoreDNS guardrails.
+
+### 8.2 Roll back Traefik dynamic stacks files
+
+Run from `terraform/lxc/ansible` (replace snapshot path):
+
+```bash
+SNAP_DIR=/home/steve/git/proxmox-homelab/docs/provisioning-refactor/snapshots/<timestamp>
+../../../with-secrets ansible -i '10.57.2.10,' -u root all -m copy -a "src=$SNAP_DIR/live/10.57.2.10/opt/proxy-stack/dynamic/stacks/ dest=/opt/proxy-stack/dynamic/stacks/ mode=0640"
+../../../with-secrets ansible-playbook -i '10.57.2.10,' -u root playbooks/deploy-proxy-stack.yml
+```
+
+Expected outcome:
+- Previous generated files are restored.
+- Traefik accepts restored config and routes recover.
+
+### 8.3 Validate rollback
+
+Repeat Sections 4.3 and 6.
+
+Stop condition:
+- Rollback cannot restore known-good DNS or route behavior.
+
+## 9. Mandatory Stop-and-Present-Options Triggers
+
+Stop and present options (do not continue) when any of the following occur:
+
+- pve-test preflight fails.
+- A command labeled as validation is discovered to be mutating.
+- Reconciler reports failed status or collision issues.
+- CoreDNS guardrail assertions fail.
+- Traefik compose/file-provider validation fails.
+- Route/auth checks indicate redirect recursion or route blackhole.
+- Rollback cannot restore previous known-good state.
+
+## 10. Minimum Evidence to Attach to Every Migration Task
+
+Attach these artifacts to Task 15+ execution notes:
+
+- Reconciler dry-run JSON before apply.
+- Snapshot directory path.
+- CoreDNS publish output and delegated-answer checks.
+- Proxy real-context check output and deploy output.
+- Route/cert/auth validation output.
+- Reconciler dry-run JSON after apply (no-op expectation).
+- Rollback test output when rollback is exercised.

--- a/docs/provisioning-refactor/runbook.md
+++ b/docs/provisioning-refactor/runbook.md
@@ -58,6 +58,41 @@ Expected outcome:
 Stop condition:
 - Any manifest validation failure.
 
+Run from repository root:
+
+```bash
+if grep -R -qE 'mode:\s*forwardAuth' terraform/lxc/stacks/*/edge.yaml; then
+	./with-secrets bash -c 'test -n "$AUTHENTIK_SUPERUSER_API_TOKEN" && echo AUTHENTIK_SUPERUSER_API_TOKEN=present'
+else
+	echo "No forwardAuth routes selected; Authentik token preflight not required."
+fi
+```
+
+Expected outcome:
+- When any selected route uses `auth.mode: forwardAuth`, output confirms
+	`AUTHENTIK_SUPERUSER_API_TOKEN=present`.
+- When no selected route uses forwardAuth, token preflight is explicitly skipped.
+
+Stop condition:
+- A selected forwardAuth route exists and
+	`AUTHENTIK_SUPERUSER_API_TOKEN` is missing/empty.
+
+Run from repository root (apply-mode gate probes):
+
+```bash
+timeout 5 bash -lc '</dev/tcp/10.57.2.10/443'
+dig @10.57.1.13 +short traefik.lab.gibbsgreatly.xyz
+```
+
+Expected outcome:
+- TCP connect to `10.57.2.10:443` succeeds.
+- Authoritative CoreDNS answer for `traefik.lab.gibbsgreatly.xyz` includes
+	`10.57.2.10`.
+
+Stop condition:
+- Traefik TCP reachability probe fails.
+- CoreDNS authoritative `dig` probe fails or returns an unexpected answer.
+
 ## 2. Shared Dry-Run Flow (Task 11 Reconciler Contract)
 
 ### 2.1 Baseline dry-run (all manifests)
@@ -72,6 +107,7 @@ Expected outcome:
 - JSON includes `"mode": "dry-run"`.
 - JSON includes `"terraform_state_mutation": false`.
 - JSON includes `"status": "passed"`.
+- JSON `issues` is empty.
 
 ### 2.2 Migration dry-run (single intended replacement host)
 
@@ -88,6 +124,7 @@ Expected outcome:
 - Status is passed.
 - No accidental duplicate-host collision errors.
 - Renderer accepts only the one explicit intended replacement host.
+- No unexpected generated changes outside the targeted migration host.
 
 Stop condition:
 - Any failed status.
@@ -107,7 +144,7 @@ cp -a terraform/lxc/.generated/coredns/coredns-lab.zone "$SNAP_DIR/coredns/" 2>/
 
 ./with-secrets ansible -i '10.57.2.10,' -u root all -m fetch -a "src=/opt/proxy-stack/dynamic/authentik.yml dest=$SNAP_DIR/live/ flat=yes" || true
 ./with-secrets ansible -i '10.57.2.10,' -u root all -m fetch -a "src=/opt/proxy-stack/dynamic/stacks dest=$SNAP_DIR/live/ flat=no" || true
-./with-secrets ansible -i '10.57.2.11,' -u root all -m fetch -a "src=/etc/coredns/lab.zone dest=$SNAP_DIR/live/coredns-lab.zone flat=yes" || true
+./with-secrets ansible -i '10.57.1.13,' -u root all -m fetch -a "src=/etc/coredns/lab.zone dest=$SNAP_DIR/live/coredns-lab.zone flat=yes" || true
 
 echo "snapshot=$SNAP_DIR"
 ```
@@ -126,7 +163,7 @@ Stop condition:
 Run from `terraform/lxc/ansible`:
 
 ```bash
-../../../with-secrets ansible -i '10.57.2.11,' -u root all -m ping
+../../../with-secrets ansible -i '10.57.1.13,' -u root all -m ping
 ```
 
 Expected outcome:
@@ -137,7 +174,7 @@ Expected outcome:
 Run from `terraform/lxc/ansible`:
 
 ```bash
-../../../with-secrets ansible-playbook -i '10.57.2.11,' -u root playbooks/deploy-coredns.yml \
+../../../with-secrets ansible-playbook -i '10.57.1.13,' -u root playbooks/deploy-coredns.yml \
 	-e coredns_generated_zone_src=/home/steve/git/proxmox-homelab/terraform/lxc/.generated/coredns/coredns-lab.zone
 ```
 
@@ -155,7 +192,7 @@ Stop condition:
 Run from repository root:
 
 ```bash
-dig @10.57.2.11 +short traefik.lab.gibbsgreatly.xyz
+dig @10.57.1.13 +short traefik.lab.gibbsgreatly.xyz
 dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz
 dig @10.57.1.1 +short authentik.lab.gibbsgreatly.xyz
 ```
@@ -223,14 +260,30 @@ Run from repository root:
 ```bash
 for h in traefik grafana authentik portainer harbor netbox; do
 	echo "== $h.lab.gibbsgreatly.xyz =="
-	curl -skI --resolve "$h.lab.gibbsgreatly.xyz:443:10.57.2.10" "https://$h.lab.gibbsgreatly.xyz" | grep -E 'HTTP/|location:|server:'
+	curl -sSI --resolve "$h.lab.gibbsgreatly.xyz:443:10.57.2.10" "https://$h.lab.gibbsgreatly.xyz" | grep -E 'HTTP/|location:|server:'
 done
 ```
 
 Expected outcome:
 - Each route returns an HTTP response via Traefik.
-- Protected routes redirect to/through Authentik as designed.
+- Route behavior matches `auth.mode` in the stack `edge.yaml`:
+	`forwardAuth` routes redirect to/through Authentik and `none` routes do not.
 - Authentik route itself does not self-protect (no forward-auth recursion).
+
+Run from repository root:
+
+```bash
+for h in traefik grafana authentik portainer harbor netbox; do
+	echo "== cert $h.lab.gibbsgreatly.xyz =="
+	echo | openssl s_client -connect 10.57.2.10:443 -servername "$h.lab.gibbsgreatly.xyz" 2>/dev/null \
+		| openssl x509 -noout -subject -issuer -ext subjectAltName
+done
+```
+
+Expected outcome:
+- Certificate SAN includes `DNS:*.lab.gibbsgreatly.xyz` (or explicit host entry
+	for the migrated route).
+- Issuer chain and certificate subject match expected lab certificate policy.
 
 Run from repository root:
 
@@ -246,6 +299,7 @@ Expected outcome:
 Stop condition:
 - Redirect loops.
 - Any route returns no response over Traefik.
+- TLS trust fails or certificate SAN/issuer is not the expected value.
 - Authentik API/discovery is unavailable.
 
 ## 7. Post-Apply Convergence Check
@@ -276,7 +330,7 @@ Run from `terraform/lxc/ansible` (replace snapshot path):
 
 ```bash
 SNAP_DIR=/home/steve/git/proxmox-homelab/docs/provisioning-refactor/snapshots/<timestamp>
-../../../with-secrets ansible-playbook -i '10.57.2.11,' -u root playbooks/deploy-coredns.yml \
+../../../with-secrets ansible-playbook -i '10.57.1.13,' -u root playbooks/deploy-coredns.yml \
 	-e coredns_generated_zone_src="$SNAP_DIR/live/coredns-lab.zone"
 ```
 
@@ -311,9 +365,12 @@ Stop and present options (do not continue) when any of the following occur:
 - pve-test preflight fails.
 - A command labeled as validation is discovered to be mutating.
 - Reconciler reports failed status or collision issues.
+- Apply-mode Traefik/CoreDNS health preflight checks fail.
 - CoreDNS guardrail assertions fail.
 - Traefik compose/file-provider validation fails.
+- Duplicate route ownership or unexpected generated-file changes are detected.
 - Route/auth checks indicate redirect recursion or route blackhole.
+- DNS, certificate, or auth behavior regresses from pre-migration baseline.
 - Rollback cannot restore previous known-good state.
 
 ## 10. Minimum Evidence to Attach to Every Migration Task

--- a/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
@@ -168,17 +168,6 @@
                     - main: "lab.gibbsgreatly.xyz"
                       sans:
                         - "*.lab.gibbsgreatly.xyz"
-              authentik:
-                rule: "Host(`authentik.lab.gibbsgreatly.xyz`)"
-                entryPoints:
-                  - websecure
-                service: authentik-backend
-                tls:
-                  certResolver: letsencrypt
-                  domains:
-                    - main: "lab.gibbsgreatly.xyz"
-                      sans:
-                        - "*.lab.gibbsgreatly.xyz"
               portainer:
                 rule: "Host(`portainer.lab.gibbsgreatly.xyz`)"
                 entryPoints:
@@ -221,10 +210,6 @@
                 loadBalancer:
                   servers:
                     - url: "{{ monitoring_grafana_url | default('http://10.57.1.12:3000') }}"
-              authentik-backend:
-                loadBalancer:
-                  servers:
-                    - url: "http://10.57.1.10:9000"
               portainer-backend:
                 loadBalancer:
                   servers:

--- a/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-proxy-stack.yml
@@ -54,7 +54,8 @@
         mode: "{{ item.mode }}"
       loop:
         - { path: "{{ proxy_compose_dir }}", mode: "0750" }
-        - { path: "{{ proxy_compose_dir }}/dynamic", mode: "0750" }
+        - { path: "{{ proxy_compose_dir }}/dynamic", mode: "0755" }
+        - { path: "{{ proxy_compose_dir }}/dynamic/stacks", mode: "0755" }
         - { path: "{{ proxy_compose_dir }}/certs", mode: "0750" }
         - { path: "{{ proxy_compose_dir }}/certs/letsencrypt", mode: "0700" }
         - { path: "{{ proxy_compose_dir }}/certs/step-ca", mode: "0700" }
@@ -119,6 +120,8 @@
             docker:
               exposedByDefault: false
             file:
+              # Includes central dynamic files and generated per-stack files under
+              # /etc/traefik/dynamic/stacks/*.yml.
               directory: "/etc/traefik/dynamic/"
               watch: true
 

--- a/terraform/lxc/reconcile-authentik-edge.py
+++ b/terraform/lxc/reconcile-authentik-edge.py
@@ -7,6 +7,7 @@ import argparse
 import importlib.util
 import json
 import os
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 import ssl
@@ -27,6 +28,7 @@ _DISCOVER_SPEC = importlib.util.spec_from_file_location("discover_authentik_edge
 if _DISCOVER_SPEC is None or _DISCOVER_SPEC.loader is None:
     raise RuntimeError("failed to load discover-authentik-edge.py")
 _DISCOVER = importlib.util.module_from_spec(_DISCOVER_SPEC)
+sys.modules["discover_authentik_edge"] = _DISCOVER
 _DISCOVER_SPEC.loader.exec_module(_DISCOVER)
 
 RouteIntent = _DISCOVER.RouteIntent

--- a/terraform/lxc/reconcile-edge.py
+++ b/terraform/lxc/reconcile-edge.py
@@ -9,12 +9,11 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-import ssl
+import socket
 import subprocess
 import sys
 import tempfile
 from typing import Any
-import urllib.request
 
 import yaml
 
@@ -42,8 +41,11 @@ RECONCILE_AUTHENTIK = _load_module("reconcile_authentik_edge", SCRIPT_DIR / "rec
 
 
 TARGET_PREFLIGHT_COMMAND: tuple[str, ...] = ("./with-secrets", "bash", "-c", "echo $TF_VAR_proxmox_node")
-DEFAULT_TRAEFIK_HEALTH_URL = "http://10.57.2.10:8080/ping"
-DEFAULT_COREDNS_HEALTH_URL = "http://10.57.2.11:8080/health"
+DEFAULT_TRAEFIK_PROBE_HOST = "10.57.2.10"
+DEFAULT_TRAEFIK_PROBE_PORT = 443
+DEFAULT_COREDNS_PROBE_SERVER = "10.57.1.13"
+DEFAULT_COREDNS_PROBE_NAME = "traefik.lab.gibbsgreatly.xyz"
+DEFAULT_COREDNS_PROBE_EXPECTED = "10.57.2.10"
 NOT_RUN_DRY_RUN = "not run (dry-run mode)"
 
 
@@ -145,14 +147,30 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Disable TLS verification for Authentik and health checks.",
     )
     parser.add_argument(
-        "--traefik-health-url",
-        default=DEFAULT_TRAEFIK_HEALTH_URL,
-        help="Traefik health endpoint required in apply mode.",
+        "--traefik-probe-host",
+        default=DEFAULT_TRAEFIK_PROBE_HOST,
+        help="Traefik host required to accept TCP connections in apply mode.",
     )
     parser.add_argument(
-        "--coredns-health-url",
-        default=DEFAULT_COREDNS_HEALTH_URL,
-        help="CoreDNS health endpoint required in apply mode.",
+        "--traefik-probe-port",
+        type=int,
+        default=DEFAULT_TRAEFIK_PROBE_PORT,
+        help="Traefik TCP port required to be reachable in apply mode.",
+    )
+    parser.add_argument(
+        "--coredns-probe-server",
+        default=DEFAULT_COREDNS_PROBE_SERVER,
+        help="Authoritative CoreDNS server IP for apply-mode dig validation.",
+    )
+    parser.add_argument(
+        "--coredns-probe-name",
+        default=DEFAULT_COREDNS_PROBE_NAME,
+        help="DNS name queried during apply-mode authoritative CoreDNS probe.",
+    )
+    parser.add_argument(
+        "--coredns-probe-expected",
+        default=DEFAULT_COREDNS_PROBE_EXPECTED,
+        help="Expected IPv4 answer in apply-mode authoritative CoreDNS probe.",
     )
     parser.add_argument(
         "--apply",
@@ -337,35 +355,63 @@ def _run_pve_target_preflight() -> tuple[bool, str]:
     return True, "target preflight passed (pve-test)"
 
 
-def _http_health_check(url: str) -> HealthCheckResult:
-    request = urllib.request.Request(url, method="GET")
-
+def _tcp_health_check(host: str, port: int) -> HealthCheckResult:
+    probe_target = f"tcp://{host}:{port}"
     try:
-        with urllib.request.urlopen(request, timeout=8) as response:
-            status = response.getcode()
-            if 200 <= status < 300:
-                return HealthCheckResult(
-                    name="",
-                    url=url,
-                    ok=True,
-                    status_code=status,
-                    detail="health probe succeeded",
-                )
+        with socket.create_connection((host, port), timeout=5):
             return HealthCheckResult(
                 name="",
-                url=url,
-                ok=False,
-                status_code=status,
-                detail=f"unexpected status code {status}",
+                url=probe_target,
+                ok=True,
+                status_code=None,
+                detail="tcp reachability probe succeeded",
             )
     except Exception as exc:
         return HealthCheckResult(
             name="",
-            url=url,
+            url=probe_target,
             ok=False,
             status_code=None,
-            detail=f"health probe failed: {exc}",
+            detail=f"tcp reachability probe failed: {exc}",
         )
+
+
+def _dns_authority_health_check(server: str, name: str, expected: str) -> HealthCheckResult:
+    probe_target = f"dig @{server} +short {name}"
+    result = subprocess.run(
+        ["dig", f"@{server}", "+short", name],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"dig exited {result.returncode}"
+        return HealthCheckResult(
+            name="",
+            url=probe_target,
+            ok=False,
+            status_code=None,
+            detail=f"authoritative dns probe failed: {detail}",
+        )
+
+    answers = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if expected in answers:
+        return HealthCheckResult(
+            name="",
+            url=probe_target,
+            ok=True,
+            status_code=None,
+            detail=f"authoritative dns probe succeeded (answer includes {expected})",
+        )
+
+    return HealthCheckResult(
+        name="",
+        url=probe_target,
+        ok=False,
+        status_code=None,
+        detail=f"authoritative dns probe returned {answers or ['<empty>']}, expected {expected}",
+    )
 
 
 def _build_failed_result(
@@ -400,7 +446,7 @@ def _run_apply_preflights(args: argparse.Namespace) -> tuple[str, HealthCheckRes
     if not target_ok:
         issues.append(EdgeIssue(code="EGR200", message=target_detail))
 
-    traefik_probe = _http_health_check(args.traefik_health_url)
+    traefik_probe = _tcp_health_check(args.traefik_probe_host, args.traefik_probe_port)
     traefik_health = HealthCheckResult(
         name="traefik",
         url=traefik_probe.url,
@@ -411,7 +457,11 @@ def _run_apply_preflights(args: argparse.Namespace) -> tuple[str, HealthCheckRes
     if not traefik_health.ok:
         issues.append(EdgeIssue(code="EGR201", message=f"Traefik health check failed: {traefik_health.detail}"))
 
-    coredns_probe = _http_health_check(args.coredns_health_url)
+    coredns_probe = _dns_authority_health_check(
+        args.coredns_probe_server,
+        args.coredns_probe_name,
+        args.coredns_probe_expected,
+    )
     coredns_health = HealthCheckResult(
         name="coredns",
         url=coredns_probe.url,
@@ -528,14 +578,14 @@ def reconcile_edge(args: argparse.Namespace) -> dict[str, object]:
         target_detail = NOT_RUN_DRY_RUN
         traefik_health = HealthCheckResult(
             name="traefik",
-            url=args.traefik_health_url,
+            url=f"tcp://{args.traefik_probe_host}:{args.traefik_probe_port}",
             ok=True,
             status_code=None,
             detail=NOT_RUN_DRY_RUN,
         )
         coredns_health = HealthCheckResult(
             name="coredns",
-            url=args.coredns_health_url,
+            url=f"dig @{args.coredns_probe_server} +short {args.coredns_probe_name}",
             ok=True,
             status_code=None,
             detail=NOT_RUN_DRY_RUN,

--- a/terraform/lxc/stacks/authentik-stack/edge.yaml
+++ b/terraform/lxc/stacks/authentik-stack/edge.yaml
@@ -1,0 +1,20 @@
+apiVersion: homelab.gibbsgreatly.xyz/v1alpha1
+kind: EdgeManifest
+metadata:
+  name: authentik-edge
+  stack: authentik-stack
+spec:
+  routes:
+    - name: authentik
+      host: authentik.lab.gibbsgreatly.xyz
+      backend:
+        type: url
+        url: http://10.57.1.10:9000
+      dns:
+        enabled: true
+        target: 10.57.2.10
+        ttl: 5m
+      tls:
+        resolver: letsencrypt
+      auth:
+        mode: none


### PR DESCRIPTION
## Summary\n- align edge apply preflights with deployed Traefik/CoreDNS services\n- migrate Authentik route to stack-owned edge manifest\n- update runbook references and migration workflow docs\n\n## Notes\n- Task 15 cutover validated on pve-test\n- snapshots retained locally as operational evidence and not committed