### PR TITLE
Refactor network provisioning to direct routed access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,10 @@ If the operator explicitly names a merge target (`baseline/teardown-validated` o
 
 ## Branching
 
-- Infrastructure work: cut `work/*` from the current working HEAD; validate through a full teardown + redeploy cycle; promote to `baseline/teardown-validated`.
-- Application stack work: cut `feat/`, `fix/`, or `task/` from the current working HEAD; validate stacks on top of `baseline/teardown-validated`; promote to `dev/pve-test`.
+- Infrastructure work: cut `work/*` from the intended stable base branch for that effort, normally `baseline/teardown-validated`; validate through a full teardown + redeploy cycle; promote to `baseline/teardown-validated`.
+- Application stack work: cut `feat/`, `fix/`, or `task/` from the intended stable base branch for that effort, normally `baseline/teardown-validated`; validate stacks on top of `baseline/teardown-validated`; promote to `dev/pve-test`.
 - AI tooling / workflow changes: cut `feat/` from the current working HEAD; merge directly to `dev/pve-test` (no infrastructure gate required).
-- `dev/pve-test` and `baseline/teardown-validated` are **promotion targets only** — never use them as the base for a new development branch.
+- `dev/pve-test` and `baseline/teardown-validated` are promotion branches. Do not develop directly on them, but do branch from the appropriate one when starting new work.
 - Validate in the short-lived branch before merging. If validation fails, stop and present options — do not merge until resolved or explicitly accepted.
 - PR `dev/pve-test` → `main` only when stable and tested on the test server.
 - After merging to `main`, pull `main` back into `dev/pve-test` to stay in sync.

--- a/docs/design/network.md
+++ b/docs/design/network.md
@@ -17,10 +17,10 @@ for per-container inbound filtering but has a known cross-zone rule generation b
 
 | Zone | Internal name | VLAN ID | Subnet | Gateway | Purpose |
 |---|---|---|---|---|---|
-| build_seg | `tvsegc` | 10 | `10.57.0.0/24` | `10.57.0.1` | CI runner — isolated build environment |
-| mgmt_seg | `tvmgmt` | 20 | `10.57.1.0/24` | `10.57.1.1` | Management plane — Portainer, Authentik, step-ca, monitoring, CoreDNS |
-| edge_seg | `tvedge` | 30 | `10.57.2.0/24` | `10.57.2.1` | Public ingress — Traefik only |
-| infra_seg | `tvinfra` | 40 | `10.57.3.0/24` | `10.57.3.1` | Infrastructure services — Harbor, apt-cacher, NetBox |
+| build_seg | `tvsegc` | 10 | `192.168.10.0/24` | `192.168.10.1` | CI runner — isolated build environment |
+| mgmt_seg | `tvmgmt` | 20 | `192.168.20.0/24` | `192.168.20.1` | Management plane — Portainer, Authentik, step-ca, monitoring, CoreDNS |
+| edge_seg | `tvedge` | 30 | `192.168.30.0/24` | `192.168.30.1` | Public ingress — Traefik only |
+| infra_seg | `tvinfra` | 40 | `192.168.40.0/24` | `192.168.40.1` | Infrastructure services — Harbor, apt-cacher, NetBox |
 
 Future zones (Phase 06+): `app_seg`, `game_seg`.
 
@@ -28,16 +28,16 @@ Future zones (Phase 06+): `app_seg`, `game_seg`.
 
 | Container | Zone | IP | VMID | Phase |
 |---|---|---|---|---|
-| ci-runner-01 | `build_seg` | `10.57.0.63` | 10063 | 01 |
-| Portainer | `mgmt_seg` | `10.57.1.20` | 20020 | 00b |
-| Authentik | `mgmt_seg` | `10.57.1.10` | 20010 | 04 |
-| step-ca | `mgmt_seg` | `10.57.1.11` | 20011 | 04 |
-| Monitoring | `mgmt_seg` | `10.57.1.12` | 20012 | 04 |
-| CoreDNS | `mgmt_seg` | `10.57.1.13` | 20013 | 04b |
-| Traefik | `edge_seg` | `10.57.2.10` | 30010 | 04 |
-| Harbor | `infra_seg` | `10.57.3.10` | 40010 | 03b |
-| apt-cacher-ng | `infra_seg` | `10.57.3.11` | 40011 | 03c |
-| NetBox | `infra_seg` | `10.57.3.12` | 40012 | 03b |
+| ci-runner-01 | `build_seg` | `192.168.10.63` | 10063 | 01 |
+| Portainer | `mgmt_seg` | `192.168.20.20` | 20020 | 00b |
+| Authentik | `mgmt_seg` | `192.168.20.10` | 20010 | 04 |
+| step-ca | `mgmt_seg` | `192.168.20.11` | 20011 | 04 |
+| Monitoring | `mgmt_seg` | `192.168.20.12` | 20012 | 04 |
+| CoreDNS | `mgmt_seg` | `192.168.20.13` | 20013 | 04b |
+| Traefik | `edge_seg` | `192.168.30.10` | 30010 | 04 |
+| Harbor | `infra_seg` | `192.168.40.10` | 40010 | 03b |
+| apt-cacher-ng | `infra_seg` | `192.168.40.11` | 40011 | 03c |
+| NetBox | `infra_seg` | `192.168.40.12` | 40012 | 03b |
 
 ## Cross-zone traffic policy
 
@@ -59,11 +59,11 @@ configuration (TM-09). A full pve-test rebuild requires manual MikroTik reconfig
 
 Two-tier model:
 
-1. **MikroTik** (`10.57.x.1` on each zone) is the DNS entry point for all SDN clients.
+1. **MikroTik** (`192.168.<vlan-id>.1` on each zone) is the DNS entry point for all SDN clients.
    Each zone's gateway IP is the resolver that containers use. The MikroTik handles public
    name resolution and conditionally forwards the internal zone.
 
-2. **CoreDNS** (`10.57.1.13`) holds authority for `lab.gibbsgreatly.xyz`. MikroTik
+2. **CoreDNS** (`192.168.20.13`) holds authority for `lab.gibbsgreatly.xyz`. MikroTik
    conditionally forwards queries matching `lab.gibbsgreatly.xyz` to CoreDNS via a FWD
    rule. All other queries are resolved by MikroTik directly (public DNS via DoH upstream).
 
@@ -80,10 +80,10 @@ Each LXC's `/etc/resolv.conf` points to its zone's MikroTik gateway IP:
 
 | Zone | DNS server in resolv.conf |
 |---|---|
-| `build_seg` | `10.57.0.1` |
-| `mgmt_seg` | `10.57.1.1` |
-| `edge_seg` | `10.57.2.1` |
-| `infra_seg` | `10.57.3.1` |
+| `build_seg` | `192.168.10.1` |
+| `mgmt_seg` | `192.168.20.1` |
+| `edge_seg` | `192.168.30.1` |
+| `infra_seg` | `192.168.40.1` |
 
 The `lxc_base` Ansible role writes the correct resolver based on the `dns_server` variable
 in each stack's `stack.yaml`. All `stack.yaml` files must set `dns_server` explicitly — do

--- a/docs/design/network.md
+++ b/docs/design/network.md
@@ -111,5 +111,5 @@ The staging issuer shows `(STAGING) Let's Encrypt` in browsers — this is expec
 |---|---|---|
 | MikroTik has no IaC | TM-09 | All ACL rules, VLAN config, and DNS forwarding rules are applied manually. A pve-test rebuild requires manual MikroTik reconfiguration. |
 | VNet firewall cross-zone rule bug | — | `vnet_policy_candidates` in `terraform/lxc/main.tf:86-95` requires both `from` and `to` to match the current container's VNet, making cross-zone ACCEPT rules impossible to generate. Proxmox VNet firewall is disabled for dev passes. |
-| SDN VLAN zone Terraform support | — | `configure-network-sdn-vnet.yml` handles Simple zones only. VLAN zones are applied by `ansible/00-initial-setup/proxmox-sdn-setup.yml` until this is fixed. |
+| MikroTik remains out of band | TM-09 | SDN VLAN attachment creation for `pve-test` is automated in `configure-network-sdn-vnet.yml`, but MikroTik VLAN interfaces, gateway IPs, DNS forwarding, and firewall ACLs are still manual prerequisites. |
 | `dns_server` contract coverage | — | Explicit `dns_server` is now set in stack metadata and validated from generated inventories; future stacks should continue to use the zone or bridge gateway explicitly. |

--- a/docs/network-refactor/README.md
+++ b/docs/network-refactor/README.md
@@ -42,6 +42,10 @@ See the preserved checkpoint:
 
 - main planning doc:
   [plan.md](/home/steve/git/proxmox-homelab/docs/network-refactor/plan.md:1)
+- target model:
+  [target-model.md](/home/steve/git/proxmox-homelab/docs/network-refactor/target-model.md:1)
+- teardown validation gate:
+  [validation-gate.md](/home/steve/git/proxmox-homelab/docs/network-refactor/validation-gate.md:1)
 - session handoff:
   [handoff.md](/home/steve/git/proxmox-homelab/docs/network-refactor/handoff.md:1)
 

--- a/docs/network-refactor/README.md
+++ b/docs/network-refactor/README.md
@@ -33,8 +33,8 @@ See the preserved checkpoint:
    intended routed VLAN design.
 2. Terraform-generated inventories do not need Proxmox to act as a general
    jump host for SDN-backed stack provisioning.
-3. `prime_sdn_host_route` is either removed or retained only as an explicitly
-   temporary compatibility shim.
+3. `prime_sdn_host_route` has been removed; only `ProxyJump` remains as an
+   explicitly temporary compatibility shim.
 4. The corrected model is validated on `pve-test` with at least one teardown +
    redeploy cycle before production canary progression resumes.
 
@@ -44,6 +44,8 @@ See the preserved checkpoint:
   [plan.md](/home/steve/git/proxmox-homelab/docs/network-refactor/plan.md:1)
 - target model:
   [target-model.md](/home/steve/git/proxmox-homelab/docs/network-refactor/target-model.md:1)
+- migration mechanics decisions:
+   [migration-mechanics.md](/home/steve/git/proxmox-homelab/docs/network-refactor/migration-mechanics.md:1)
 - teardown validation gate:
   [validation-gate.md](/home/steve/git/proxmox-homelab/docs/network-refactor/validation-gate.md:1)
 - session handoff:

--- a/docs/network-refactor/README.md
+++ b/docs/network-refactor/README.md
@@ -1,0 +1,48 @@
+# Network Refactor
+
+## Purpose
+
+This directory is the planning and execution home for the network/provisioning
+refactor that follows the preserved `refactor/productionize` checkpoint.
+
+The immediate goal is not new service rollout. It is to correct the networking
+and provisioning model so SDN-backed guests are reached and managed in the way
+the platform actually intends:
+
+- routed by the main router at L3
+- not implicitly dependent on Proxmox acting as a jump host
+- not dependent on ad hoc host-side route priming as a long-term design
+
+## Why This Exists
+
+The productionizing work proved that:
+
+1. production env/storage/network parameterization is viable
+2. `apt-cacher-stack` is a good first production canary candidate
+3. the current Terraform/Ansible provisioning path assumes `ProxyJump` through
+   the Proxmox host for SDN-backed guests
+4. that assumption does not match the intended network design
+
+See the preserved checkpoint:
+
+- [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+
+## Outcomes We Want
+
+1. Operator workstations and approved clients reach guest subnets through the
+   intended routed VLAN design.
+2. Terraform-generated inventories do not need Proxmox to act as a general
+   jump host for SDN-backed stack provisioning.
+3. `prime_sdn_host_route` is either removed or retained only as an explicitly
+   temporary compatibility shim.
+4. The corrected model is validated on `pve-test` with at least one teardown +
+   redeploy cycle before production canary progression resumes.
+
+## Working Documents
+
+- main planning doc:
+  [plan.md](/home/steve/git/proxmox-homelab/docs/network-refactor/plan.md:1)
+- session handoff:
+  [handoff.md](/home/steve/git/proxmox-homelab/docs/network-refactor/handoff.md:1)
+
+Add focused task docs under this directory as the plan becomes more concrete.

--- a/docs/network-refactor/checkpoint.md
+++ b/docs/network-refactor/checkpoint.md
@@ -78,9 +78,9 @@ Read-only checks against `pve-test` showed:
    - route `192.168.20.0/24 dev tvmgmt src 192.168.20.254`
 4. `tvinfra` exists as a link, but did not show comparable working host-side
    reachability during inspection
-5. route lookup from `pve-test` to `10.57.3.11` fell back to the default route
+5. route lookup from `pve-test` to `192.168.40.11` fell back to the default route
    via `vmbr0`
-6. ping from `pve-test` to `10.57.3.11` failed
+6. ping from `pve-test` to `192.168.40.11` failed
 
 Interpretation:
 

--- a/docs/network-refactor/checkpoint.md
+++ b/docs/network-refactor/checkpoint.md
@@ -1,0 +1,112 @@
+# Network Refactor Checkpoint
+
+## Why This Refactor Exists
+
+The preserved `refactor/productionize` work proved that production-targeted
+stack modeling is viable, but it also exposed a provisioning/networking
+assumption that conflicts with the intended platform design.
+
+The current Terraform/Ansible path for SDN-backed guests assumes:
+
+1. generated inventory connects through `ProxyJump=root@<proxmox-host>`
+2. the Proxmox host itself must be able to reach guest SDN subnets directly
+3. host-side route/IP priming is acceptable as part of normal stack bring-up
+
+The intended design is different:
+
+1. inter-VLAN/subnet routing belongs to the main router
+2. Proxmox should not become the default administrative jump host for guest
+   networks
+3. host-side route priming should not be the long-term provisioning model
+
+## What The Productionizing Work Already Achieved
+
+The paused `refactor/productionize` branch established:
+
+1. production credential controls and separate production secrets handling
+2. a production non-secret env model in `.env.pve` / `.env.pve.template`
+3. production storage intent in `terraform/lxc/storage/pve.yaml`
+4. production network intent in `terraform/lxc/network/pve.yaml`
+5. stack targeting decoupled from hardcoded `pve-test`
+6. Portainer-specific secrets no longer blocking unrelated stack plans
+7. SDN creation guardrails widened from `pve-test`-only to environment-aware
+   creation, while destroy remained conservative
+8. `apt-cacher-stack` identified and prepared as the first production canary
+
+## Production Canary Evidence Preserved
+
+For `apt-cacher-stack` on `pve`:
+
+1. production-targeted plans rendered successfully
+2. collision checks found no live conflict for:
+   - VMID `40011`
+   - IP `192.168.40.11`
+   - an existing production `apt-cacher` workload
+3. a narrow targeted apply created production SDN prerequisites for the canary:
+   - zone `tvinfra`
+   - VNet `tvinfra`
+   - subnet `192.168.40.0/24`
+   - gateway `192.168.40.1`
+
+## The Specific Design Mismatch
+
+Current repo behavior:
+
+1. `terraform/lxc/templates/inventory.tpl` emits:
+   - `ansible_ssh_common_args: ... ProxyJump=root@${pve_host}`
+2. `terraform/lxc/main.tf` includes:
+   - `null_resource.prime_sdn_host_route`
+3. `prime_sdn_host_route` mutates host networking by adding:
+   - a host-side bridge IP (`*.254`)
+   - a route for the SDN guest subnet through that bridge
+
+This is a workaround for the current provisioning path, not evidence that the
+network should be designed this way.
+
+## Live pve-test Evidence
+
+Read-only checks against `pve-test` showed:
+
+1. SDN zones and VNets exist for:
+   - `tvinfra`
+   - `tvmgmt`
+   - `tvedge`
+   - `tvsegc`
+2. `apt-cacher-stack` and `harbor-stack` are live on `bridge=tvinfra`
+3. `tvmgmt` has working host-side L3 presence:
+   - interface IP `192.168.20.254/24`
+   - route `192.168.20.0/24 dev tvmgmt src 192.168.20.254`
+4. `tvinfra` exists as a link, but did not show comparable working host-side
+   reachability during inspection
+5. route lookup from `pve-test` to `10.57.3.11` fell back to the default route
+   via `vmbr0`
+6. ping from `pve-test` to `10.57.3.11` failed
+
+Interpretation:
+
+- `pve-test` does not currently demonstrate a clean, router-centric reachability
+  model for SDN-backed guest provisioning
+- it also does not support assuming that host-side route priming is unnecessary
+
+## Current Program Decision
+
+Do not continue production canary apply work yet.
+
+Instead:
+
+1. preserve the productionizing branch state for later reuse
+2. plan and validate a dedicated network/provisioning refactor first
+3. require at least one teardown + redeploy validation cycle on `pve-test`
+   before returning to production canary progression
+
+## What Can Be Reused Later
+
+When this refactor is complete, the preserved productionizing work should still
+be reusable:
+
+1. production env and secret separation
+2. production storage and network manifests
+3. environment-driven stack targeting
+4. production canary candidate selection (`apt-cacher-stack`)
+5. SDN bootstrap logic, if still relevant after the corrected access model is
+   chosen

--- a/docs/network-refactor/handoff.md
+++ b/docs/network-refactor/handoff.md
@@ -16,10 +16,12 @@ Read these in order:
 1. [README.md](/home/steve/git/proxmox-homelab/docs/network-refactor/README.md:1)
 2. [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
 3. [plan.md](/home/steve/git/proxmox-homelab/docs/network-refactor/plan.md:1)
-4. [terraform/lxc/templates/inventory.tpl](/home/steve/git/proxmox-homelab/terraform/lxc/templates/inventory.tpl:1)
-5. [terraform/lxc/main.tf](/home/steve/git/proxmox-homelab/terraform/lxc/main.tf:595)
-6. [terraform/lxc/network/pve-test.yaml](/home/steve/git/proxmox-homelab/terraform/lxc/network/pve-test.yaml:1)
-7. [docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1)
+4. [target-model.md](/home/steve/git/proxmox-homelab/docs/network-refactor/target-model.md:1)
+5. [validation-gate.md](/home/steve/git/proxmox-homelab/docs/network-refactor/validation-gate.md:1)
+6. [terraform/lxc/templates/inventory.tpl](/home/steve/git/proxmox-homelab/terraform/lxc/templates/inventory.tpl:1)
+7. [terraform/lxc/main.tf](/home/steve/git/proxmox-homelab/terraform/lxc/main.tf:595)
+8. [terraform/lxc/network/pve-test.yaml](/home/steve/git/proxmox-homelab/terraform/lxc/network/pve-test.yaml:1)
+9. [docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1)
 
 ## What Is Already Known
 
@@ -33,25 +35,19 @@ Read these in order:
 
 ## What The Next Session Should Do
 
-1. Confirm the intended L3 model:
-   - which networks are routed by the main router
-   - which hosts/admin workstations are supposed to reach which guest subnets
-2. Map the current implementation assumptions:
-   - inventory generation
-   - ProxyJump usage
-   - host-route priming
-   - any manual router/proxmox configuration
-3. Convert the current `plan.md` into a more concrete task breakdown under
-   `docs/network-refactor/`.
-4. Define the teardown validation gate for the refactor.
+1. Start from the session roadmap in `plan.md` rather than re-scoping the
+   architecture from scratch.
+2. Confirm the current session's place in the roadmap and update the docs.
+3. Map the exact code or validation changes for that session only.
+4. Capture evidence and stop points so the next session can continue cleanly.
 
 ## Expected Outputs From The Next Session
 
 At minimum, produce:
 
-1. a clarified target network/provisioning model doc
-2. a concrete implementation plan doc
-3. a teardown validation plan doc
+1. an updated target network/provisioning model doc when new evidence changes it
+2. an updated implementation plan doc with session progress recorded
+3. an updated teardown validation plan doc when validation mechanics change
 4. explicit open questions that still require operator decisions
 
 ## Constraints

--- a/docs/network-refactor/handoff.md
+++ b/docs/network-refactor/handoff.md
@@ -26,7 +26,8 @@ Read these in order:
 ## What Is Already Known
 
 1. The current generated inventory uses `ProxyJump=root@${pve_host}`.
-2. `prime_sdn_host_route` adds host-side IP/route state on the Proxmox host.
+2. `prime_sdn_host_route` was removed in Session 5; host-side route priming
+   is no longer part of the current Terraform apply flow.
 3. Production canary prep for `apt-cacher-stack` worked up to the point where
    the jump-host/routing model became the design concern.
 4. `pve-test` live state is inconsistent:
@@ -37,9 +38,10 @@ Read these in order:
 
 1. Start from the session roadmap in `plan.md` rather than re-scoping the
    architecture from scratch.
-2. Confirm the current session's place in the roadmap and update the docs.
-3. Map the exact code or validation changes for that session only.
-4. Capture evidence and stop points so the next session can continue cleanly.
+2. Run Session 6 preflight and evidence capture, then Session 7 representative
+   stack validation.
+3. Capture inventory, SSH-path, DNS, and health evidence for the direct path.
+4. Record any stack-specific exceptions that still prevent the teardown gate.
 
 ## Expected Outputs From The Next Session
 

--- a/docs/network-refactor/handoff.md
+++ b/docs/network-refactor/handoff.md
@@ -1,0 +1,63 @@
+# Network Refactor Handoff
+
+## Session Goal
+
+Prepare the network/provisioning refactor so future implementation work can
+correct SDN-backed guest reachability without relying on Proxmox as the default
+jump host.
+
+This handoff is for planning and evidence gathering first, not immediate
+implementation.
+
+## Start Here
+
+Read these in order:
+
+1. [README.md](/home/steve/git/proxmox-homelab/docs/network-refactor/README.md:1)
+2. [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+3. [plan.md](/home/steve/git/proxmox-homelab/docs/network-refactor/plan.md:1)
+4. [terraform/lxc/templates/inventory.tpl](/home/steve/git/proxmox-homelab/terraform/lxc/templates/inventory.tpl:1)
+5. [terraform/lxc/main.tf](/home/steve/git/proxmox-homelab/terraform/lxc/main.tf:595)
+6. [terraform/lxc/network/pve-test.yaml](/home/steve/git/proxmox-homelab/terraform/lxc/network/pve-test.yaml:1)
+7. [docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1)
+
+## What Is Already Known
+
+1. The current generated inventory uses `ProxyJump=root@${pve_host}`.
+2. `prime_sdn_host_route` adds host-side IP/route state on the Proxmox host.
+3. Production canary prep for `apt-cacher-stack` worked up to the point where
+   the jump-host/routing model became the design concern.
+4. `pve-test` live state is inconsistent:
+   - `tvmgmt` has host-side reachability
+   - `tvinfra` guests exist, but host-side reachability did not behave the same
+
+## What The Next Session Should Do
+
+1. Confirm the intended L3 model:
+   - which networks are routed by the main router
+   - which hosts/admin workstations are supposed to reach which guest subnets
+2. Map the current implementation assumptions:
+   - inventory generation
+   - ProxyJump usage
+   - host-route priming
+   - any manual router/proxmox configuration
+3. Convert the current `plan.md` into a more concrete task breakdown under
+   `docs/network-refactor/`.
+4. Define the teardown validation gate for the refactor.
+
+## Expected Outputs From The Next Session
+
+At minimum, produce:
+
+1. a clarified target network/provisioning model doc
+2. a concrete implementation plan doc
+3. a teardown validation plan doc
+4. explicit open questions that still require operator decisions
+
+## Constraints
+
+1. Do not resume production canary apply work in this planning session.
+2. Do not merge preserved `refactor/productionize` work into a promotion branch.
+3. Do not normalize `prime_sdn_host_route` as the final design without an
+   explicit architecture decision.
+4. Prefer read-only inspection and documentation updates first.

--- a/docs/network-refactor/implementation-inventory.md
+++ b/docs/network-refactor/implementation-inventory.md
@@ -1,0 +1,244 @@
+# Implementation Inventory: ProxyJump and SDN Provisioning
+
+This document maps exactly where ProxyJump is injected and records that
+`prime_sdn_host_route` was removed in Session 5. The remaining compatibility
+path is explicit `ProxyJump` only.
+
+## ProxyJump Injection: Complete Path
+
+### Where ProxyJump is generated
+
+**File:** [terraform/lxc/templates/inventory.tpl](../../terraform/lxc/templates/inventory.tpl)
+
+```yaml
+%{ if use_proxyjump ~}
+          ansible_ssh_common_args: '-F /dev/null -o ProxyJump=root@${pve_host} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+%{ else ~}
+          ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+%{ endif ~}
+          ssh_access_mode: ${ssh_access_mode}
+```
+
+**Condition:** ProxyJump is added if and only if `use_proxyjump` is true.
+
+### How pve_host reaches the template
+
+**File:** [terraform/lxc/main.tf](../../terraform/lxc/main.tf) line 533
+
+```hcl
+content = templatefile("${local.lxc_root}/templates/inventory.tpl", {
+  ...
+  pve_host            = local.effective_pve_host
+  ssh_access_mode     = local.effective_network_access_path
+  use_proxyjump       = local.use_proxyjump
+})
+```
+
+The template now receives both effective access mode metadata and a dedicated
+ProxyJump gate.
+
+### How effective access mode is computed
+
+**File:** [terraform/lxc/main.tf](../../terraform/lxc/main.tf)
+
+```hcl
+requested_network_access_path = try(local.stack.network.access_path, null)
+normalized_network_access_path = local.requested_network_access_path == null ? null : try(lower(trimspace(local.requested_network_access_path)), null)
+
+effective_network_access_path = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? coalesce(local.normalized_network_access_path, "direct") : coalesce(local.normalized_network_access_path, "proxyjump_compat")
+
+use_proxyjump = local.effective_network_access_path == "proxyjump_compat" && local.effective_pve_host != ""
+```
+
+Rules implemented by these locals:
+
+1. SDN-backed (`sdn_vnet`) stacks default to `direct` when `network.access_path` is absent.
+2. Bridge/default path stacks preserve compatibility behavior by default (`proxyjump_compat`).
+3. Explicit `network.access_path` may override defaults using `direct` or `proxyjump_compat`.
+4. `pve_host` presence alone no longer enables `ProxyJump`.
+
+### How effective_pve_host is computed
+
+**File:** [terraform/lxc/main.tf](../../terraform/lxc/main.tf) line 137
+
+```hcl
+effective_pve_host = local.stack_network_zone != null ?
+                     local.network_intent.proxmox.pve_host :
+                     try(local.stack.proxmox_host, var.proxmox_host)
+```
+
+**Two paths:**
+
+1. **If stack has a network zone** (`stack.yaml` contains `network.zone`):
+   - Use `local.network_intent.proxmox.pve_host` (from the network intent YAML)
+2. **Otherwise (legacy fallback)**:
+   - Use `stack.proxmox_host` if present, else fall back to `var.proxmox_host`
+
+### How pve_host gets its value in network intent
+
+**File:** [terraform/lxc/network/pve-test.yaml](../../terraform/lxc/network/pve-test.yaml) line 55
+
+```yaml
+proxmox:
+  target_node: pve-test
+  pve_host: ${proxmox_host}
+```
+
+The value `${proxmox_host}` is a template variable that gets substituted during main.tf processing.
+
+**Template variable source:** [terraform/lxc/main.tf](../../terraform/lxc/main.tf) lines 26-42
+
+```hcl
+locals {
+  stack_template_vars = {
+    # ... other vars ...
+    proxmox_host = var.proxmox_host
+    # ...
+  }
+  stack = yamldecode(templatefile(var.stack_yaml_path, local.stack_template_vars))
+```
+
+The network intent file is also templated with the same `stack_template_vars`:
+
+```hcl
+network_intent = local.stack_network_zone != null ?
+                 yamldecode(templatefile(local.effective_network_intent_path, local.stack_template_vars)) :
+                 null
+```
+
+**Implication:** `pve_host` in the network intent still resolves from `var.proxmox_host` on `pve-test`,
+but inventory `ProxyJump` behavior now follows `network.access_path`.
+
+## prime_sdn_host_route: Removed in Session 5
+
+`prime_sdn_host_route` no longer exists in `terraform/lxc/main.tf`. Session 5
+removed the host-side `.254` bridge IP and route mutation entirely so SDN-
+backed provisioning no longer depends on Proxmox-side reachability priming.
+
+What remains relevant for provisioning is the explicit inventory access mode:
+
+1. `network.access_path: direct` is the default for `sdn_vnet`
+2. `network.access_path: proxyjump_compat` is the only remaining temporary
+  compatibility path
+3. `pve_host` still feeds the explicit `ProxyJump` path, but no longer implies
+  host-route mutation
+
+## SDN Zone and VNet Automation
+
+### What is already automated
+
+**File:** [terraform/lxc/main.tf](../../terraform/lxc/main.tf) lines 423-496
+
+Automation path:
+1. Calls [terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml](../../terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml)
+2. Runs before LXC container creation (no dependency on container)
+3. Triggered when: `local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet"`
+
+What the playbook creates (lines 1–177 of configure-network-sdn-vnet.yml):
+- **SDN Zone** if missing (e.g., `tvinfra`, `tvmgmt`, `tvedge`, `tvsegc`)
+- **SDN VNet** if missing (e.g., `tvinfra` with VLAN tag 40)
+- **SDN Subnet** with gateway IP and SNAT settings
+- **Apply pending SDN changes** to make them live
+- **Validate proxmox-firewall compilation** to catch syntax errors
+
+### What remains manual
+
+**File:** [terraform/lxc/network/pve-test.yaml](../../terraform/lxc/network/pve-test.yaml) lines 26-52
+
+MikroTik prerequisites (must exist before direct-SSH provisioning is viable):
+- VLAN interfaces for each zone (e.g., `vlan10-build`, `vlan20-mgmt`, etc.)
+- Gateway IPs on each VLAN (for the current `pve-test` environment:
+  `192.168.10.1`, `192.168.20.1`, `192.168.30.1`, `192.168.40.1`)
+- DNS forwarding rules (public DNS resolution + lab.gibbsgreatly.xyz delegation)
+- Firewall ACLs for cross-zone policy (documented in pve-test.yaml policies section)
+
+### Example: How a stack triggers SDN automation
+
+When deploying `apt-cacher-stack` with this stack.yaml:
+
+```yaml
+network:
+  zone: infra_seg
+ansible_playbook: deploy-apt-cacher.yml
+```
+
+1. Network zone is set → `local.stack_network_zone = "infra_seg"`
+2. Network intent attachment `infra_seg` has type `sdn_vnet` → automation path is enabled
+3. Before container creation: configure-network-sdn-vnet.yml runs
+4. Creates zone `tvinfra`, VNet `tvinfra`, subnet `192.168.40.0/24` if missing
+5. Container is created with bridge `tvinfra` and IP `192.168.40.11`
+6. Ansible inventory is generated with either direct SSH or explicit
+  `ProxyJump` compatibility metadata
+
+## Current Generated Inventory Example
+
+For a stack with network zone and pve_host set:
+
+```yaml
+all:
+  children:
+    infra_seg_stack:
+      hosts:
+        infra-container:
+          ansible_host: 192.168.40.11
+          ansible_user: root
+          ansible_ssh_private_key_file: /path/to/key
+          ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+          ssh_access_mode: direct
+          network_zone: infra_seg
+          dns_server: 192.168.40.1
+          vmid: 40011
+          stack_name: infra_seg_stack
+```
+
+For an SDN stack explicitly labeled for temporary fallback:
+
+```yaml
+all:
+  children:
+    infra_seg_stack:
+      hosts:
+        infra-container:
+          ansible_host: 192.168.40.11
+          ansible_user: root
+          ansible_ssh_private_key_file: /path/to/key
+          ansible_ssh_common_args: '-F /dev/null -o ProxyJump=root@pve-test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+          ssh_access_mode: proxyjump_compat
+          network_zone: infra_seg
+          dns_server: 192.168.40.1
+          vmid: 40011
+          pve_host: pve-test
+          stack_name: infra_seg_stack
+```
+
+For a non-zone or legacy bridge stack (no ProxyJump):
+
+```yaml
+all:
+  children:
+    test_stack:
+      hosts:
+        test-container:
+          ansible_host: 192.168.1.100
+          ansible_user: root
+          ansible_ssh_private_key_file: /path/to/key
+          ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+```
+
+## Summary for Session 3+ Planning
+
+| Item | Location | Current State |
+|---|---|---|
+| ProxyJump generation | inventory.tpl | Conditional on `use_proxyjump` (`ssh_access_mode == proxyjump_compat` and `pve_host` set) |
+| Access path resolution | main.tf locals | `sdn_vnet` defaults to `direct`; bridge/default path preserves `proxyjump_compat` |
+| pve_host source | main.tf | From network intent if zone set, else legacy fallback |
+| prime_sdn_host_route | removed in Session 5 | No longer present; host-side route priming is not part of the current model |
+| SDN automation | configure-network-sdn-vnet.yml | Already automated; MikroTik side still manual |
+| Network intent template | pve-test.yaml line 55 | pve_host set via template var substitution |
+
+## How to Reference This Document
+
+- **For removing ProxyJump:** Reference the template path and condition.
+- **For validating the Session 5 removal:** Confirm `terraform/lxc/main.tf` no longer contains a `prime_sdn_host_route` resource and that inventories still choose only between direct SSH and explicit `proxyjump_compat`.
+- **For understanding SDN prerequisites:** See the MikroTik setup section in pve-test.yaml.
+- **For planning direct-SSH path:** Understand that effective_pve_host now only influences the explicit `ProxyJump` compatibility path.

--- a/docs/network-refactor/migration-mechanics.md
+++ b/docs/network-refactor/migration-mechanics.md
@@ -1,0 +1,127 @@
+# Migration Mechanics (Session 3 Decisions)
+
+## Purpose
+
+This document captures the Session 3 design decisions that unblock Session 4
+implementation. It defines one recommended migration path from default
+`ProxyJump` behavior to direct SSH for router-reachable SDN-backed guests.
+
+Scope note:
+
+1. This is a design contract only.
+2. It does not change current Terraform or Ansible behavior by itself.
+
+## Recommended Inventory Contract
+
+For router-reachable SDN-backed stacks, generated inventory should follow this
+contract:
+
+1. `ansible_host` is the guest IP address.
+2. `ansible_user` remains `root` unless stack-specific auth requirements say
+   otherwise.
+3. `ansible_ssh_common_args` for default SDN path does not include `ProxyJump`.
+4. `pve_host` is compatibility metadata only for temporary fallback mode.
+5. Inventory metadata should clearly state effective access mode (`direct` or
+   `proxyjump_compat`) so operators can audit behavior quickly.
+
+## Recommended `pve_host` Migration Logic
+
+### Decision
+
+Use attachment-type defaults with explicit per-stack compatibility override.
+
+### Defaults
+
+1. `sdn_vnet` attachment: default to direct SSH.
+2. `bridge` attachment: preserve existing behavior during migration.
+
+### Explicit compatibility control
+
+Session 4 should introduce one stack-level selector:
+
+```yaml
+network:
+  access_path: direct | proxyjump_compat
+```
+
+Rules:
+
+1. For `sdn_vnet`, default is `direct` when `access_path` is absent.
+2. `ProxyJump` is rendered only when `access_path: proxyjump_compat`.
+3. `pve_host` presence alone is not enough to force ProxyJump for SDN-backed
+   stacks after migration wiring.
+4. For `bridge`, default behavior remains unchanged unless explicitly set to
+   `access_path: direct`.
+
+## Preflight Placement Decision
+
+### Decision
+
+Use a combination model with one validator implementation.
+
+### Placement
+
+1. Standalone validator is the source of truth for router reachability checks.
+2. Validator is required before Terraform apply workflows.
+3. Validator is re-used before Ansible provisioning for stacks marked
+   `access_path: direct`.
+
+### Why this model
+
+1. One validator avoids duplicated check logic.
+2. Pre-apply execution catches global readiness issues early.
+3. Pre-provision execution catches per-stack access-path mismatch right before
+   SSH-dependent work.
+
+## Temporary Fallback Policy (`ProxyJump`)
+
+### When fallback is allowed
+
+1. Only when stack is explicitly labeled `access_path: proxyjump_compat`.
+2. Only when a blocking direct-path issue is documented.
+
+### Required labeling
+
+Each fallback stack must carry migration labeling in adjacent docs or stack
+comments with:
+
+1. reason
+2. owner
+3. review date or remove-by target
+
+### New stack policy
+
+1. New SDN-backed stacks should not start in `proxyjump_compat` by default.
+2. Any exception must include a documented blocker and removal plan.
+
+### Removal criteria per stack
+
+A stack can leave fallback mode only after all are true:
+
+1. router preflight passes for that stack zone
+2. one successful provisioning run with `access_path: direct`
+3. no dependency on `prime_sdn_host_route` in that path
+
+### Global gate condition
+
+Default or unlabeled `ProxyJump` behavior must be removed before the
+`pve-test` refactor validation gate can pass.
+
+## Session 4 Implementation Targets
+
+1. Update Terraform locals to parse and validate `network.access_path`.
+2. Update inventory template logic to gate ProxyJump by effective access mode,
+   not by non-empty `pve_host` alone.
+3. Keep bridge-path compatibility as default during migration.
+4. Surface effective access mode in generated inventory metadata.
+5. Session 5 removed `prime_sdn_host_route`; do not add host-side route
+   priming back into the compatibility path.
+
+## Session 5 Outcome
+
+1. Host-side `.254` route priming is no longer part of the Terraform apply
+   flow.
+2. The only remaining compatibility mechanism in the inventory contract is the
+   explicit `proxyjump_compat` access path.
+3. Any future direct-access failure should be handled by preflight evidence and
+   stack-level labeling, not by reintroducing Proxmox host mutation.

--- a/docs/network-refactor/plan.md
+++ b/docs/network-refactor/plan.md
@@ -54,19 +54,26 @@ proves otherwise:
 5. SDN VLAN definitions remain environment data in
    `terraform/lxc/network/<env>.yaml`, with router prerequisites still handled
    out of band for now.
+6. The operator workstation on LAN `192.168.1.0/24` is the canonical Ansible
+   automation origin. Proxmox is not. A dedicated bastion is deferred to a
+   future phase and is outside this refactor's scope.
+7. `ProxyJump` through Proxmox is the accepted temporary escape hatch during
+   migration. It must be explicitly labeled in any stack that still uses it and
+   must be removed before the teardown validation gate passes.
+8. Portainer is on `mgmt_seg` (confirmed in
+   `terraform/lxc/stacks/portainer-stack/stack.yaml`). The `vmbr0` (`lan`)
+   attachment in `pve-test.yaml` is retained for legacy test stacks only and
+   is not an active exception in the platform model.
 
 ## Remaining Decisions
 
-The plan should explicitly force answers to these before any risky code removal:
+These must be answered before any risky code removal (Session 3+):
 
-1. Is the operator workstation the canonical automation origin for Ansible, or
-   should there be a separate bastion later?
-2. Which exact router prerequisites must exist before a stack apply is allowed
-   to proceed?
-3. Do any bootstrap exceptions remain, or can every active stack move to the
-   same direct-SSH contract?
-4. What temporary escape hatch, if any, is acceptable if one stack still needs
-   `ProxyJump` during the migration?
+1. Which exact router prerequisites must exist before a stack apply is allowed
+   to proceed, and where should the preflight check live?
+2. Should `ansible_ssh_common_args` become conditional (on attachment type,
+   environment flag, or explicit opt-in) or be removed from the template
+   entirely once direct-SSH is the default?
 
 ## Workstreams
 
@@ -137,6 +144,9 @@ Done when:
 1. No future session needs to debate whether Proxmox is allowed to be the L3
    gateway.
 2. The target access path is written down in one place.
+3. Current temporary exceptions (`ProxyJump` and `prime_sdn_host_route`) are
+   explicitly named with retirement conditions in `target-model.md`.
+4. Non-goals are explicitly stated so future sessions do not re-open them.
 
 ### Session 2 - Capture current implementation and evidence
 
@@ -172,16 +182,90 @@ Goal:
 Tasks:
 
 1. Define the desired inventory contract for router-reachable guests.
-2. Decide whether `ansible_ssh_common_args` becomes conditional on attachment
-   type, environment intent, or an explicit compatibility flag.
+2. Decide the logic for when to set `pve_host` (which gates ProxyJump generation):
+    - Decide the default behavior for `sdn_vnet` attachments.
+    - Decide how compatibility fallback is explicitly requested.
+    - Decide how legacy bridge-path stacks behave during migration.
 3. Decide where router reachability preflights should run:
    before inventory generation, before Ansible, or in a dedicated validator.
-4. Decide what temporary fallback is allowed during migration.
+4. Decide what temporary fallback is allowed during migration (if any).
 
 Outputs:
 
-1. An implementation checklist in this doc.
-2. Any new feature flags or manifest fields documented before code changes.
+1. A concrete inventory contract for SDN-backed stacks.
+2. A concrete `pve_host` migration rule and compatibility mechanism.
+3. A concrete preflight placement model.
+4. A concrete temporary fallback policy.
+5. Any new feature flags or manifest fields documented before code changes.
+
+Session 3 decision outcomes (2026-05-22):
+
+1. Desired inventory contract for router-reachable SDN-backed guests:
+    - `ansible_host` remains the guest IP rendered from Terraform state.
+    - Direct SSH is the default for `sdn_vnet` attachments.
+    - `ansible_ssh_common_args` for the default path includes only strict host
+       key bypass options already used in this repo; it does not include
+       `ProxyJump`.
+    - `pve_host` is no longer the default transport selector for SDN-backed
+       guests; it is treated as compatibility-only metadata when explicitly
+       requested.
+
+2. Preferred migration approach for `pve_host`:
+    - Use a hybrid control model: attachment-type default plus explicit
+       compatibility override.
+    - Attachment-type default:
+       - `sdn_vnet` => direct SSH default (no `ProxyJump`).
+       - `bridge` => preserve existing behavior during migration to avoid
+          surprise regressions in legacy/test stacks.
+    - Explicit compatibility override:
+       - Add a stack-level migration flag in `stack.yaml` for Session 4
+          implementation: `network.access_path` with allowed values:
+          - `direct` (default for `sdn_vnet`)
+          - `proxyjump_compat` (temporary fallback)
+       - Template/locals logic should generate `ProxyJump` only when
+          `network.access_path == "proxyjump_compat"`.
+    - Legacy bridge-path stacks:
+       - Continue with current behavior unless explicitly opted into
+          `network.access_path: direct`.
+       - They remain out of the SDN direct-SSH success criteria until migrated.
+
+3. Preflight placement decision:
+    - Use a combination model with one source of truth.
+    - Source of truth: a standalone validator command that checks router
+       reachability and DNS path assumptions from the workstation.
+    - Required invocation point: before Terraform apply (including teardown/
+       redeploy workflows).
+    - Secondary invocation point: before Ansible provisioning for stacks marked
+       `network.access_path: direct` (enforced by Session 4/6 wiring).
+    - Rationale: one validator avoids duplicated logic and drift, while two
+       invocation points catch both upfront readiness and per-stack access-path
+       mismatches.
+
+4. Temporary fallback policy (`ProxyJump` during migration):
+    - Allowed only when a stack is explicitly labeled
+       `network.access_path: proxyjump_compat`.
+    - Any fallback stack must include a migration annotation in `stack.yaml`
+       comment or adjacent docs with:
+       - reason for fallback
+       - owner
+       - review date/remove-by target
+    - `ProxyJump` fallback is disallowed for new SDN-backed stacks unless a
+       blocking preflight finding is documented.
+    - Removal readiness criteria for each fallback stack:
+       - router preflight passes for the stack zone
+       - one successful provisioning run using `network.access_path: direct`
+       - no dependency on `prime_sdn_host_route` for that stack path
+    - Global retirement condition remains unchanged: default `ProxyJump` must be
+       gone before the validation gate can pass.
+
+5. Session 4 implementation checklist (derived from these decisions):
+    - Add `network.access_path` parsing and validation in Terraform locals.
+    - Make inventory rendering use explicit `access_path` instead of
+       `pve_host != ""` as the ProxyJump gate.
+    - Keep existing bridge behavior unless explicitly overridden.
+    - Emit clear inventory metadata so operators can see whether a stack is in
+       `direct` or `proxyjump_compat` mode.
+    - Document migration labeling requirements in stack docs.
 
 Done when:
 
@@ -241,6 +325,15 @@ Validation:
 1. Run a representative stack plan/apply in a safe scope.
 2. Prove guest provisioning succeeds without adding a Proxmox-side route.
 
+Session 5 implementation note (2026-05-22):
+
+1. `null_resource.prime_sdn_host_route` has been removed from
+   `terraform/lxc/main.tf`.
+2. The remaining compatibility path is explicit `network.access_path:
+   proxyjump_compat`; there is no host-route fallback.
+3. The next live validation work is Session 6 preflight/evidence capture,
+   followed by Session 7 representative stack validation.
+
 Stop if:
 
 1. Any stack still depends on host-side reachability that the router path does
@@ -262,6 +355,24 @@ Tasks:
 2. Decide whether these checks belong in Terraform-adjacent scripts, session
    docs, or both.
 3. Add evidence capture guidance for future sessions.
+
+Session 6 implementation note (2026-05-22):
+
+1. `scripts/preflight-network-refactor.sh` added as a standalone preflight
+   validator. Invoke with `./with-secrets scripts/preflight-network-refactor.sh`.
+2. Checks implemented:
+   - Check 1: targeting guard (`TF_VAR_proxmox_node == pve-test`)
+   - Check 2: ICMP ping to all four SDN gateways (`192.168.10.1` –
+     `192.168.40.1`)
+   - Check 3: DNS via MikroTik gateway (`192.168.20.1`) for delegated internal
+     name
+     and public name
+   - Check 4: TCP:22 probe to at least one representative guest IP
+3. Evidence capture: `--save-evidence <dir>` writes a timestamped evidence file.
+4. `validation-gate.md` updated with a "Preflight Script" section that
+   documents standard, explicit-IP, and evidence-capture invocations.
+5. Check 4 is warn-only when no stacks are deployed and the default candidate
+   list is used; it becomes a hard check when explicit IPs are passed.
 
 Done when:
 
@@ -289,6 +400,18 @@ Stop if:
 
 1. Any representative stack requires reintroducing `ProxyJump` or host-route
    priming to succeed.
+
+Session 7 implementation note (2026-05-22):
+
+1. Session blocked at precondition stage from the current operator context.
+2. `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11`
+   exited 1
+   with failed gateway reachability, DNS via MikroTik gateway, and
+   representative guest TCP:22 checks.
+3. No representative stack re-apply/provision run was executed after preflight
+   failure.
+4. See `docs/network-refactor/session-7-summary.md` for captured evidence and
+   restart checklist.
 
 ### Session 8 - Execute teardown and redeploy gate
 
@@ -331,7 +454,7 @@ Use this as the quick tracker across sessions:
 2. Current implementation inventory captured with file references.
 3. Direct-SSH inventory contract designed.
 4. Inventory generation updated.
-5. `prime_sdn_host_route` removed or explicitly quarantined.
+5. `prime_sdn_host_route` removed.
 6. Preflight checks documented or automated.
 7. Representative live stacks validated.
 8. One teardown/redeploy cycle completed on `pve-test`.

--- a/docs/network-refactor/plan.md
+++ b/docs/network-refactor/plan.md
@@ -1,0 +1,125 @@
+# Network Refactor Plan
+
+## Problem Statement
+
+The preserved productionizing checkpoint uncovered a provisioning assumption
+that does not match the intended platform design:
+
+1. `terraform/lxc/templates/inventory.tpl` emits `ProxyJump=root@${pve_host}`
+   for stack provisioning.
+2. SDN-backed guests therefore depend on the Proxmox host having direct
+   host-side reachability into guest subnets.
+3. `terraform/lxc/main.tf` compensates with `null_resource.prime_sdn_host_route`
+   to add a host bridge IP and route dynamically.
+4. The intended network model is that inter-VLAN/subnet routing belongs to the
+   main router, not to Proxmox acting as the default jump host or gateway.
+
+## Preserved Evidence
+
+The previous branch established:
+
+1. production env, storage, and network manifests can be modeled cleanly
+2. `apt-cacher-stack` on `pve` can render and partially bootstrap
+3. production SDN object creation for `tvinfra` is now possible
+4. `pve-test` live inspection shows inconsistent host-side SDN reachability:
+   - `tvmgmt` has a host-side IP/route
+   - `tvinfra` guests exist but the host does not currently route to them in
+     the expected way
+
+Reference:
+
+- [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+
+## Refactor Goals
+
+1. Make the intended routed network model explicit for `pve-test` and `pve`.
+2. Decide the correct provisioning access model for SDN-backed guests.
+3. Remove accidental dependence on Proxmox as a general-purpose jump host if
+   that is not the intended design.
+4. Prove the corrected model with teardown/redeploy validation before resuming
+   production canary work.
+
+## Key Questions
+
+1. Which systems are meant to have L3 reachability into:
+   - `build_seg`
+   - `mgmt_seg`
+   - `edge_seg`
+   - `infra_seg`
+2. Is the operator workstation expected to reach these subnets directly via the
+   main router?
+3. If not direct, what is the intentional administrative access path?
+4. Are Proxmox hosts expected to have subnet-local bridge IPs for any of these
+   SDN networks, and if so, which ones and why?
+5. Should Terraform/Ansible provisioning connect:
+   - directly to guest IPs
+   - through a router-accessible path
+   - through a bastion that is not the Proxmox host
+
+## Workstreams
+
+### 1. Design Clarification
+
+Document the intended L2/L3 model for:
+
+1. router VLAN interfaces and gateways
+2. Proxmox bridge/VNet responsibilities
+3. host management reachability
+4. operator/admin workstation reachability
+5. provisioning access path for stack automation
+
+### 2. Implementation Inventory
+
+Map the current live and repo behavior:
+
+1. generated Ansible inventory and `ProxyJump` usage
+2. `prime_sdn_host_route` behavior
+3. current SDN zone/VNet creation path
+4. live `pve-test` routing/interface state
+5. any manual router/proxmox configuration that the repo currently assumes
+
+### 3. Refactor Plan
+
+Define the exact code/doc changes needed, likely including:
+
+1. inventory generation changes
+2. Terraform/Ansible provisioning path changes
+3. SDN host-route logic removal or narrowing
+4. any required router-side documentation or automation
+5. validation updates for both `pve-test` and future `pve`
+
+### 4. Validation Plan
+
+This refactor must include at least one teardown/redeploy validation cycle on
+`pve-test`.
+
+Minimum validation should cover:
+
+1. SDN zone/VNet creation and guest attachment
+2. provisioning reachability to SDN-backed guests without unintended
+   Proxmox-host routing hacks
+3. representative stack deploys after teardown:
+   - `apt-cacher-stack`
+   - one `mgmt_seg` stack
+   - one additional SDN-backed stack if needed
+
+## Initial Deliverables
+
+1. This planning directory.
+2. A clarified branch/workflow model in `AGENTS.md`.
+3. Detailed task docs to be added next:
+   - scope and assumptions
+   - target network model
+   - implementation plan
+   - teardown validation gate
+4. A session-ready handoff:
+   - [handoff.md](/home/steve/git/proxmox-homelab/docs/network-refactor/handoff.md:1)
+
+## Non-Goals
+
+For the initial planning phase, do not:
+
+1. resume production canary apply work
+2. merge preserved `refactor/productionize` work into a promotion branch
+3. normalize `prime_sdn_host_route` as the accepted final design without a
+   deliberate architecture decision

--- a/docs/network-refactor/plan.md
+++ b/docs/network-refactor/plan.md
@@ -1,5 +1,30 @@
 # Network Refactor Plan
 
+## Executive Summary
+
+This refactor is no longer an architecture-discovery exercise. The intended
+target model is already stated in
+[docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1):
+the MikroTik is the L3 gateway for every SDN VLAN zone, and Proxmox is a pure
+L2 attachment point.
+
+The implementation problem is that the provisioning path still assumes a
+different model:
+
+1. `terraform/lxc/templates/inventory.tpl` emits `ProxyJump=root@${pve_host}`.
+2. `terraform/lxc/main.tf` includes `null_resource.prime_sdn_host_route`.
+3. SDN-backed stack automation therefore succeeds by mutating Proxmox host
+   routing instead of proving workstation-to-router-to-guest reachability.
+
+The work now is to replace that provisioning assumption with a validated,
+router-centric access path, then retire the compatibility shim safely.
+
+Reference checkpoints:
+
+- [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+- [target-model.md](/home/steve/git/proxmox-homelab/docs/network-refactor/target-model.md:1)
+- [validation-gate.md](/home/steve/git/proxmox-homelab/docs/network-refactor/validation-gate.md:1)
+
 ## Problem Statement
 
 The preserved productionizing checkpoint uncovered a provisioning assumption
@@ -14,112 +39,309 @@ that does not match the intended platform design:
 4. The intended network model is that inter-VLAN/subnet routing belongs to the
    main router, not to Proxmox acting as the default jump host or gateway.
 
-## Preserved Evidence
+## What Is Already Settled
 
-The previous branch established:
+These points should be treated as the working contract unless live validation
+proves otherwise:
 
-1. production env, storage, and network manifests can be modeled cleanly
-2. `apt-cacher-stack` on `pve` can render and partially bootstrap
-3. production SDN object creation for `tvinfra` is now possible
-4. `pve-test` live inspection shows inconsistent host-side SDN reachability:
-   - `tvmgmt` has a host-side IP/route
-   - `tvinfra` guests exist but the host does not currently route to them in
-     the expected way
+1. Router-centric L3 is the target design, not a proposal.
+2. Workstation and approved admin clients should reach SDN guest IPs through
+   the MikroTik without Proxmox host route injection.
+3. Proxmox should not carry `.254` interface addresses on SDN VNets as the
+   normal provisioning path.
+4. `prime_sdn_host_route` is a compatibility workaround to remove, not a design
+   pattern to extend.
+5. SDN VLAN definitions remain environment data in
+   `terraform/lxc/network/<env>.yaml`, with router prerequisites still handled
+   out of band for now.
 
-Reference:
+## Remaining Decisions
 
-- [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+The plan should explicitly force answers to these before any risky code removal:
 
-## Refactor Goals
-
-1. Make the intended routed network model explicit for `pve-test` and `pve`.
-2. Decide the correct provisioning access model for SDN-backed guests.
-3. Remove accidental dependence on Proxmox as a general-purpose jump host if
-   that is not the intended design.
-4. Prove the corrected model with teardown/redeploy validation before resuming
-   production canary work.
-
-## Key Questions
-
-1. Which systems are meant to have L3 reachability into:
-   - `build_seg`
-   - `mgmt_seg`
-   - `edge_seg`
-   - `infra_seg`
-2. Is the operator workstation expected to reach these subnets directly via the
-   main router?
-3. If not direct, what is the intentional administrative access path?
-4. Are Proxmox hosts expected to have subnet-local bridge IPs for any of these
-   SDN networks, and if so, which ones and why?
-5. Should Terraform/Ansible provisioning connect:
-   - directly to guest IPs
-   - through a router-accessible path
-   - through a bastion that is not the Proxmox host
+1. Is the operator workstation the canonical automation origin for Ansible, or
+   should there be a separate bastion later?
+2. Which exact router prerequisites must exist before a stack apply is allowed
+   to proceed?
+3. Do any bootstrap exceptions remain, or can every active stack move to the
+   same direct-SSH contract?
+4. What temporary escape hatch, if any, is acceptable if one stack still needs
+   `ProxyJump` during the migration?
 
 ## Workstreams
 
-### 1. Design Clarification
+### 1. Confirm the access contract
 
-Document the intended L2/L3 model for:
+Document and prove:
 
-1. router VLAN interfaces and gateways
-2. Proxmox bridge/VNet responsibilities
-3. host management reachability
-4. operator/admin workstation reachability
-5. provisioning access path for stack automation
+1. workstation to MikroTik to guest L3 reachability
+2. router-owned gateway IPs for all SDN subnets
+3. DNS entry path through MikroTik for each zone
+4. the allowed admin source networks for SSH/HTTP validation
 
-### 2. Implementation Inventory
+### 2. Inventory the current implementation
 
-Map the current live and repo behavior:
+Capture the current repo behavior in the refactor docs:
 
-1. generated Ansible inventory and `ProxyJump` usage
-2. `prime_sdn_host_route` behavior
-3. current SDN zone/VNet creation path
-4. live `pve-test` routing/interface state
-5. any manual router/proxmox configuration that the repo currently assumes
+1. generated inventory and `ProxyJump` usage
+2. `prime_sdn_host_route` lifecycle and triggers
+3. current SDN attachment automation capabilities
+4. remaining manual MikroTik prerequisites
+5. current validation scripts and where they assume Proxmox-host reachability
 
-### 3. Refactor Plan
+### 3. Migrate the provisioning path
 
-Define the exact code/doc changes needed, likely including:
+Make the code follow the access contract:
 
-1. inventory generation changes
-2. Terraform/Ansible provisioning path changes
-3. SDN host-route logic removal or narrowing
-4. any required router-side documentation or automation
-5. validation updates for both `pve-test` and future `pve`
+1. introduce a direct-SSH inventory mode for router-reachable guests
+2. narrow or remove `prime_sdn_host_route`
+3. add preflight checks that fail fast when router reachability is missing
+4. update stack validation flows to prove direct access instead of host mutation
 
-### 4. Validation Plan
+### 4. Validate teardown and redeploy
 
-This refactor must include at least one teardown/redeploy validation cycle on
-`pve-test`.
+Require at least one full `pve-test` rebuild pass that proves:
 
-Minimum validation should cover:
+1. router prerequisites were applied first
+2. SDN zone/VNet attachment creation still works
+3. representative stacks provision without Proxmox route priming
+4. guest DNS and service health match the intended design
 
-1. SDN zone/VNet creation and guest attachment
-2. provisioning reachability to SDN-backed guests without unintended
-   Proxmox-host routing hacks
-3. representative stack deploys after teardown:
-   - `apt-cacher-stack`
-   - one `mgmt_seg` stack
-   - one additional SDN-backed stack if needed
+## Copilot Session Roadmap
 
-## Initial Deliverables
+Each session below should end with a small, reviewable commit or a documented
+stop point. Do not combine removal of `ProxyJump` and teardown validation into
+the same first pass.
 
-1. This planning directory.
-2. A clarified branch/workflow model in `AGENTS.md`.
-3. Detailed task docs to be added next:
-   - scope and assumptions
-   - target network model
-   - implementation plan
-   - teardown validation gate
-4. A session-ready handoff:
-   - [handoff.md](/home/steve/git/proxmox-homelab/docs/network-refactor/handoff.md:1)
+### Session 1 - Baseline the contract
+
+Goal:
+
+1. Freeze the intended model and eliminate planning ambiguity.
+
+Inputs:
+
+1. [docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1)
+2. [docs/reference/sdn-segment-routing.md](/home/steve/git/proxmox-homelab/docs/reference/sdn-segment-routing.md:1)
+3. [checkpoint.md](/home/steve/git/proxmox-homelab/docs/network-refactor/checkpoint.md:1)
+
+Tasks:
+
+1. Produce or refresh `target-model.md`.
+2. Record which source systems are expected to reach each SDN subnet.
+3. Record the router prerequisites that remain manual.
+4. Record explicit non-goals for the migration.
+
+Done when:
+
+1. No future session needs to debate whether Proxmox is allowed to be the L3
+   gateway.
+2. The target access path is written down in one place.
+
+### Session 2 - Capture current implementation and evidence
+
+Goal:
+
+1. Replace assumptions with repo-anchored evidence.
+
+Primary files:
+
+1. [terraform/lxc/templates/inventory.tpl](/home/steve/git/proxmox-homelab/terraform/lxc/templates/inventory.tpl:1)
+2. [terraform/lxc/main.tf](/home/steve/git/proxmox-homelab/terraform/lxc/main.tf:517)
+3. [terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml](/home/steve/git/proxmox-homelab/terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml:1)
+4. [terraform/lxc/network/pve-test.yaml](/home/steve/git/proxmox-homelab/terraform/lxc/network/pve-test.yaml:1)
+
+Tasks:
+
+1. Document exactly where `ProxyJump` is injected.
+2. Document exactly when `prime_sdn_host_route` runs.
+3. Verify whether SDN VLAN attachment creation is already automated.
+4. Write down any stale docs uncovered during that comparison.
+
+Done when:
+
+1. The refactor plan has explicit file targets for every intended code change.
+2. Historical notes are separated from current blockers.
+
+### Session 3 - Design the migration mechanics
+
+Goal:
+
+1. Decide how the code will switch from jump-host SSH to direct SSH.
+
+Tasks:
+
+1. Define the desired inventory contract for router-reachable guests.
+2. Decide whether `ansible_ssh_common_args` becomes conditional on attachment
+   type, environment intent, or an explicit compatibility flag.
+3. Decide where router reachability preflights should run:
+   before inventory generation, before Ansible, or in a dedicated validator.
+4. Decide what temporary fallback is allowed during migration.
+
+Outputs:
+
+1. An implementation checklist in this doc.
+2. Any new feature flags or manifest fields documented before code changes.
+
+Done when:
+
+1. The next session can edit Terraform and templates without re-opening design
+   questions.
+
+### Session 4 - Update inventory generation
+
+Goal:
+
+1. Make inventories support direct SSH for SDN-backed guests.
+
+Primary edits:
+
+1. `terraform/lxc/templates/inventory.tpl`
+2. `terraform/lxc/main.tf`
+3. Any stack metadata or locals needed to drive the new behavior
+
+Tasks:
+
+1. Remove unconditional `ProxyJump` generation for the router-centric path.
+2. Preserve a narrowly scoped compatibility mode only if still needed.
+3. Regenerate one or more sample inventories and inspect them.
+4. Update docs that describe the generated inventory contract.
+
+Validation:
+
+1. Confirm generated inventory for an SDN-backed stack no longer requires
+   `ProxyJump` by default.
+2. Confirm non-SDN or explicitly exempted cases still render correctly.
+
+Stop if:
+
+1. Direct SSH is not yet possible from the workstation to a live guest.
+
+### Session 5 - Retire host-route priming
+
+Goal:
+
+1. Remove or sharply constrain Proxmox host route mutation.
+
+Primary edits:
+
+1. `terraform/lxc/main.tf`
+2. Any docs or validators that still assume `.254` bridge IPs on Proxmox
+
+Tasks:
+
+1. Remove `null_resource.prime_sdn_host_route`, or gate it behind an explicit
+   temporary compatibility toggle with a removal deadline.
+2. Update any dependent comments and assumptions.
+3. Confirm Terraform no longer relies on mutating host interfaces for SDN guest
+   provisioning.
+
+Validation:
+
+1. Run a representative stack plan/apply in a safe scope.
+2. Prove guest provisioning succeeds without adding a Proxmox-side route.
+
+Stop if:
+
+1. Any stack still depends on host-side reachability that the router path does
+   not yet provide.
+
+### Session 6 - Add preflight and evidence capture
+
+Goal:
+
+1. Fail fast on bad network prerequisites instead of discovering them mid-apply.
+
+Tasks:
+
+1. Add a validation script or documented command set that checks:
+   - `./with-secrets bash -c 'echo $TF_VAR_proxmox_node'` returns `pve-test`
+   - the workstation can reach the expected guest subnet gateways
+   - DNS answers from the zone gateway path
+   - direct SSH or TCP reachability to at least one representative guest IP
+2. Decide whether these checks belong in Terraform-adjacent scripts, session
+   docs, or both.
+3. Add evidence capture guidance for future sessions.
+
+Done when:
+
+1. A future operator can prove the router path is ready before running apply.
+
+### Session 7 - Run representative stack validation
+
+Goal:
+
+1. Prove the migration on live `pve-test` workloads before a full rebuild.
+
+Suggested order:
+
+1. `apt-cacher-stack`
+2. one `mgmt_seg` stack such as `dns-stack` or `step-ca-stack`
+3. one additional SDN-backed stack if needed
+
+Tasks:
+
+1. Re-apply or redeploy selected stacks with the new access model.
+2. Capture SSH, DNS, and service-health evidence.
+3. Record any stack-specific exceptions that still block the full cycle.
+
+Stop if:
+
+1. Any representative stack requires reintroducing `ProxyJump` or host-route
+   priming to succeed.
+
+### Session 8 - Execute teardown and redeploy gate
+
+Goal:
+
+1. Prove the design survives a fresh environment lifecycle.
+
+Workflow:
+
+1. Follow [validation-gate.md](/home/steve/git/proxmox-homelab/docs/network-refactor/validation-gate.md:1).
+2. Run the teardown/redeploy cycle on `pve-test`.
+3. Re-validate representative stacks and DNS.
+4. Record results, regressions, and any manual router actions taken.
+
+Success criteria:
+
+1. SDN-backed stacks provision from the intended access path.
+2. No Proxmox host route priming is required.
+3. Evidence is sufficient to resume production canary preparation later.
+
+### Session 9 - Clean up and promote
+
+Goal:
+
+1. Finish documentation and branch hygiene after the refactor is proven.
+
+Tasks:
+
+1. Remove stale migration notes and temporary flags.
+2. Update `handoff.md` with what remains for production canary work.
+3. Run required scanners for changed file types before merge.
+4. Promote according to `AGENTS.md` branch rules only after validation is
+   complete.
+
+## Implementation Checklist
+
+Use this as the quick tracker across sessions:
+
+1. Target model doc written and agreed.
+2. Current implementation inventory captured with file references.
+3. Direct-SSH inventory contract designed.
+4. Inventory generation updated.
+5. `prime_sdn_host_route` removed or explicitly quarantined.
+6. Preflight checks documented or automated.
+7. Representative live stacks validated.
+8. One teardown/redeploy cycle completed on `pve-test`.
+9. Required scans run before merge.
 
 ## Non-Goals
 
-For the initial planning phase, do not:
+Until the refactor validates cleanly, do not:
 
 1. resume production canary apply work
 2. merge preserved `refactor/productionize` work into a promotion branch
-3. normalize `prime_sdn_host_route` as the accepted final design without a
-   deliberate architecture decision
+3. normalize `prime_sdn_host_route` as the accepted final design
+4. treat manual MikroTik prerequisites as solved IaC work

--- a/docs/network-refactor/session-2-summary.md
+++ b/docs/network-refactor/session-2-summary.md
@@ -1,0 +1,160 @@
+# Session 2 Summary: Implementation Inventory Complete
+
+## Work Completed
+
+✅ **1. ProxyJump Injection Path Documented**
+
+ProxyJump is injected via conditional logic in the Ansible inventory template:
+
+- **Template file:** `terraform/lxc/templates/inventory.tpl` (lines 8–12)
+- **Condition:** Adds `ProxyJump=root@<pve_host>` only if `pve_host` template variable is not empty
+- **Variable source:** `local.effective_pve_host` (main.tf line 137)
+- **Resolution:**
+  - If stack has `network.zone` → use network intent's `proxmox.pve_host`
+  - Otherwise → legacy fallback: `stack.proxmox_host` or `var.proxmox_host`
+- **Network intent value:** `pve-test.yaml` line 55 sets `pve_host: ${proxmox_host}` (template-substituted)
+
+**How to disable ProxyJump:** Empty `pve_host` at inventory generation time (either in network intent or via `-var proxmox_host=""`).
+
+✅ **2. prime_sdn_host_route Trigger Conditions Documented**
+
+The resource runs only when ALL four conditions are met:
+
+- **Location:** `terraform/lxc/main.tf` lines 593–614
+- **Count condition (line 594):**
+  ```
+  count = local.stack_network_zone != null &&
+          local.resolved_attachment_type == "sdn_vnet" &&
+          try(local.stack.ansible_playbook, "") != "" &&
+          local.effective_pve_host != "" ? 1 : 0
+  ```
+
+**Breakdown:**
+1. Stack has `network.zone` defined in stack.yaml
+2. Network intent attachment type is `sdn_vnet` (not `bridge`)
+3. Stack has `ansible_playbook` defined (non-empty)
+4. `pve_host` is not empty
+
+**What it does:** After LXC creation, SSH to Proxmox host and:
+- Add `.254` bridge IP to SDN VNet bridge (for example `192.168.40.254/24`
+  in the current `pve-test` addressing model)
+- Add host route for the subnet through that bridge
+- Verify with `ip route get <guest_ip>`
+
+**How to disable without removal:** Omit any of the four conditions above.
+
+✅ **3. SDN VLAN Attachment Automation Verified**
+
+**Status:** ✅ Already fully automated for pve-test
+
+- **Playbook:** `terraform/lxc/ansible/playbooks/configure-network-sdn-vnet.yml`
+- **Trigger:** Runs when `stack_network_zone != null && attachment_type == "sdn_vnet"`
+- **Timing:** Before LXC container is created (independent resource)
+- **Creates:** SDN zone, VNet, subnet with gateway IP and SNAT settings
+
+**Remains manual (MikroTik side):**
+- VLAN interfaces for each zone
+- Gateway IPs on each VLAN
+- DNS forwarding rules
+- Firewall ACLs for cross-zone policy
+
+Documentation is in `terraform/lxc/network/pve-test.yaml` lines 26–52.
+
+✅ **4. Stale Assumptions Corrected**
+
+**Found and updated:**
+
+1. **docs/network-refactor/plan.md Session 3:**
+   - Changed task 2 from "decide whether...becomes conditional" to more precise "decide the logic for when to set pve_host"
+   - Now lists four concrete options: always empty, conditional on type, conditional on env, or explicit per-stack flag
+
+2. **docs/network-refactor/target-model.md Temporary Exceptions:**
+   - Added detailed control mechanisms for both ProxyJump and prime_sdn_host_route
+   - Clarified that pve_host controls ProxyJump generation via network intent
+   - Listed all four ways to disable prime_sdn_host_route without code removal
+
+**Verified as accurate (no changes needed):**
+
+- Non-goals section correctly identifies that `.254` addresses are temporary
+- Target model correctly states Proxmox should not be permanent L3 gateway
+- Network design doc accurately describes zone-based architecture
+
+✅ **5. New Documentation Created**
+
+**File:** `docs/network-refactor/implementation-inventory.md`
+
+This focused document provides:
+- File-anchored paths for every injection point and trigger
+- Complete call chain from template variable to inventory output
+- Current generated inventory examples
+- Summary table for Session 3+ planning
+- Quick reference section for disabling each component
+
+## Summary of Current Implementation State
+
+| Component | Where | Trigger | Status |
+|---|---|---|---|
+| **ProxyJump generation** | inventory.tpl lines 8–12 | `pve_host != ""` | ✅ Working conditionally |
+| **pve_host value** | main.tf line 137 | Zone set → network intent; else → legacy | ✅ Dual path working |
+| **prime_sdn_host_route** | main.tf lines 593–614 | Four conditions (zone + vnet + playbook + host) | ✅ Working conditionally |
+| **SDN automation** | configure-network-sdn-vnet.yml | Zone + sdn_vnet attachment | ✅ Already automated |
+| **MikroTik side** | pve-test.yaml lines 26–52 | Manual | 🔄 Documented, out of band |
+
+## Key Insights for Session 3
+
+1. **pve_host is the control knob:** Setting it empty disables both ProxyJump AND prime_sdn_host_route simultaneously.
+
+2. **Four ways to disable prime_sdn_host_route without removal:**
+   - Omit `network.zone` → falls back to legacy bridge path
+   - Change attachment type to `bridge` → skips SDN automation
+   - Remove `ansible_playbook` → stops host route priming
+   - Empty `pve_host` → both ProxyJump and host priming disabled
+
+3. **SDN zone/VNet creation is already automated:** No work needed here; focus on inventory generation and host route removal.
+
+4. **Network intent template substitution is important:** The network intent file gets `${proxmox_host}` replaced with `var.proxmox_host` during evaluation, so the value flows: variable → intent → effective_pve_host → inventory.
+
+5. **Session 3 decision is narrower than stated:** Not "whether to make conditional" but "which condition controls it"—the mechanism is already there.
+
+## Recommendation: Can Session 3 Begin?
+
+### ✅ YES, Session 3 can begin immediately
+
+**Prerequisites met:**
+1. Implementation is fully mapped with file references
+2. All trigger conditions are documented
+3. Control mechanisms (how to disable without removal) are clear
+4. No code changes are needed before Session 3 design work begins
+5. Stale assumptions have been corrected
+
+**What Session 3 should do:**
+1. Decide: Should pve_host default to empty for new SDN zones (direct SSH only)?
+2. If yes, update network intent loading to distinguish new stacks from legacy bridge stacks
+3. Define the inventory contract for direct-SSH (no ProxyJump, no .254 bridges expected)
+4. Plan preflight checks to validate router reachability before apply
+5. Decide: Remove prime_sdn_host_route immediately or gate it behind a temporary flag?
+
+**What Session 3 should NOT do yet:**
+- Do not modify inventory.tpl or main.tf until design is final
+- Do not remove prime_sdn_host_route
+- Do not remove ProxyJump from any stacks
+- Do not run teardown
+
+## Updated Files
+
+1. [docs/network-refactor/implementation-inventory.md](../../docs/network-refactor/implementation-inventory.md) — NEW: File-anchored implementation reference
+2. [docs/network-refactor/plan.md](../../docs/network-refactor/plan.md) — UPDATED: Session 3 task clarification
+3. [docs/network-refactor/target-model.md](../../docs/network-refactor/target-model.md) — UPDATED: Temporary Exceptions with control mechanisms
+
+## Session Outputs
+
+1. ✅ ProxyJump injection path fully documented with file references
+2. ✅ prime_sdn_host_route lifecycle and all trigger conditions documented
+3. ✅ SDN VLAN automation verified as already present and working
+4. ✅ Stale assumptions identified and corrected
+5. ✅ Implementation inventory created as focused reference doc
+6. ✅ Recommendation: Session 3 can proceed immediately
+
+---
+
+**Next: Session 3 - Design the migration mechanics (ready to start)**

--- a/docs/network-refactor/session-6-summary.md
+++ b/docs/network-refactor/session-6-summary.md
@@ -1,0 +1,111 @@
+# Session 6 Summary — Preflight and Evidence Capture
+
+Date: 2026-05-22
+
+## What Was Done
+
+Session 6 implemented the preflight validation tool and evidence-capture
+mechanism specified in the Session 3 decision outcomes.
+
+### 1. Preflight script created
+
+`scripts/preflight-network-refactor.sh`
+
+Standalone bash script. Invoke via `./with-secrets` (required so the
+targeting guard can verify `TF_VAR_proxmox_node`).
+
+Four checks in order:
+
+| # | Check | Type |
+|---|-------|------|
+| 1 | `TF_VAR_proxmox_node == pve-test` | Hard fail |
+| 2 | ICMP ping to all four SDN gateways (192.168.10.1 – 192.168.40.1) | Hard fail |
+| 3 | DNS via mgmt_seg gateway (192.168.20.1): internal and public name | Hard fail |
+| 4 | TCP:22 reachability to at least one representative guest IP | Hard fail (explicit IPs) / Warn (default candidates only) |
+
+Exit code 0 = all required checks passed. Exit code 1 = at least one failed.
+
+The script accepts optional guest IPs as positional arguments:
+
+```sh
+./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11 192.168.30.10
+```
+
+To save a copy of the output for evidence:
+
+```sh
+./with-secrets scripts/preflight-network-refactor.sh \
+    --save-evidence docs/sessions/ 192.168.40.11
+```
+
+### 2. validation-gate.md updated
+
+Added a "Preflight Script" section at the top with:
+- Standard, explicit-IP, and evidence-capture invocations
+- Per-check explanations (why each check matters, what failure means)
+- Default guest candidate list
+- Manual `dig` equivalent commands for the DNS checks
+
+### 3. plan.md updated
+
+Session 6 implementation note added under the Session 6 heading.
+
+## Session 6 Validation Run
+
+The script was run from `garuda` (operator workstation, not currently on the
+lab LAN) to verify it runs to completion:
+
+```
+Check 1: PASS — TF_VAR_proxmox_node = pve-test
+Check 2: FAIL — all four SDN gateways unreachable (workstation offline from lab)
+Check 3: FAIL — DNS unreachable (gateway offline)
+Check 4: WARN — no default candidate guests reachable (none deployed)
+Exit: 1
+```
+
+The failures are expected. The workstation is not currently connected to the
+lab LAN, so the MikroTik VLAN gateways are unreachable. The script correctly
+identified this and failed fast without producing misleading output.
+
+## Preflight Checks Implementation Checklist
+
+| Item | Status |
+|------|--------|
+| Script exists and is executable | Done |
+| Bash syntax valid | Done (`bash -n` passes) |
+| Runs to completion with proper exit codes | Done |
+| All four checks implemented | Done |
+| Evidence file output (`--save-evidence`) | Done |
+| `--no-colour` flag for log capture | Done |
+| `--help` output | Done |
+| validation-gate.md updated | Done |
+| plan.md Session 6 note added | Done |
+
+## Can Session 7 Begin?
+
+**Yes, with one prerequisite step first.**
+
+Before Session 7 can run representative stack validation, the operator must:
+
+1. Be on the lab LAN (or have a path to the MikroTik from the workstation).
+2. Run the preflight script and confirm all four checks pass.
+3. Capture the evidence output with `--save-evidence`.
+
+Once the preflight script exits 0, Session 7 may proceed directly to
+representative stack validation in the order specified in plan.md:
+
+1. `apt-cacher-stack` (infra_seg, 192.168.40.11)
+2. One mgmt_seg stack (`dns-stack` or `step-ca-stack`)
+3. One additional SDN-backed stack if needed
+
+The preflight script will surface any remaining MikroTik prerequisite gaps
+before any Terraform apply is attempted.
+
+## Open Items for Session 7
+
+1. Run `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11` once
+   on the lab LAN and confirm exit code 0.
+2. Save the evidence output.
+3. Begin representative stack validation per plan.md Session 7.
+4. Note any stacks still labeled `proxyjump_compat` that will need migration
+   before the teardown gate can pass.

--- a/docs/network-refactor/session-7-summary.md
+++ b/docs/network-refactor/session-7-summary.md
@@ -1,83 +1,254 @@
-# Session 7 Summary — Representative Stack Validation (Blocked)
+# Session 7 Summary — Representative Validation (apt-cacher-stack)
 
 Date: 2026-05-22
 
-## Session Goal
+## Scope
 
-Run representative live stack validation for the router-centric provisioning
-path in this order:
+Session 7 representative validation started with `apt-cacher-stack` only,
+as required by the validation order.
 
-1. `apt-cacher-stack`
-2. one `mgmt_seg` stack (`dns-stack` or `step-ca-stack`)
-3. one additional SDN-backed stack if needed
+Operator-provided context for this session:
 
-## Required Precondition
+1. Session 6 preflight already passed on 2026-05-22 from the operator
+   workstation on the lab LAN.
+2. Representative guest reachability to `192.168.40.11` already succeeded.
 
-Proceed only if preflight exits 0 while the operator is on the lab LAN.
+No teardown was started.
 
-### Commands attempted
+## Commands Executed
 
-1. `./with-secrets preflight-network-refactor.sh 192.168.40.11`
-   - Result: command not found (`preflight-network-refactor.sh` is not on PATH
-     in this workspace)
-2. `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11`
-   - Result: executed, exit code 1
+1. Targeting guard:
+   - `./with-secrets bash -c 'echo "$TF_VAR_proxmox_node"'`
+2. Apt-cacher stack plan/apply:
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/apt-cacher-stack && terragrunt plan -no-color'`
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/apt-cacher-stack && terragrunt apply -auto-approve -no-color'`
+3. Inventory evidence capture:
+   - `sed -n '1,80p' terraform/lxc/stacks/apt-cacher-stack/inventory.yml`
+   - `rg -n "ProxyJump|ssh_access_mode|ansible_host|pve_host" terraform/lxc/stacks/apt-cacher-stack/inventory.yml`
+4. Provisioning validation:
+   - `./with-secrets ./scripts/provision.sh --stack apt-cacher-stack --check`
+   - `./with-secrets ./scripts/provision.sh --stack apt-cacher-stack`
+5. Health checks:
+   - `nc -vz 192.168.40.11 3142`
+   - `./with-secrets ansible -i terraform/lxc/stacks/apt-cacher-stack/inventory.yml apt-cacher-stack -m ansible.builtin.command -a 'systemctl is-active apt-cacher-ng'`
+6. Host-route priming retirement evidence (state):
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/apt-cacher-stack && terragrunt state list | rg "prime_sdn_host_route|ansible_inventory|configure_network_sdn_attachment|module.lxc"'`
 
-### Preflight results
+## Evidence
 
-1. Check 1 (targeting guard): PASS (`TF_VAR_proxmox_node = pve-test`)
-2. Check 2 (gateway reachability): FAIL (`192.168.10.1`, `192.168.20.1`,
-   `192.168.30.1`, `192.168.40.1` unreachable)
-3. Check 3 (DNS via MikroTik): FAIL (`traefik.lab.gibbsgreatly.xyz` and
-   `github.com` unresolved via `192.168.20.1`)
-4. Check 4 (representative guest reachability): FAIL (`192.168.40.11:22`
-   unreachable)
+### 1. Generated inventory uses guest IP directly
 
-## Outcome
+From `terraform/lxc/stacks/apt-cacher-stack/inventory.yml` after apply:
 
-Session 7 live validation did not proceed.
+1. `ansible_host: 192.168.40.11`
+2. `ssh_access_mode: direct`
 
-Per the validation gate and session constraints, representative re-apply or
-provisioning runs were not executed after preflight failure.
+### 2. Default ProxyJump is not used for apt-cacher-stack
 
-## Findings and Exceptions
+From the same generated inventory:
 
-1. No new generated inventory evidence was captured from a fresh apply run in
-   this session because the precondition failed.
-2. No stack-specific health checks were run in this session for
-   `apt-cacher-stack`, `dns-stack`/`step-ca-stack`, or additional SDN-backed
-   stacks.
-3. No evidence was produced for direct SSH path success from workstation to
-   guest for this session.
-4. The previous compatibility inventory artifacts under stack state/history may
-   still show `ProxyJump`; they were not re-validated live in this blocked run.
+1. `ansible_ssh_common_args` contains only strict host-key options.
+2. No `ProxyJump` token appears.
+3. No `pve_host` key is emitted for this host.
 
-## Blockers
+`terragrunt plan` showed the compatibility inventory being replaced:
 
-1. Workstation-to-lab routed path is currently unavailable from this operator
-   context (all SDN gateways unreachable).
-2. DNS via MikroTik gateway is not reachable from the current operator context.
-3. Representative guest TCP:22 is unreachable from this operator context.
+1. `ansible_ssh_common_args` changed from ProxyJump form to direct form.
+2. `ssh_access_mode: direct` added.
+3. `pve_host` removed from generated host vars.
 
-## Next Session Restart Checklist
+### 3. Provisioning succeeds without host-route priming
 
-1. Ensure operator workstation is on the lab LAN with route to
-   `192.168.10.0/24`–`192.168.40.0/24` through MikroTik.
-2. Re-run preflight and require exit 0:
-   - `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11`
-3. If preflight passes, run representative validation in order:
-   - `apt-cacher-stack`
-   - one `mgmt_seg` stack (`dns-stack` or `step-ca-stack`)
-   - one additional SDN-backed stack (for example `proxy-stack`) if needed
-4. Capture evidence per stack:
-   - generated inventory (`ssh_access_mode`, `ansible_ssh_common_args`)
-   - SSH/provisioning path (no default `ProxyJump`)
-   - DNS behavior via zone gateway
-   - stack-specific health check
+`terragrunt apply` for apt-cacher-stack completed successfully and removed the
+legacy state-only host-route shim:
 
-## Session 8 Readiness
+1. `null_resource.prime_sdn_host_route[0]` destroyed because it is not in
+   configuration.
+2. Apply result: `2 added, 0 changed, 2 destroyed`.
 
-Session 8 teardown/redeploy validation cannot begin yet.
+Post-apply state list confirms no `prime_sdn_host_route` remains.
 
-Reason: Session 7 representative live validation prerequisites are not met
-(preflight did not pass).
+Provisioning then succeeded via stack inventory path:
+
+1. Check mode play recap: `unreachable=0 failed=0`.
+2. Live play recap: `ok=5 changed=0 unreachable=0 failed=0`.
+
+### 4. apt-cacher-stack health checks pass
+
+1. TCP service reachability from workstation path:
+   - `nc -vz 192.168.40.11 3142` => connection succeeded.
+2. In-guest service state via Ansible:
+   - `systemctl is-active apt-cacher-ng` => `active`.
+
+## Result
+
+`apt-cacher-stack` passes Session 7 representative validation for the
+direct-access model:
+
+1. Direct guest-IP inventory is in effect.
+2. Default ProxyJump is not used.
+3. Provisioning succeeds without host-route priming.
+4. Stack health checks pass.
+
+## Can mgmt_seg Representative Validation Proceed?
+
+Yes. Based on this apt-cacher representative result, the next Session 7 step
+(one `mgmt_seg` stack such as `dns-stack` or `step-ca-stack`) can proceed.
+
+---
+
+## Session 7 Update — mgmt_seg Representative Validation (dns-stack)
+
+Date: 2026-05-22
+
+### Scope
+
+Validated `dns-stack` as the required `mgmt_seg` representative stack using
+the direct-access model on `pve-test`.
+
+### Commands Executed
+
+1. Targeting guard:
+   - `./with-secrets bash -c 'echo "$TF_VAR_proxmox_node"'`
+2. Dns stack plan/apply:
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/dns-stack && terragrunt plan -no-color'`
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/dns-stack && terragrunt apply -auto-approve -no-color'`
+3. Inventory evidence capture:
+   - `sed -n '1,100p' terraform/lxc/stacks/dns-stack/inventory.yml`
+   - `rg -n "ProxyJump|ssh_access_mode|ansible_host|pve_host" terraform/lxc/stacks/dns-stack/inventory.yml`
+4. Provisioning validation:
+   - `./with-secrets ./scripts/provision.sh --stack dns-stack --check`
+   - `./with-secrets ./scripts/provision.sh --stack dns-stack`
+5. DNS/service health checks:
+   - `nc -vz 192.168.20.13 53`
+   - `dig @192.168.20.13 +short traefik.lab.gibbsgreatly.xyz`
+   - `dig @192.168.20.13 +short github.com`
+   - `./with-secrets ansible -i terraform/lxc/stacks/dns-stack/inventory.yml dns-stack -m ansible.builtin.command -a 'systemctl is-active coredns'`
+6. Host-route priming retirement evidence (state):
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/dns-stack && terragrunt state list | rg "prime_sdn_host_route|ansible_inventory|configure_network_sdn_attachment|module.lxc"'`
+
+### Evidence
+
+1. Generated inventory is direct guest access:
+   - `ansible_host: 192.168.20.13`
+   - `ssh_access_mode: direct`
+
+2. No default ProxyJump in generated inventory:
+   - `ansible_ssh_common_args` contains strict host key options only.
+   - No `ProxyJump` string present.
+   - No `pve_host` host var emitted.
+
+3. Provisioning succeeds without host-route priming:
+   - `terragrunt plan` and `terragrunt apply` both show stale
+     `null_resource.prime_sdn_host_route[0]` removed because it is not in
+     configuration.
+   - Apply result: `1 added, 0 changed, 2 destroyed`.
+   - Post-apply state listing confirms no `prime_sdn_host_route` remains.
+   - Provision check and live runs completed with `unreachable=0 failed=0`.
+
+4. DNS/service health checks pass:
+   - TCP 53 reachable: `nc -vz 192.168.20.13 53` succeeded.
+   - Authority response: `dig @192.168.20.13 +short traefik.lab.gibbsgreatly.xyz` returned `192.168.30.10`.
+   - Recursive response: `dig @192.168.20.13 +short github.com` returned an IP (`4.237.22.38`).
+   - CoreDNS service active: `systemctl is-active coredns` returned `active`.
+
+### Result
+
+`dns-stack` passes Session 7 representative validation for `mgmt_seg` on the
+direct-access contract:
+
+1. No default `ProxyJump` is used.
+2. Provisioning succeeds via direct path.
+3. No host-route priming is required.
+4. Stack DNS/service checks pass.
+
+### Is A Third Representative SDN-Backed Stack Still Needed?
+
+Recommendation: **Yes**. Run one additional SDN-backed representative stack
+(for example `proxy-stack` on `edge_seg`) before Session 8.
+
+Reason: The validation gate still specifies a third representative stack as
+"if needed" to increase confidence across zones before teardown/redeploy.
+With `infra_seg` and `mgmt_seg` now validated direct, one `edge_seg` validation
+provides stronger cross-zone confirmation before starting Session 8.
+
+---
+
+## Session 7 Final Update — Additional SDN Representative (proxy-stack)
+
+Date: 2026-05-22
+
+### Scope
+
+Validated `proxy-stack` (`edge_seg`) as the final additional SDN-backed
+representative to confirm the direct-access model holds across zones.
+
+### Commands Executed
+
+1. Targeting guard:
+   - `./with-secrets bash -c 'echo "$TF_VAR_proxmox_node"'`
+2. Proxy stack plan/apply:
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/proxy-stack && terragrunt plan -no-color'`
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/proxy-stack && terragrunt apply -auto-approve -no-color'`
+3. Inventory evidence capture:
+   - `sed -n '1,120p' terraform/lxc/stacks/proxy-stack/inventory.yml`
+   - `rg -n "ProxyJump|ssh_access_mode|ansible_host|pve_host" terraform/lxc/stacks/proxy-stack/inventory.yml`
+4. Provisioning validation:
+   - `./with-secrets ./scripts/provision.sh --stack proxy-stack --check`
+   - `./with-secrets ./scripts/provision.sh --stack proxy-stack`
+5. Stack health checks:
+   - `nc -vz 192.168.30.10 80`
+   - `nc -vz 192.168.30.10 443`
+   - `curl -skI https://192.168.30.10 | head -n 1`
+   - `curl -sI http://192.168.30.10 | head -n 1`
+   - `./with-secrets ansible -i terraform/lxc/stacks/proxy-stack/inventory.yml proxy-stack -m ansible.builtin.command -a 'docker compose -f /opt/proxy-stack/docker-compose.yml ps'`
+   - `./with-secrets ansible -i terraform/lxc/stacks/proxy-stack/inventory.yml proxy-stack -m ansible.builtin.command -a 'systemctl is-active docker'`
+6. Host-route priming retirement evidence (state):
+   - `./with-secrets bash -lc 'cd terraform/lxc/stacks/proxy-stack && terragrunt state list | rg "prime_sdn_host_route|ansible_inventory|configure_network_sdn_attachment|module.lxc"'`
+
+### Evidence
+
+1. Generated inventory is direct guest access:
+   - `ansible_host: 192.168.30.10`
+   - `ssh_access_mode: direct`
+
+2. No default ProxyJump in generated inventory:
+   - `ansible_ssh_common_args` contains strict host key options only.
+   - No `ProxyJump` string present.
+   - No `pve_host` host var emitted.
+
+3. Provisioning succeeds without host-route priming:
+   - `terragrunt plan` and `terragrunt apply` showed stale
+     `null_resource.prime_sdn_host_route[0]` removed because it is not in
+     configuration.
+   - Apply result: `1 added, 0 changed, 2 destroyed`.
+   - Post-apply state listing confirms no `prime_sdn_host_route` remains.
+   - Provision check and live runs completed with `unreachable=0 failed=0`.
+
+4. Stack health checks pass:
+   - TCP ingress ports reachable: `80` and `443` succeeded.
+   - HTTPS probe to edge IP returned `HTTP/2 404` (Traefik responding).
+   - HTTP probe returned `HTTP/1.1 308 Permanent Redirect`.
+   - Compose status shows Traefik container `Up` with `80/443` port bindings.
+   - `systemctl is-active docker` returned `active`.
+
+### Result
+
+`proxy-stack` passes the additional representative validation for the direct
+access model on `edge_seg`:
+
+1. No default `ProxyJump` is used.
+2. Provisioning succeeds via direct path.
+3. No host-route priming is required.
+4. Edge service health checks pass.
+
+### Session 8 Teardown/Redeploy Readiness
+
+**Yes.** Session 8 teardown/redeploy validation is now ready from the
+representative-stack perspective:
+
+1. `infra_seg` validated (`apt-cacher-stack`).
+2. `mgmt_seg` validated (`dns-stack`).
+3. `edge_seg` validated (`proxy-stack`).
+
+No teardown was started in Session 7.

--- a/docs/network-refactor/session-7-summary.md
+++ b/docs/network-refactor/session-7-summary.md
@@ -1,0 +1,83 @@
+# Session 7 Summary — Representative Stack Validation (Blocked)
+
+Date: 2026-05-22
+
+## Session Goal
+
+Run representative live stack validation for the router-centric provisioning
+path in this order:
+
+1. `apt-cacher-stack`
+2. one `mgmt_seg` stack (`dns-stack` or `step-ca-stack`)
+3. one additional SDN-backed stack if needed
+
+## Required Precondition
+
+Proceed only if preflight exits 0 while the operator is on the lab LAN.
+
+### Commands attempted
+
+1. `./with-secrets preflight-network-refactor.sh 192.168.40.11`
+   - Result: command not found (`preflight-network-refactor.sh` is not on PATH
+     in this workspace)
+2. `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11`
+   - Result: executed, exit code 1
+
+### Preflight results
+
+1. Check 1 (targeting guard): PASS (`TF_VAR_proxmox_node = pve-test`)
+2. Check 2 (gateway reachability): FAIL (`192.168.10.1`, `192.168.20.1`,
+   `192.168.30.1`, `192.168.40.1` unreachable)
+3. Check 3 (DNS via MikroTik): FAIL (`traefik.lab.gibbsgreatly.xyz` and
+   `github.com` unresolved via `192.168.20.1`)
+4. Check 4 (representative guest reachability): FAIL (`192.168.40.11:22`
+   unreachable)
+
+## Outcome
+
+Session 7 live validation did not proceed.
+
+Per the validation gate and session constraints, representative re-apply or
+provisioning runs were not executed after preflight failure.
+
+## Findings and Exceptions
+
+1. No new generated inventory evidence was captured from a fresh apply run in
+   this session because the precondition failed.
+2. No stack-specific health checks were run in this session for
+   `apt-cacher-stack`, `dns-stack`/`step-ca-stack`, or additional SDN-backed
+   stacks.
+3. No evidence was produced for direct SSH path success from workstation to
+   guest for this session.
+4. The previous compatibility inventory artifacts under stack state/history may
+   still show `ProxyJump`; they were not re-validated live in this blocked run.
+
+## Blockers
+
+1. Workstation-to-lab routed path is currently unavailable from this operator
+   context (all SDN gateways unreachable).
+2. DNS via MikroTik gateway is not reachable from the current operator context.
+3. Representative guest TCP:22 is unreachable from this operator context.
+
+## Next Session Restart Checklist
+
+1. Ensure operator workstation is on the lab LAN with route to
+   `192.168.10.0/24`–`192.168.40.0/24` through MikroTik.
+2. Re-run preflight and require exit 0:
+   - `./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11`
+3. If preflight passes, run representative validation in order:
+   - `apt-cacher-stack`
+   - one `mgmt_seg` stack (`dns-stack` or `step-ca-stack`)
+   - one additional SDN-backed stack (for example `proxy-stack`) if needed
+4. Capture evidence per stack:
+   - generated inventory (`ssh_access_mode`, `ansible_ssh_common_args`)
+   - SSH/provisioning path (no default `ProxyJump`)
+   - DNS behavior via zone gateway
+   - stack-specific health check
+
+## Session 8 Readiness
+
+Session 8 teardown/redeploy validation cannot begin yet.
+
+Reason: Session 7 representative live validation prerequisites are not met
+(preflight did not pass).

--- a/docs/network-refactor/session-8-summary.md
+++ b/docs/network-refactor/session-8-summary.md
@@ -1,0 +1,174 @@
+# Session 8 Summary — Teardown And Redeploy Validation Gate (pve-test)
+
+Date: 2026-05-22
+
+## Scope
+
+Completed Session 8 from `docs/network-refactor/plan.md`:
+
+1. Captured fresh preflight evidence before teardown.
+2. Executed the `pve-test` teardown/redeploy workflow using the documented harness.
+3. Confirmed SDN zone/VNet attachment reconciliation during redeploy.
+4. Revalidated representative stacks (`apt-cacher-stack`, `dns-stack`, `proxy-stack`) through redeploy/final checks.
+5. Captured post-rebuild evidence for direct access, no default ProxyJump, no host-route priming dependency, MikroTik DNS path, and representative stack health.
+
+## Preconditions And Preflight
+
+Mandatory preflight command (before teardown):
+
+```bash
+./with-secrets scripts/preflight-network-refactor.sh --save-evidence docs/teardown-test/evidence 192.168.40.11
+```
+
+Result: PASS
+
+Evidence:
+
+- `docs/teardown-test/evidence/preflight-evidence-20260522-131059.txt`
+
+## Teardown/Redeploy Execution
+
+Harness path used:
+
+```bash
+scripts/teardown-deploy-test.sh cycle --execute --approval-text "approve" --approval-packet /tmp/teardown-approval-20260522-011241.md --stamp 20260522-011241
+```
+
+Initial cycle run status:
+
+- `destroy`: passed
+- `deploy-foundation`: passed
+- `deploy-edge`: passed
+- `activate-edge`: passed
+- `deploy-platform`: failed at `deploy-netbox-stack`
+
+Failure cause:
+
+- `configure-keyctl.yml` required `pve_host`, but direct-access inventory no longer emits that host var by default.
+
+Fix applied during this session:
+
+- `terraform/lxc/ansible/playbooks/configure-keyctl.yml`
+  - Added `proxmox_delegate_host` fallback (`pve_host` -> `PVE_TEST_FQDN` -> `pve-test.gibbsgreatly.xyz`).
+
+Resume command:
+
+```bash
+scripts/teardown-deploy-test.sh deploy-platform --execute --approval-text "approve" --stamp 20260522-011241
+scripts/teardown-deploy-test.sh final-validation --stamp 20260522-011241
+```
+
+Resume status:
+
+- `deploy-platform`: passed
+- `final-validation`: passed
+
+Evidence stamp:
+
+- `docs/teardown-test/evidence/20260522-011241/`
+
+## SDN Attachment Confirmation
+
+Post-destroy redeploy logs show SDN attachment orchestration running and passing (`configure_network_sdn_attachment`) during stack apply.
+
+Representative evidence logs:
+
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-apt-cacher-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-dns-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-proxy-stack.log`
+
+## Post-Rebuild Direct-Access Evidence
+
+Post-redeploy preflight (explicit representative guest IPs):
+
+```bash
+./with-secrets scripts/preflight-network-refactor.sh --save-evidence docs/teardown-test/evidence 192.168.40.11 192.168.20.13 192.168.30.10
+```
+
+Result: PASS
+
+Evidence:
+
+- `docs/teardown-test/evidence/preflight-evidence-20260522-135237.txt`
+
+Observed:
+
+1. Target guard passed (`TF_VAR_proxmox_node = pve-test`).
+2. All SDN gateways reachable (`192.168.10.1`, `.20.1`, `.30.1`, `.40.1`).
+3. DNS via MikroTik gateway (`192.168.20.1`) resolved internal and public names.
+4. TCP:22 reachable for representative guest IPs in infra/mgmt/edge zones.
+
+## No Default ProxyJump Evidence
+
+Representative generated inventories after rebuild:
+
+- `terraform/lxc/stacks/apt-cacher-stack/inventory.yml`
+- `terraform/lxc/stacks/dns-stack/inventory.yml`
+- `terraform/lxc/stacks/proxy-stack/inventory.yml`
+
+Observed:
+
+1. `ssh_access_mode: direct` for all three representatives.
+2. `ansible_host` set directly to guest IP.
+3. No `ProxyJump` token present.
+4. No `pve_host` key present.
+
+## No Host-Route Priming Dependency Evidence
+
+Representative state inspection:
+
+```bash
+./with-secrets bash -lc 'for s in apt-cacher-stack dns-stack proxy-stack; do
+  cd terraform/lxc/stacks/$s
+  terragrunt state list | rg "prime_sdn_host_route|configure_network_sdn_attachment|local_file.ansible_inventory" || true
+  cd - >/dev/null
+done'
+```
+
+Observed:
+
+1. `local_file.ansible_inventory` and `null_resource.configure_network_sdn_attachment[0]` present.
+2. No `prime_sdn_host_route` entries present.
+3. No manual host-side route priming step required to complete apply/provision/final-validation.
+
+## Representative Stack Health After Rebuild
+
+Representative stacks validated in required order through harness phase logs:
+
+1. `apt-cacher-stack` (infra_seg): deploy/provision/pct/health passed.
+2. `dns-stack` (mgmt_seg): deploy/provision/pct/authoritative+delegated DNS checks passed.
+3. `proxy-stack` (edge_seg): deploy/provision/pct/HTTPS route health passed.
+
+Representative evidence logs:
+
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-apt-cacher-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/health-apt-cacher-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-dns-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/health-dns-stack-delegated.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/deploy-proxy-stack.log`
+- `docs/teardown-test/evidence/20260522-011241/logs/health-proxy-stack.log`
+
+## Final Gate Verdict
+
+Network refactor teardown/redeploy validation gate on `pve-test`: **YES (PASSED)**.
+
+Rationale:
+
+1. Full teardown and redeploy lifecycle completed (with resume after one code-level blocker fix).
+2. Direct-access path remains in effect post-rebuild.
+3. No default ProxyJump usage in representative inventories.
+4. No host-route priming dependency observed.
+5. DNS and routed service checks through MikroTik gateway path passed after rebuild.
+
+## Blockers Before Promotion Or Canary Resume
+
+No unresolved network-path blockers remain from Session 8.
+
+Resolved within session:
+
+- `configure-keyctl.yml` dependence on `pve_host` for direct-mode inventories.
+
+Tracking note:
+
+- Harness `state.json` still records `cycle: failed` from the first interrupted run, while resumed phases (`deploy-platform`, `final-validation`) are recorded as passed for the same stamp.
+- Use log evidence under stamp `20260522-011241` as the authoritative completion record.

--- a/docs/network-refactor/target-model.md
+++ b/docs/network-refactor/target-model.md
@@ -1,0 +1,85 @@
+# Network Refactor Target Model
+
+## Purpose
+
+This document states the target access and provisioning model that the
+refactor should implement. Future sessions should treat this as the default
+contract and only deviate if live evidence forces a correction.
+
+## Core Network Contract
+
+1. The MikroTik is the sole L3 gateway for every SDN VLAN subnet.
+2. Proxmox provides VLAN-aware L2 switching only.
+3. Proxmox hosts do not carry subnet-local `.254` gateway-style addresses on
+   SDN VNets as part of the normal operating model.
+4. Inter-zone routing and east-west policy are enforced at the MikroTik.
+5. SDN guest workloads should be reachable from approved admin clients through
+   the routed VLAN design, not by using Proxmox as a default jump host.
+
+Reference architecture:
+
+- [docs/design/network.md](/home/steve/git/proxmox-homelab/docs/design/network.md:1)
+- [docs/reference/sdn-segment-routing.md](/home/steve/git/proxmox-homelab/docs/reference/sdn-segment-routing.md:1)
+
+## Administrative Access Contract
+
+The intended administrative path for `pve-test` is:
+
+1. operator workstation on LAN `192.168.1.0/24`
+2. MikroTik routes to the destination VLAN subnet
+3. guest answers directly on its assigned `10.57.x.x` address
+
+Implications:
+
+1. generated Ansible inventories for SDN-backed guests should target the guest
+   IP directly
+2. direct SSH from the workstation is the default success path to prove
+3. `ProxyJump` through Proxmox is a temporary compatibility exception only
+4. any future bastion design should be explicit and separate from Proxmox
+
+## Subnet Reachability Expectations
+
+Approved admin clients should be able to reach these guest subnets via the
+router:
+
+1. `build_seg` at `10.57.0.0/24`
+2. `mgmt_seg` at `10.57.1.0/24`
+3. `edge_seg` at `10.57.2.0/24`
+4. `infra_seg` at `10.57.3.0/24`
+
+This does not imply all application ports are open from LAN. It does mean the
+network path exists, and selective SSH or validation traffic can be allowed by
+policy.
+
+## DNS Contract
+
+1. Each SDN-attached LXC uses its zone gateway on MikroTik as its resolver.
+2. `lab.gibbsgreatly.xyz` is delegated behind MikroTik to internal authority.
+3. DNS validation must prove the guest sees working resolution through the zone
+   gateway path, not just that a public resolver works.
+
+## Current Manual Prerequisites
+
+These remain out of band for now and must be present before direct-SSH
+provisioning is considered valid:
+
+1. MikroTik VLAN interfaces for each SDN zone
+2. MikroTik gateway IPs for each zone
+3. MikroTik DNS behavior for public lookups and delegated internal names
+4. MikroTik firewall rules that allow the expected admin and cross-zone traffic
+
+## Migration Principles
+
+1. Prefer direct-SSH proof before removing compatibility shims.
+2. Remove `prime_sdn_host_route` only after the router path is verified.
+3. Make exceptions explicit, time-bounded, and easy to delete.
+4. Keep `pve-test` as the proving ground before reusing the pattern on `pve`.
+
+## Evidence Requirements
+
+To claim the target model is working for a stack, capture:
+
+1. route reachability from the workstation to the guest IP
+2. successful SSH without `ProxyJump`
+3. guest-side DNS success via the zone gateway
+4. service health appropriate to that stack type

--- a/docs/network-refactor/target-model.md
+++ b/docs/network-refactor/target-model.md
@@ -27,25 +27,28 @@ The intended administrative path for `pve-test` is:
 
 1. operator workstation on LAN `192.168.1.0/24`
 2. MikroTik routes to the destination VLAN subnet
-3. guest answers directly on its assigned `10.57.x.x` address
+3. guest answers directly on its assigned zone IP, currently
+   `192.168.<vlan-id>.x` on `pve-test`
 
 Implications:
 
 1. generated Ansible inventories for SDN-backed guests should target the guest
    IP directly
 2. direct SSH from the workstation is the default success path to prove
-3. `ProxyJump` through Proxmox is a temporary compatibility exception only
-4. any future bastion design should be explicit and separate from Proxmox
+3. Proxmox is not the Ansible automation origin in the target model
+4. `ProxyJump` through Proxmox is a temporary compatibility exception only
+5. any future bastion design should be explicit and separate from Proxmox
 
 ## Subnet Reachability Expectations
 
-Approved admin clients should be able to reach these guest subnets via the
-router:
+The operator workstation on LAN `192.168.1.0/24` is the approved admin source
+for SSH, Ansible automation, and service validation. It must be able to reach
+these guest subnets through the MikroTik:
 
-1. `build_seg` at `10.57.0.0/24`
-2. `mgmt_seg` at `10.57.1.0/24`
-3. `edge_seg` at `10.57.2.0/24`
-4. `infra_seg` at `10.57.3.0/24`
+1. `build_seg` at `192.168.10.0/24` (gateway `192.168.10.1`, VLAN 10)
+2. `mgmt_seg` at `192.168.20.0/24` (gateway `192.168.20.1`, VLAN 20)
+3. `edge_seg` at `192.168.30.0/24` (gateway `192.168.30.1`, VLAN 30)
+4. `infra_seg` at `192.168.40.0/24` (gateway `192.168.40.1`, VLAN 40)
 
 This does not imply all application ports are open from LAN. It does mean the
 network path exists, and selective SSH or validation traffic can be allowed by
@@ -68,10 +71,34 @@ provisioning is considered valid:
 3. MikroTik DNS behavior for public lookups and delegated internal names
 4. MikroTik firewall rules that allow the expected admin and cross-zone traffic
 
+Specific RouterOS commands for items 1–2 and DNS baseline setup are documented
+in `terraform/lxc/network/pve-test.yaml` under the "MikroTik one-time setup"
+header. That file is the authoritative reference for what must be done manually
+before a `pve-test` direct-SSH provisioning pass.
+
+## Temporary Exceptions
+
+The following patterns are active in the repo today but are not part of the
+target model. Neither should be extended to new stacks.
+
+| Exception | Location | Retirement condition |
+|---|---|---|
+| `ProxyJump=root@<pve_host>` | `terraform/lxc/templates/inventory.tpl` | Remove once direct SSH from the workstation is validated end-to-end on `pve-test` |
+
+`ProxyJump` is the accepted temporary escape hatch during migration. It must
+remain explicitly labeled and must be removed before the validation gate passes.
+
+`prime_sdn_host_route` has been removed in Session 5. The target model no
+longer treats host-side route priming as a supported compatibility path.
+
+For the exact current call chain, trigger conditions, and short-term control
+knobs behind these exceptions, use
+[implementation-inventory.md](/home/steve/git/proxmox-homelab/docs/network-refactor/implementation-inventory.md:1).
+
 ## Migration Principles
 
 1. Prefer direct-SSH proof before removing compatibility shims.
-2. Remove `prime_sdn_host_route` only after the router path is verified.
+2. Do not reintroduce host-side route priming as a compatibility path.
 3. Make exceptions explicit, time-bounded, and easy to delete.
 4. Keep `pve-test` as the proving ground before reusing the pattern on `pve`.
 
@@ -83,3 +110,16 @@ To claim the target model is working for a stack, capture:
 2. successful SSH without `ProxyJump`
 3. guest-side DNS success via the zone gateway
 4. service health appropriate to that stack type
+
+## Non-Goals
+
+These are explicitly out of scope for this refactor:
+
+1. Proxmox acting as a routing or NAT transit point for any SDN subnet.
+2. Host-side `.254` bridge addresses as a permanent provisioning pattern.
+3. A dedicated bastion host (deferred to a future phase; workstation is the
+   origin for now).
+4. MikroTik IaC automation (tracked separately as TM-09; MikroTik configuration
+   remains manual for this refactor).
+5. Any production (`pve`) environment changes before `pve-test` validation is
+   complete and the teardown gate is passed.

--- a/docs/network-refactor/validation-gate.md
+++ b/docs/network-refactor/validation-gate.md
@@ -1,0 +1,92 @@
+# Network Refactor Validation Gate
+
+## Purpose
+
+This gate defines the minimum validation required before the network refactor
+can be considered complete on `pve-test`.
+
+## Preconditions
+
+Before any apply or teardown/redeploy validation:
+
+1. Run `./with-secrets bash -c 'echo $TF_VAR_proxmox_node'` and confirm it
+   returns `pve-test`.
+2. Confirm the intended branch is a short-lived work branch, not
+   `baseline/teardown-validated` or `dev/pve-test`.
+3. Confirm the manual MikroTik prerequisites for the SDN zones are present.
+4. Confirm the generated inventory path under test is the new direct-access
+   path, not a silent fallback to `ProxyJump`.
+
+## Preflight Evidence
+
+Capture evidence for each of these before changing live state:
+
+1. Reach the expected SDN gateways from the workstation:
+   - `10.57.0.1`
+   - `10.57.1.1`
+   - `10.57.2.1`
+   - `10.57.3.1`
+2. Resolve a delegated internal name through MikroTik:
+   - `dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz`
+3. Resolve a public name through MikroTik:
+   - `dig @10.57.1.1 +short github.com`
+4. Reach at least one representative guest IP directly from the workstation.
+
+## Representative Live Validation
+
+Before a full teardown/redeploy cycle, validate the new access model on live
+stacks in this order:
+
+1. `apt-cacher-stack`
+2. one `mgmt_seg` stack such as `dns-stack` or `step-ca-stack`
+3. one additional SDN-backed stack if needed
+
+For each stack, capture:
+
+1. generated inventory content
+2. SSH path used
+3. provisioning result
+4. stack-specific health proof
+
+## Teardown And Redeploy Cycle
+
+Run at least one full validation cycle on `pve-test` after the representative
+live checks succeed.
+
+Required sequence:
+
+1. ensure preflight evidence is current
+2. run the teardown/redeploy workflow for `pve-test`
+3. recreate or confirm SDN zone and VNet attachments
+4. reprovision representative stacks
+5. rerun DNS and service-health checks
+6. capture any manual router actions required during the cycle
+
+## Success Criteria
+
+The refactor passes only if all of these are true:
+
+1. SDN-backed guests are provisioned through the intended router-centric path.
+2. No Proxmox host route priming is required.
+3. No default `ProxyJump` through Proxmox is required for the validated stacks.
+4. DNS works through the intended MikroTik gateway path for validated guests.
+5. Representative stack health checks pass after the rebuild.
+
+## Failure Conditions
+
+Stop and document options instead of continuing if:
+
+1. a validated stack still requires `ProxyJump`
+2. a validated stack still requires `prime_sdn_host_route`
+3. the workstation cannot reach a required SDN subnet through the router
+4. DNS works only via public resolver overrides rather than the zone gateway
+5. the teardown/redeploy cycle needs undocumented manual recovery steps
+
+## Post-Gate Outputs
+
+When the gate passes, record:
+
+1. commands used
+2. evidence locations
+3. remaining cleanup items
+4. what is now safe to resume from the preserved productionizing work

--- a/docs/network-refactor/validation-gate.md
+++ b/docs/network-refactor/validation-gate.md
@@ -5,32 +5,132 @@
 This gate defines the minimum validation required before the network refactor
 can be considered complete on `pve-test`.
 
+## Preflight Script
+
+Session 6 added a standalone preflight script that automates all required
+checks and produces structured evidence output:
+
+```
+scripts/preflight-network-refactor.sh
+```
+
+**Standard invocation** (run from repo root):
+
+```sh
+./with-secrets scripts/preflight-network-refactor.sh
+```
+
+**With explicit representative guest IPs** (recommended once stacks are
+deployed):
+
+```sh
+./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11 192.168.30.10
+```
+
+**With evidence file saved to a session directory:**
+
+```sh
+./with-secrets scripts/preflight-network-refactor.sh \
+    --save-evidence docs/sessions/ 192.168.40.11
+```
+
+Exit code 0 means all required checks passed. Exit code 1 means one or more
+required checks failed and the session should not proceed.
+
+If `--save-evidence` points to a directory, the script writes a timestamped
+`preflight-evidence-YYYYMMDD-HHMMSS.txt` file there. Keep evidence files in
+an ignored directory; summarize results in tracked docs only.
+
 ## Preconditions
 
 Before any apply or teardown/redeploy validation:
 
 1. Run `./with-secrets bash -c 'echo $TF_VAR_proxmox_node'` and confirm it
-   returns `pve-test`.
+   returns `pve-test`. The preflight script performs this check automatically.
 2. Confirm the intended branch is a short-lived work branch, not
    `baseline/teardown-validated` or `dev/pve-test`.
-3. Confirm the manual MikroTik prerequisites for the SDN zones are present.
+3. Confirm the manual MikroTik prerequisites for the SDN zones are present
+   (VLAN interfaces, gateway IPs, DNS rules). The preflight script tests the
+   observable outcomes; it does not configure the router.
 4. Confirm the generated inventory path under test is the new direct-access
    path, not a silent fallback to `ProxyJump`.
 
+## Preflight Checks (performed by the script)
+
+The preflight script runs these four checks in order:
+
+### Check 1 — Targeting guard
+
+Verifies `TF_VAR_proxmox_node == pve-test` in the injected environment.
+
+Required because:
+
+- Operators must invoke `./with-secrets` before any apply.
+- A wrong target node would silently run teardown/redeploy against production.
+
+### Check 2 — SDN gateway reachability
+
+Pings each MikroTik VLAN gateway from the workstation:
+
+| Zone       | Gateway IP  |
+|------------|-------------|
+| build_seg  | 192.168.10.1 |
+| mgmt_seg   | 192.168.20.1 |
+| edge_seg   | 192.168.30.1 |
+| infra_seg  | 192.168.40.1 |
+
+Failure means either the MikroTik VLAN interface is missing or the workstation
+does not have a route to that subnet through the router.
+
+### Check 3 — DNS via MikroTik gateway
+
+Queries the `mgmt_seg` gateway (`192.168.20.1`) for:
+
+1. A delegated internal name: `traefik.lab.gibbsgreatly.xyz`
+   - Confirms MikroTik static A record or FWD delegation is in place.
+2. A public name: `github.com`
+   - Confirms MikroTik upstream DNS forwarding is working.
+
+Equivalent manual commands for evidence capture:
+
+```sh
+dig @192.168.20.1 +short traefik.lab.gibbsgreatly.xyz
+dig @192.168.20.1 +short github.com
+```
+
+### Check 4 — Representative guest reachability
+
+Probes TCP:22 on one or more guest IPs to confirm the workstation can reach a
+live container through the routed path without `ProxyJump`.
+
+Default candidate list (first reachable wins):
+
+```
+192.168.40.11  apt-cacher-stack (infra_seg)
+192.168.30.10  proxy-stack / Traefik (edge_seg)
+192.168.20.10  authentik-stack (mgmt_seg)
+192.168.20.11  step-ca-stack (mgmt_seg)
+192.168.20.12  monitoring-stack (mgmt_seg)
+192.168.40.10  harbor-stack (infra_seg)
+192.168.10.63  ci-runner-01 (build_seg)
+```
+
+If no stacks are currently deployed, this check produces a warning rather than
+a failure when using the default candidate list. Once stacks are deployed,
+pass explicit IPs on the command line to convert this to a hard check.
+
 ## Preflight Evidence
 
-Capture evidence for each of these before changing live state:
+Capture evidence for each of these before changing live state. The preflight
+script produces a structured summary suitable for pasting into a session doc.
+To save a copy automatically, use `--save-evidence docs/sessions/`.
 
-1. Reach the expected SDN gateways from the workstation:
-   - `10.57.0.1`
-   - `10.57.1.1`
-   - `10.57.2.1`
-   - `10.57.3.1`
-2. Resolve a delegated internal name through MikroTik:
-   - `dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz`
-3. Resolve a public name through MikroTik:
-   - `dig @10.57.1.1 +short github.com`
-4. Reach at least one representative guest IP directly from the workstation.
+Required evidence items (produced by the script):
+
+1. Targeting guard result (`TF_VAR_proxmox_node = pve-test`)
+2. Gateway ping results for all four SDN zones
+3. DNS resolution results via `192.168.20.1` for both internal and public names
+4. Representative guest TCP:22 probe result
 
 ## Representative Live Validation
 
@@ -47,6 +147,7 @@ For each stack, capture:
 2. SSH path used
 3. provisioning result
 4. stack-specific health proof
+5. confirmation that no Proxmox-side route priming step was required
 
 ## Teardown And Redeploy Cycle
 
@@ -77,7 +178,7 @@ The refactor passes only if all of these are true:
 Stop and document options instead of continuing if:
 
 1. a validated stack still requires `ProxyJump`
-2. a validated stack still requires `prime_sdn_host_route`
+2. a validated stack still requires host-side route priming
 3. the workstation cannot reach a required SDN subnet through the router
 4. DNS works only via public resolver overrides rather than the zone gateway
 5. the teardown/redeploy cycle needs undocumented manual recovery steps

--- a/docs/reference/sdn-segment-routing.md
+++ b/docs/reference/sdn-segment-routing.md
@@ -19,10 +19,10 @@ adding a new segment.
          |
     MikroTik (router/firewall)
     ├── LAN: 192.168.1.1/24       (untagged)
-    ├── VLAN 10: 10.57.0.1/24    (build_seg)
-    ├── VLAN 20: 10.57.1.1/24    (mgmt_seg)
-    ├── VLAN 30: 10.57.2.1/24    (edge_seg)
-    └── VLAN 40: 10.57.3.1/24    (infra_seg)
+    ├── VLAN 10: 192.168.10.1/24  (build_seg)
+    ├── VLAN 20: 192.168.20.1/24  (mgmt_seg)
+    ├── VLAN 30: 192.168.30.1/24  (edge_seg)
+    └── VLAN 40: 192.168.40.1/24  (infra_seg)
          |
     pve-test (trunk port — all VLANs tagged)
     ├── vmbr0 (VLAN-aware bridge)
@@ -33,7 +33,7 @@ adding a new segment.
 ```
 
 Each container uses its zone's MikroTik interface as its default gateway
-(e.g. `10.57.3.1` for infra_seg). All routing — including inter-zone traffic,
+(for example `192.168.40.1` for infra_seg). All routing — including inter-zone traffic,
 LAN access, and internet egress — flows through the MikroTik. Proxmox does
 not have any gateway IPs and performs no routing or SNAT.
 
@@ -52,7 +52,7 @@ not have any gateway IPs and performs no routing or SNAT.
 
 With VLAN zones, **no static routes are needed on the MikroTik** — the VLAN
 interfaces are directly connected routes. Any host on 192.168.1.0/24 can reach
-any container at 10.57.x.x directly via the MikroTik.
+any container at `192.168.<vlan-id>.x` directly via the MikroTik.
 
 ---
 
@@ -60,10 +60,10 @@ any container at 10.57.x.x directly via the MikroTik.
 
 | Zone | VNet bridge | VLAN | Subnet | Gateway | Containers |
 |---|---|---|---|---|---|
-| `build_seg` | `tvnetc` | 10 | `10.57.0.0/24` | `10.57.0.1` | ci-runner-01 (10.57.0.63) |
-| `mgmt_seg` | `tvmgmt` | 20 | `10.57.1.0/24` | `10.57.1.1` | Authentik (10.57.1.10), step-ca (10.57.1.11), Monitoring (10.57.1.12) |
-| `edge_seg` | `tvedge` | 30 | `10.57.2.0/24` | `10.57.2.1` | Traefik (10.57.2.10) |
-| `infra_seg` | `tvinfra` | 40 | `10.57.3.0/24` | `10.57.3.1` | Harbor (10.57.3.10), apt-cacher (10.57.3.11), NetBox (10.57.3.12) |
+| `build_seg` | `tvnetc` | 10 | `192.168.10.0/24` | `192.168.10.1` | ci-runner-01 (192.168.10.63) |
+| `mgmt_seg` | `tvmgmt` | 20 | `192.168.20.0/24` | `192.168.20.1` | Authentik (192.168.20.10), step-ca (192.168.20.11), Monitoring (192.168.20.12) |
+| `edge_seg` | `tvedge` | 30 | `192.168.30.0/24` | `192.168.30.1` | Traefik (192.168.30.10) |
+| `infra_seg` | `tvinfra` | 40 | `192.168.40.0/24` | `192.168.40.1` | Harbor (192.168.40.10), apt-cacher (192.168.40.11), NetBox (192.168.40.12) |
 
 ---
 
@@ -74,10 +74,10 @@ zone:
 
 | Zone | Resolver target |
 |---|---|
-| `build_seg` | `10.57.0.1` |
-| `mgmt_seg` | `10.57.1.1` |
-| `edge_seg` | `10.57.2.1` |
-| `infra_seg` | `10.57.3.1` |
+| `build_seg` | `192.168.10.1` |
+| `mgmt_seg` | `192.168.20.1` |
+| `edge_seg` | `192.168.30.1` |
+| `infra_seg` | `192.168.40.1` |
 
 This is the intended platform contract. Public resolvers such as `1.1.1.1` are not the
 target architecture for normal LXC operation.
@@ -90,7 +90,7 @@ to a dedicated internal DNS server while clients continue querying MikroTik.
 ### 2026-04-16 runner recovery note
 
 During the greenfield `ci-runner-01` recovery, `build_seg` was missing its MikroTik VLAN
-interface initially, and router-local DNS on `10.57.0.1` did not answer during runner
+interface initially, and router-local DNS on `192.168.10.1` did not answer during runner
 bootstrap even after the VLAN and gateway were added. A temporary `dns_server: "1.1.1.1"`
 override was used to recover the runner.
 
@@ -155,11 +155,11 @@ RouterOS command baseline for this delegation model:
 Resolver-path validation baseline:
 
 ```bash
-dig @10.57.0.1 +short traefik.lab.gibbsgreatly.xyz
-dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz
-dig @10.57.2.1 +short traefik.lab.gibbsgreatly.xyz
-dig @10.57.3.1 +short traefik.lab.gibbsgreatly.xyz
-dig @10.57.1.1 +short github.com
+dig @192.168.10.1 +short traefik.lab.gibbsgreatly.xyz
+dig @192.168.20.1 +short traefik.lab.gibbsgreatly.xyz
+dig @192.168.30.1 +short traefik.lab.gibbsgreatly.xyz
+dig @192.168.40.1 +short traefik.lab.gibbsgreatly.xyz
+dig @192.168.20.1 +short github.com
 ```
 
 ---
@@ -186,8 +186,8 @@ Choose a VLAN ID and subnet that does not conflict with existing zones. Update
       vnet: tvnew
       vlan_tag: 50          # ← new VLAN ID
       alias: pve-test new segment
-      subnet: "10.57.4.0/24"
-      gateway: "10.57.4.1"
+      subnet: "192.168.50.0/24"
+      gateway: "192.168.50.1"
       snat: false           # ← always false — MikroTik handles routing
 ```
 
@@ -202,21 +202,20 @@ In the MikroTik terminal:
 
 ```text
 /interface vlan add interface=<trunk-iface> name=vlan50-new vlan-id=50
-/ip address add address=10.57.4.1/24 interface=vlan50-new comment="pve-test new_seg gw"
+/ip address add address=192.168.50.1/24 interface=vlan50-new comment="pve-test new_seg gw"
 ```
 
 Verify the new VLAN interface is up and reachable:
 
 ```bash
 # From the workstation — should respond
-ping -c 3 10.57.4.1
+ping -c 3 192.168.50.1
 ```
 
-### Step 3 — Apply SDN zone manually (Terraform code gap)
+### Step 3 — Apply SDN zone through the current automation path
 
-The `configure-network-sdn-vnet.yml` playbook currently handles Simple zone
-creation only. Use `ansible/00-initial-setup/proxmox-sdn-setup.yml` for VLAN
-zones until Terraform-side support is updated for `zone_type: vlan`.
+The current `configure-network-sdn-vnet.yml` playbook handles `zone_type: vlan`
+for `pve-test`. The remaining out-of-band prerequisite is the MikroTik side.
 
 ```bash
 # Create the SDN zone
@@ -226,7 +225,7 @@ pvesh create /cluster/sdn/zones --type vlan --zone tvnew --bridge vmbr0 --nodes 
 pvesh create /cluster/sdn/vnets --vnet tvnew --zone tvnew --tag 50
 
 # Create the subnet
-pvesh create /cluster/sdn/vnets/tvnew/subnets --subnet 10.57.4.0/24 --gateway 10.57.4.1 --type subnet
+pvesh create /cluster/sdn/vnets/tvnew/subnets --subnet 192.168.50.0/24 --gateway 192.168.50.1 --type subnet
 
 # Apply SDN config
 pvesh set /cluster/sdn
@@ -245,19 +244,19 @@ Once the zone is created and a container is deployed:
 
 ```bash
 # From a workstation — container should be reachable
-ping -c 3 10.57.4.<host>
+ping -c 3 192.168.50.<host>
 
 # From pve-test — internet egress via MikroTik
 pct exec <vmid> -- ping -c 3 8.8.8.8
 
 # Inter-zone routing — e.g. from a container in build_seg to new_seg
-pct exec 141 -- ping -c 3 10.57.4.<host>
+pct exec 141 -- ping -c 3 192.168.50.<host>
 
 # Delegated internal zone check via zone resolver
-pct exec <vmid> -- dig @10.57.<zone>.1 +short traefik.lab.gibbsgreatly.xyz
+pct exec <vmid> -- dig @192.168.<vlan-id>.1 +short traefik.lab.gibbsgreatly.xyz
 
 # Public probe check via the same resolver path
-pct exec <vmid> -- dig @10.57.<zone>.1 +short github.com
+pct exec <vmid> -- dig @192.168.<vlan-id>.1 +short github.com
 ```
 
 ---

--- a/scripts/preflight-network-refactor.sh
+++ b/scripts/preflight-network-refactor.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 _COLOUR=true
 if [[ ! -t 1 ]]; then _COLOUR=false; fi
 
-colour_on()  { [[ "$_COLOUR" == true ]] && printf '%s' "$1" || true; }
+colour_on()  { [[ "$_COLOUR" == true ]] && printf '%b' "$1" || true; }
 RED=$(    colour_on '\033[0;31m')
 GREEN=$(  colour_on '\033[0;32m')
 YELLOW=$( colour_on '\033[1;33m')

--- a/scripts/preflight-network-refactor.sh
+++ b/scripts/preflight-network-refactor.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# scripts/preflight-network-refactor.sh
+#
+# Network refactor preflight checks.
+#
+# Verifies that the router-centric provisioning prerequisites are in place
+# before running a Terraform apply, teardown, or redeploy against pve-test.
+#
+# Usage:
+#   ./with-secrets scripts/preflight-network-refactor.sh [OPTIONS] [GUEST_IP...]
+#
+# Options:
+#   --save-evidence FILE   Write a copy of the output to FILE (timestamped by
+#                          default when FILE is a directory).
+#   --no-colour            Disable ANSI colour codes (useful for log capture).
+#   --help                 Show this help.
+#
+# Positional arguments (optional):
+#   GUEST_IP...   One or more representative guest IPs to probe on TCP:22.
+#                 If none are given, a default candidate list is tried.
+#                 At least one must be reachable for the check to pass.
+#
+# Expected invocation:
+#   ./with-secrets scripts/preflight-network-refactor.sh
+#   ./with-secrets scripts/preflight-network-refactor.sh 192.168.40.11 192.168.30.10
+#   ./with-secrets scripts/preflight-network-refactor.sh \
+#       --save-evidence docs/sessions/evidence/ 192.168.40.11
+#
+# Exit codes:
+#   0  All required checks passed.
+#   1  One or more required checks failed.
+#
+# This script is read-only and non-destructive.
+# Reference: docs/network-refactor/validation-gate.md
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colour helpers
+# ---------------------------------------------------------------------------
+_COLOUR=true
+if [[ ! -t 1 ]]; then _COLOUR=false; fi
+
+colour_on()  { [[ "$_COLOUR" == true ]] && printf '%s' "$1" || true; }
+RED=$(    colour_on '\033[0;31m')
+GREEN=$(  colour_on '\033[0;32m')
+YELLOW=$( colour_on '\033[1;33m')
+BLUE=$(   colour_on '\033[0;34m')
+CYAN=$(   colour_on '\033[0;36m')
+BOLD=$(   colour_on '\033[1m')
+RESET=$(  colour_on '\033[0m')
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log_header()  { printf '\n%s%s%s\n' "${BOLD}${CYAN}" "$1" "${RESET}"; }
+log_info()    { printf '%s[INFO]%s %s\n'    "${BLUE}"   "${RESET}" "$1"; }
+log_pass()    { printf '%s[PASS]%s %s\n'    "${GREEN}"  "${RESET}" "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+log_warn()    { printf '%s[WARN]%s %s\n'    "${YELLOW}" "${RESET}" "$1"; WARN_COUNT=$((WARN_COUNT + 1)); }
+log_fail()    { printf '%s[FAIL]%s %s\n'    "${RED}"    "${RESET}" "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+log_sep()     { printf '%s\n' "----------------------------------------------------------------------"; }
+log_bigsep()  { printf '%s\n' "======================================================================"; }
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Evidence capture
+# ---------------------------------------------------------------------------
+EVIDENCE_FILE=""
+EVIDENCE_LINES=()
+
+evidence() { EVIDENCE_LINES+=("$1"); }
+
+flush_evidence() {
+    if [[ -z "$EVIDENCE_FILE" ]]; then return; fi
+    printf '%s\n' "${EVIDENCE_LINES[@]}" > "$EVIDENCE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SAVE_EVIDENCE_ARG=""
+GUEST_IPS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --save-evidence)
+            SAVE_EVIDENCE_ARG="$2"; shift 2 ;;
+        --no-colour)
+            _COLOUR=false
+            RED=""; GREEN=""; YELLOW=""; BLUE=""; CYAN=""; BOLD=""; RESET=""
+            shift ;;
+        --help)
+            grep '^#' "$0" | grep -v '^#!/' | sed 's/^# //' | sed 's/^#//'
+            exit 0 ;;
+        --)
+            shift; GUEST_IPS+=("$@"); break ;;
+        -*)
+            printf 'Unknown option: %s\n' "$1" >&2; exit 1 ;;
+        *)
+            GUEST_IPS+=("$1"); shift ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve evidence file path
+# ---------------------------------------------------------------------------
+if [[ -n "$SAVE_EVIDENCE_ARG" ]]; then
+    if [[ -d "$SAVE_EVIDENCE_ARG" ]]; then
+        EVIDENCE_FILE="${SAVE_EVIDENCE_ARG%/}/preflight-evidence-$(date +%Y%m%d-%H%M%S).txt"
+    else
+        EVIDENCE_FILE="$SAVE_EVIDENCE_ARG"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Network defaults (prefer injected env vars, then current pve-test defaults)
+# ---------------------------------------------------------------------------
+LAB_IP_APT_CACHER="${TF_VAR_lab_ip_apt_cacher:-${lab_ip_apt_cacher:-192.168.40.11}}"
+LAB_IP_PROXY="${TF_VAR_lab_ip_proxy:-${lab_ip_proxy:-192.168.30.10}}"
+LAB_IP_AUTHENTIK="${TF_VAR_lab_ip_authentik:-${lab_ip_authentik:-192.168.20.10}}"
+LAB_IP_STEP_CA="${TF_VAR_lab_ip_step_ca:-${lab_ip_step_ca:-192.168.20.11}}"
+LAB_IP_MONITORING="${TF_VAR_lab_ip_monitoring:-${lab_ip_monitoring:-192.168.20.12}}"
+LAB_IP_HARBOR="${TF_VAR_lab_ip_harbor:-${lab_ip_harbor:-192.168.40.10}}"
+LAB_IP_CI_RUNNER="${TF_VAR_lab_ip_ci_runner:-${lab_ip_ci_runner:-192.168.10.63}}"
+
+LAB_GW_BUILD="${TF_VAR_lab_gw_build:-${lab_gw_build:-192.168.10.1}}"
+LAB_GW_MGMT="${TF_VAR_lab_gw_mgmt:-${lab_gw_mgmt:-192.168.20.1}}"
+LAB_GW_EDGE="${TF_VAR_lab_gw_edge:-${lab_gw_edge:-192.168.30.1}}"
+LAB_GW_INFRA="${TF_VAR_lab_gw_infra:-${lab_gw_infra:-192.168.40.1}}"
+
+# ---------------------------------------------------------------------------
+# Default representative guest candidates (probed in order, first hit wins)
+# ---------------------------------------------------------------------------
+DEFAULT_GUEST_CANDIDATES=(
+    "${LAB_IP_APT_CACHER}"   # apt-cacher-stack (infra_seg) — usually deployed first
+    "${LAB_IP_PROXY}"        # proxy-stack / Traefik (edge_seg)
+    "${LAB_IP_AUTHENTIK}"    # authentik-stack (mgmt_seg)
+    "${LAB_IP_STEP_CA}"      # step-ca-stack (mgmt_seg)
+    "${LAB_IP_MONITORING}"   # monitoring-stack (mgmt_seg)
+    "${LAB_IP_HARBOR}"       # harbor-stack (infra_seg)
+    "${LAB_IP_CI_RUNNER}"    # ci-runner-01 (build_seg)
+)
+
+# Use CLI-provided IPs if given; otherwise use defaults.
+if [[ ${#GUEST_IPS[@]} -eq 0 ]]; then
+    GUEST_IPS=("${DEFAULT_GUEST_CANDIDATES[@]}")
+    USING_DEFAULT_GUESTS=true
+else
+    USING_DEFAULT_GUESTS=false
+fi
+
+# ---------------------------------------------------------------------------
+# SDN gateway definitions
+# ---------------------------------------------------------------------------
+declare -A SDN_GATEWAYS=(
+    [build_seg]="${LAB_GW_BUILD}"
+    [mgmt_seg]="${LAB_GW_MGMT}"
+    [edge_seg]="${LAB_GW_EDGE}"
+    [infra_seg]="${LAB_GW_INFRA}"
+)
+
+# Primary DNS-check gateway (mgmt_seg — resolver used by management containers)
+DNS_CHECK_GATEWAY="${LAB_GW_MGMT}"
+
+# ---------------------------------------------------------------------------
+# Internal DNS name to resolve (lab zone delegated through MikroTik)
+# ---------------------------------------------------------------------------
+INTERNAL_DNS_NAME="traefik.lab.gibbsgreatly.xyz"
+PUBLIC_DNS_NAME="github.com"
+
+# ---------------------------------------------------------------------------
+# Utility: TCP probe
+# ---------------------------------------------------------------------------
+tcp_probe() {
+    local host="$1" port="$2" timeout="${3:-3}"
+    timeout "$timeout" bash -c "</dev/tcp/${host}/${port}" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Utility: ICMP ping (1 packet, short timeout)
+# ---------------------------------------------------------------------------
+ping_host() {
+    local host="$1"
+    ping -c 1 -W 3 "$host" &>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+RUN_TS="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+GIT_BRANCH="$(git -C "$(dirname "$0")/.." rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+HOSTNAME_SHORT="$(hostname -s)"
+
+evidence "======================================================================"
+evidence "NETWORK REFACTOR PREFLIGHT EVIDENCE"
+evidence "Run: ${RUN_TS}"
+evidence "Host: ${HOSTNAME_SHORT}"
+evidence "Branch: ${GIT_BRANCH}"
+evidence "======================================================================"
+
+log_bigsep
+log_header "NETWORK REFACTOR PREFLIGHT"
+printf '%s  Run:    %s\n'    "${BOLD}" "${RESET}${RUN_TS}"
+printf '%s  Host:   %s\n'    "${BOLD}" "${RESET}${HOSTNAME_SHORT}"
+printf '%s  Branch: %s\n'    "${BOLD}" "${RESET}${GIT_BRANCH}"
+log_bigsep
+
+# ---------------------------------------------------------------------------
+# CHECK 1: TF_VAR_proxmox_node must equal "pve-test"
+# ---------------------------------------------------------------------------
+log_header "CHECK 1: TF_VAR_proxmox_node targeting guard"
+log_sep
+evidence ""
+evidence "[CHECK 1] TF_VAR_proxmox_node targeting guard"
+
+PROXMOX_NODE_ACTUAL="${TF_VAR_proxmox_node:-}"
+log_info "TF_VAR_proxmox_node = '${PROXMOX_NODE_ACTUAL}' (expected: pve-test)"
+evidence "  TF_VAR_proxmox_node = '${PROXMOX_NODE_ACTUAL}'"
+
+if [[ "$PROXMOX_NODE_ACTUAL" == "pve-test" ]]; then
+    log_pass "TF_VAR_proxmox_node is pve-test — targeting is correct"
+    evidence "  Status: PASS"
+else
+    log_fail "TF_VAR_proxmox_node is not 'pve-test' — stop and check your environment"
+    evidence "  Status: FAIL — expected pve-test, got '${PROXMOX_NODE_ACTUAL}'"
+    log_info "Hint: run this script via ./with-secrets scripts/preflight-network-refactor.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# CHECK 2: SDN gateway reachability from workstation
+# ---------------------------------------------------------------------------
+log_header "CHECK 2: SDN gateway reachability"
+log_sep
+evidence ""
+evidence "[CHECK 2] SDN gateway reachability (ICMP ping, 3 s timeout)"
+
+GW_PASS=0
+GW_FAIL=0
+
+for zone in build_seg mgmt_seg edge_seg infra_seg; do
+    gw="${SDN_GATEWAYS[$zone]}"
+    log_info "Pinging ${zone} gateway ${gw} ..."
+    if ping_host "$gw"; then
+        log_pass "${zone} gateway ${gw} reachable"
+        evidence "  ${gw} (${zone}): PASS"
+        GW_PASS=$((GW_PASS + 1))
+    else
+        log_fail "${zone} gateway ${gw} unreachable — MikroTik VLAN interface or route may be missing"
+        evidence "  ${gw} (${zone}): FAIL"
+        GW_FAIL=$((GW_FAIL + 1))
+    fi
+done
+
+if [[ $GW_FAIL -eq 0 ]]; then
+    evidence "  Overall: PASS (all 4 gateways reachable)"
+else
+    evidence "  Overall: FAIL (${GW_FAIL}/4 gateways unreachable)"
+fi
+
+# ---------------------------------------------------------------------------
+# CHECK 3: DNS resolution through MikroTik
+# ---------------------------------------------------------------------------
+log_header "CHECK 3: DNS resolution via MikroTik gateway (${DNS_CHECK_GATEWAY})"
+log_sep
+evidence ""
+evidence "[CHECK 3] DNS resolution via MikroTik gateway ${DNS_CHECK_GATEWAY}"
+
+DNS_PASS=0
+DNS_FAIL=0
+
+# 3a: delegated internal name
+log_info "Resolving ${INTERNAL_DNS_NAME} via ${DNS_CHECK_GATEWAY} ..."
+if command -v dig &>/dev/null; then
+    INTERNAL_RESULT="$(dig @"${DNS_CHECK_GATEWAY}" +short +timeout=5 +tries=1 "${INTERNAL_DNS_NAME}" 2>/dev/null | grep -v '^;' | head -1 || true)"
+else
+    INTERNAL_RESULT=""
+    log_warn "dig not found — skipping DNS checks (install bind-tools or dnsutils)"
+fi
+
+if [[ -n "$INTERNAL_RESULT" ]]; then
+    log_pass "${INTERNAL_DNS_NAME} resolved to ${INTERNAL_RESULT}"
+    evidence "  ${INTERNAL_DNS_NAME}: ${INTERNAL_RESULT} — PASS"
+    DNS_PASS=$((DNS_PASS + 1))
+else
+    log_fail "${INTERNAL_DNS_NAME} did not resolve via ${DNS_CHECK_GATEWAY}"
+    evidence "  ${INTERNAL_DNS_NAME}: FAIL — no answer from ${DNS_CHECK_GATEWAY}"
+    DNS_FAIL=$((DNS_FAIL + 1))
+fi
+
+# 3b: public name
+log_info "Resolving ${PUBLIC_DNS_NAME} via ${DNS_CHECK_GATEWAY} ..."
+if command -v dig &>/dev/null; then
+    PUBLIC_RESULT="$(dig @"${DNS_CHECK_GATEWAY}" +short +timeout=5 +tries=1 "${PUBLIC_DNS_NAME}" 2>/dev/null | grep -E '^[0-9]+\.' | grep -v '^;' | head -1 || true)"
+else
+    PUBLIC_RESULT=""
+fi
+
+if [[ -n "$PUBLIC_RESULT" ]]; then
+    log_pass "${PUBLIC_DNS_NAME} resolved to ${PUBLIC_RESULT} via ${DNS_CHECK_GATEWAY}"
+    evidence "  ${PUBLIC_DNS_NAME}: ${PUBLIC_RESULT} — PASS"
+    DNS_PASS=$((DNS_PASS + 1))
+else
+    log_fail "${PUBLIC_DNS_NAME} did not resolve via ${DNS_CHECK_GATEWAY} — MikroTik DNS forwarding may be broken"
+    evidence "  ${PUBLIC_DNS_NAME}: FAIL — no answer from ${DNS_CHECK_GATEWAY}"
+    DNS_FAIL=$((DNS_FAIL + 1))
+fi
+
+if [[ $DNS_FAIL -eq 0 ]]; then
+    evidence "  Overall: PASS"
+else
+    evidence "  Overall: FAIL (${DNS_FAIL} DNS checks failed)"
+fi
+
+# ---------------------------------------------------------------------------
+# CHECK 4: Direct guest reachability (TCP:22)
+# ---------------------------------------------------------------------------
+log_header "CHECK 4: Representative guest reachability (TCP:22)"
+log_sep
+evidence ""
+evidence "[CHECK 4] Representative guest reachability (TCP:22, 3 s timeout)"
+
+if [[ "$USING_DEFAULT_GUESTS" == true ]]; then
+    log_info "No guest IPs specified — probing default candidates:"
+    log_info "  ${GUEST_IPS[*]}"
+    log_info "Pass --help to see how to specify explicit IPs."
+else
+    log_info "Probing operator-specified guest IPs: ${GUEST_IPS[*]}"
+fi
+
+GUEST_REACHABLE=()
+GUEST_UNREACHABLE=()
+
+for ip in "${GUEST_IPS[@]}"; do
+    log_info "Probing ${ip} TCP:22 ..."
+    if tcp_probe "$ip" 22 3; then
+        log_pass "  ${ip} TCP:22 reachable"
+        evidence "  ${ip} TCP:22: PASS"
+        GUEST_REACHABLE+=("$ip")
+    else
+        log_info "  ${ip} TCP:22 not reachable (may not be deployed)"
+        evidence "  ${ip} TCP:22: unreachable (not deployed or port blocked)"
+        GUEST_UNREACHABLE+=("$ip")
+    fi
+done
+
+if [[ ${#GUEST_REACHABLE[@]} -ge 1 ]]; then
+    log_pass "At least one guest IP is reachable: ${GUEST_REACHABLE[*]}"
+    evidence "  Overall: PASS (${#GUEST_REACHABLE[@]} reachable: ${GUEST_REACHABLE[*]})"
+else
+    if [[ "$USING_DEFAULT_GUESTS" == true ]]; then
+        log_warn "No default candidate guest IPs are currently reachable"
+        log_warn "This may mean no stacks are deployed on pve-test yet — not a blocking failure"
+        log_warn "Re-run with explicit IPs once a stack is deployed: scripts/preflight-network-refactor.sh ${LAB_IP_APT_CACHER}"
+        evidence "  Overall: WARN — no candidate guests reachable (may not be deployed)"
+        WARN_COUNT=$((WARN_COUNT + 1))
+        # Don't increment FAIL_COUNT for default candidates; warn only
+    else
+        log_fail "None of the specified guest IPs are reachable via TCP:22"
+        evidence "  Overall: FAIL — specified guests unreachable"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+log_bigsep
+log_header "PREFLIGHT SUMMARY"
+log_sep
+
+evidence ""
+evidence "[SUMMARY]"
+evidence "  Checks passed: ${PASS_COUNT}"
+evidence "  Warnings:      ${WARN_COUNT}"
+evidence "  Checks failed: ${FAIL_COUNT}"
+
+printf '  %s%-20s%s %s%d%s\n' "${BOLD}" "Checks passed:"  "${RESET}" "${GREEN}" "$PASS_COUNT"  "${RESET}"
+printf '  %s%-20s%s %s%d%s\n' "${BOLD}" "Warnings:"       "${RESET}" "${YELLOW}" "$WARN_COUNT" "${RESET}"
+printf '  %s%-20s%s %s%d%s\n' "${BOLD}" "Checks failed:"  "${RESET}" "${RED}" "$FAIL_COUNT"    "${RESET}"
+log_sep
+
+if [[ $FAIL_COUNT -eq 0 ]]; then
+    if [[ $WARN_COUNT -eq 0 ]]; then
+        log_pass "All preflight checks passed — Session 7 representative stack validation may proceed."
+        evidence "Verdict: PASS — Session 7 may proceed"
+    else
+        log_warn "Preflight passed with warnings — review warnings before proceeding."
+        log_warn "Session 7 may proceed for stacks in zones whose gateways passed."
+        evidence "Verdict: PASS WITH WARNINGS — review before Session 7"
+    fi
+else
+    log_fail "One or more required preflight checks failed — do not proceed until resolved."
+    evidence "Verdict: FAIL — resolve failures before Session 7"
+fi
+
+log_bigsep
+
+# ---------------------------------------------------------------------------
+# Evidence file output
+# ---------------------------------------------------------------------------
+if [[ -n "$EVIDENCE_FILE" ]]; then
+    flush_evidence
+    log_info "Evidence written to: ${EVIDENCE_FILE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Exit
+# ---------------------------------------------------------------------------
+if [[ $FAIL_COUNT -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/terraform/lxc/PLATFORM_CONTRACT.md
+++ b/terraform/lxc/PLATFORM_CONTRACT.md
@@ -55,8 +55,8 @@ These are declared in `variables.tf` and may be overridden per environment:
 
 | Variable                | Default        | pve-test value  | Notes |
 |-------------------------|----------------|-----------------|-------|
-| `registry_host`         | `192.168.1.10` | `10.57.3.10`    | Harbor IP for Docker pulls |
-| `apt_cacher_host`       | `192.168.1.35` | `10.57.3.11`    | apt-cacher-ng proxy |
+| `registry_host`         | `192.168.1.10` | `192.168.40.10` | Harbor IP for Docker pulls |
+| `apt_cacher_host`       | `192.168.1.35` | `192.168.40.11` | apt-cacher-ng proxy |
 | `portainer_server_ip`   | `192.168.1.4`  | `${lab_ip_portainer}`    | Portainer server for app-tier endpoint registration |
 
 `registry_host` and `apt_cacher_host` now flow through `variables.tf` →
@@ -87,7 +87,7 @@ change to field names or semantics as a platform API change affecting all stacks
 | Field              | Type   | Notes |
 |--------------------|--------|-------|
 | `hostname`         | string | LXC hostname |
-| `ip_address`       | string | CIDR notation (e.g. `10.57.3.10/24`) |
+| `ip_address`       | string | CIDR notation (e.g. `192.168.40.10/24`) |
 | `deployment_tier`  | string | Explicit orchestration tier: `platform` or `apps` |
 | `dns_server`       | string | Guest resolver written into `/etc/resolv.conf`; set explicitly in every stack |
 
@@ -108,6 +108,7 @@ change to field names or semantics as a platform API change affecting all stacks
 | `template_profile`    | string  | Falls back to `storage/<env>.yaml` defaults and maps to template storage |
 | `tags`                | list    | Defaults to `[stack_name]` |
 | `network.zone`        | string  | Optional; when omitted, the stack uses bridge defaults rather than network intent |
+| `network.access_path` | string  | Optional; allowed values are `direct` and `proxyjump_compat`; defaults to `direct` for `sdn_vnet` attachments and `proxyjump_compat` for bridge/default path |
 | `ansible_playbook`    | string  | Playbook name consumed by `scripts/provision.sh` during the explicit Ansible phase |
 | `portainer_agent`     | bool    | Defaults to `false`; relevant for app-tier/legacy Portainer cleanup behavior only |
 | `keyctl`              | bool    | Defaults to `false` |
@@ -186,8 +187,8 @@ apt_cacher_host = try(local.stack.apt_cacher_host, var.apt_cacher_host)
 
 `.env.pve-test` — add (if not already present):
 ```
-export TF_VAR_registry_host=10.57.3.10
-export TF_VAR_apt_cacher_host=10.57.3.11
+export TF_VAR_registry_host=192.168.40.10
+export TF_VAR_apt_cacher_host=192.168.40.11
 ```
 
 ### 2. Parameterize apt proxy in `lxc_base`

--- a/terraform/lxc/ansible/playbooks/configure-keyctl.yml
+++ b/terraform/lxc/ansible/playbooks/configure-keyctl.yml
@@ -2,18 +2,21 @@
 # Delegates pct commands to the Proxmox host, then waits for the
 # container to come back online after reboot.
 #
-# Required inventory vars: vmid, pve_host
+# Required inventory vars: vmid
+# Optional inventory vars: pve_host
 # Optional inventory vars: pve_ssh_user (default: root)
 ---
 - name: Configure keyctl feature flag on LXC container
   hosts: all
   gather_facts: false
+  vars:
+    proxmox_delegate_host: "{{ pve_host | default(lookup('env', 'PVE_TEST_FQDN'), true) | default('pve-test.gibbsgreatly.xyz', true) }}"
 
   tasks:
     - name: Set keyctl feature flag via pct
       ansible.builtin.command:
         cmd: "pct set {{ vmid }} -features nesting=1,keyctl=1"
-      delegate_to: "{{ pve_host }}"
+      delegate_to: "{{ proxmox_delegate_host }}"
       vars:
         ansible_user: "{{ pve_ssh_user | default('root') }}"
         ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
@@ -23,7 +26,7 @@
     - name: Reboot container to apply feature flags
       ansible.builtin.command:
         cmd: "pct reboot {{ vmid }}"
-      delegate_to: "{{ pve_host }}"
+      delegate_to: "{{ proxmox_delegate_host }}"
       vars:
         ansible_user: "{{ pve_ssh_user | default('root') }}"
         ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -54,6 +54,7 @@ locals {
   # current bridge defaults unless they opt in with stack.network.zone.
   stack_network                 = try(local.stack.network, null)
   stack_network_zone            = try(local.stack.network.zone, null)
+  requested_network_access_path = try(local.stack.network.access_path, null)
   effective_proxmox_node        = try(local.stack.proxmox_node, var.proxmox_node)
   storage_manifest_default_path = "${local.lxc_root}/storage/${local.effective_proxmox_node}.yaml"
   effective_storage_manifest_path = coalesce(
@@ -133,8 +134,15 @@ locals {
   resolved_sdn_snat             = local.resolved_sdn_attachment != null ? try(local.resolved_sdn_attachment.snat, null) : null
   effective_dns_server          = coalesce(try(local.stack.dns_server, null), local.resolved_sdn_gateway, try(local.stack.gateway, null), var.default_gateway)
 
+  normalized_network_access_path = local.requested_network_access_path == null ? null : try(lower(trimspace(local.requested_network_access_path)), null)
+  # Session 4 migration contract:
+  # - sdn_vnet defaults to direct SSH
+  # - bridge/default path preserves ProxyJump compatibility behavior
+  effective_network_access_path = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? coalesce(local.normalized_network_access_path, "direct") : coalesce(local.normalized_network_access_path, "proxyjump_compat")
+
   effective_target_node = local.stack_network_zone != null ? local.network_intent.proxmox.target_node : try(local.stack.target_node, local.effective_proxmox_node)
   effective_pve_host    = local.stack_network_zone != null ? local.network_intent.proxmox.pve_host : try(local.stack.proxmox_host, var.proxmox_host)
+  use_proxyjump         = local.effective_network_access_path == "proxyjump_compat" && local.effective_pve_host != ""
 
   effective_network_bridge = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.bridge, "vmbr0") : try(local.stack.network_bridge, "vmbr0")
   effective_vlan_tag       = local.resolved_zone_attachment != null ? try(local.resolved_zone_attachment.vlan_tag, null) : null
@@ -244,6 +252,20 @@ check "network_layer_attachment_type_is_supported" {
   assert {
     condition     = local.stack_network_zone == null || contains(["bridge", "sdn_vnet"], local.resolved_attachment_type)
     error_message = "Network intent attachments must use type 'bridge' or 'sdn_vnet'."
+  }
+}
+
+check "network_access_path_is_supported" {
+  assert {
+    condition     = local.normalized_network_access_path == null || contains(["direct", "proxyjump_compat"], local.normalized_network_access_path)
+    error_message = "stack.network.access_path must be either 'direct' or 'proxyjump_compat' when set."
+  }
+}
+
+check "network_access_path_proxyjump_requires_pve_host" {
+  assert {
+    condition     = local.effective_network_access_path != "proxyjump_compat" || local.effective_pve_host != ""
+    error_message = "stack.network.access_path is 'proxyjump_compat' but no pve_host is available for ProxyJump."
   }
 }
 
@@ -531,6 +553,8 @@ resource "local_file" "ansible_inventory" {
     app_stack_name      = coalesce(var.stack_app_name, try(local.stack.app_stack_name, null), local.stack_name)
     vmid                = module.lxc.container_id
     pve_host            = local.effective_pve_host
+    ssh_access_mode     = local.effective_network_access_path
+    use_proxyjump       = local.use_proxyjump
   })
 }
 
@@ -581,37 +605,6 @@ resource "local_file" "network_firewall_vars" {
     network_firewall_target     = local.effective_target_node
     network_firewall_pve_host   = local.effective_pve_host
   })
-
-  depends_on = [module.lxc]
-}
-
-# ---------------------------------------------------------------------------
-# Ensure the Proxmox host can reach SDN-attached guests for Ansible
-# provisioning. Without a direct route, ProxyJump sessions to VNet-backed
-# containers follow the LAN default route and fail with "No route to host".
-# ---------------------------------------------------------------------------
-resource "null_resource" "prime_sdn_host_route" {
-  count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && try(local.stack.ansible_playbook, "") != "" && local.effective_pve_host != "" ? 1 : 0
-
-  triggers = {
-    container_id = module.lxc.container_id
-    guest_ip     = replace(module.lxc.ip_address, "/24", "")
-    pve_host     = local.effective_pve_host
-    subnet       = local.resolved_sdn_subnet
-    bridge       = local.effective_network_bridge
-    host_ip      = cidrhost(local.resolved_sdn_subnet, 254)
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      ssh -F /dev/null \
-        -o BatchMode=yes \
-        -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null \
-        'root@${local.effective_pve_host}' \
-        'ip addr replace ${cidrhost(local.resolved_sdn_subnet, 254)}/${split("/", local.resolved_sdn_subnet)[1]} dev ${local.effective_network_bridge} && ip route replace ${local.resolved_sdn_subnet} dev ${local.effective_network_bridge} src ${cidrhost(local.resolved_sdn_subnet, 254)} && ip route get ${replace(module.lxc.ip_address, "/24", "")}'
-    EOT
-  }
 
   depends_on = [module.lxc]
 }

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -52,14 +52,11 @@
 #   Then on the host: ifreload -a
 #   Verify: bridge vlan show
 #
-# Code gap: configure-network-sdn-vnet.yml currently handles Simple zone
-# creation only. It must be updated to support zone_type: vlan before
-# these zones can be applied via Terraform. Until then, run
-# ansible/00-initial-setup/proxmox-sdn-setup.yml or apply manually:
-#   pvesh create /cluster/sdn/zones --type vlan --zone <zone> --bridge vmbr0 --nodes pve-test
-#   pvesh create /cluster/sdn/vnets --vnet <vnet> --zone <zone> --tag <vlan_id>
-#   pvesh create /cluster/sdn/vnets/<vnet>/subnets --subnet <cidr> --gateway <gw> --type subnet
-#   pvesh set /cluster/sdn
+# Automation note: `configure-network-sdn-vnet.yml` now handles
+# `zone_type: vlan` for `pve-test` SDN attachment creation. The remaining
+# out-of-band dependency is the MikroTik side: VLAN interfaces, gateway IPs,
+# DNS behavior, and firewall policy must already exist before stack
+# provisioning relies on direct routed access.
 
 proxmox:
   target_node: pve-test

--- a/terraform/lxc/network/pve-test.yaml
+++ b/terraform/lxc/network/pve-test.yaml
@@ -11,10 +11,10 @@
 # Physical setup:
 #   pve-test (laptop) NIC → MikroTik trunk port
 #     Untagged (native): LAN — 192.168.1.0/24
-#     Tagged VLAN 10: build_seg — 10.57.0.0/24, gw 10.57.0.1
-#     Tagged VLAN 20: mgmt_seg  — 10.57.1.0/24, gw 10.57.1.1
-#     Tagged VLAN 30: edge_seg  — 10.57.2.0/24, gw 10.57.2.1
-#     Tagged VLAN 40: infra_seg — 10.57.3.0/24, gw 10.57.3.1
+#     Tagged VLAN 10: build_seg — 192.168.10.0/24, gw 192.168.10.1
+#     Tagged VLAN 20: mgmt_seg  — 192.168.20.0/24, gw 192.168.20.1
+#     Tagged VLAN 30: edge_seg  — 192.168.30.0/24, gw 192.168.30.1
+#     Tagged VLAN 40: infra_seg — 192.168.40.0/24, gw 192.168.40.1
 #
 # MikroTik one-time setup (run once before the first SDN stack is deployed):
 #   # Replace <trunk-iface> with the interface facing pve-test (active baseline: ether5)
@@ -22,27 +22,27 @@
 #   /interface vlan add interface=<trunk-iface> name=vlan20-mgmt  vlan-id=20
 #   /interface vlan add interface=<trunk-iface> name=vlan30-edge  vlan-id=30
 #   /interface vlan add interface=<trunk-iface> name=vlan40-infra vlan-id=40
-#   /ip address add address=10.57.0.1/24 interface=vlan10-build comment="pve-test build_seg gw"
-#   /ip address add address=10.57.1.1/24 interface=vlan20-mgmt  comment="pve-test mgmt_seg gw"
-#   /ip address add address=10.57.2.1/24 interface=vlan30-edge  comment="pve-test edge_seg gw"
-#   /ip address add address=10.57.3.1/24 interface=vlan40-infra comment="pve-test infra_seg gw"
+#   /ip address add address=192.168.10.1/24 interface=vlan10-build comment="pve-test build_seg gw"
+#   /ip address add address=192.168.20.1/24 interface=vlan20-mgmt  comment="pve-test mgmt_seg gw"
+#   /ip address add address=192.168.30.1/24 interface=vlan30-edge  comment="pve-test edge_seg gw"
+#   /ip address add address=192.168.40.1/24 interface=vlan40-infra comment="pve-test infra_seg gw"
 #   # Delegate lab.gibbsgreatly.xyz — baseline: static A records on MikroTik.
 #   # Apply with admin credentials (api-user is read-only by design).
 #   # For each internal platform name, add a static A record:
-#   /ip dns static add name=traefik.lab.gibbsgreatly.xyz type=A address=10.57.2.10 ttl=5m comment=lab-zone-baseline
+#   /ip dns static add name=traefik.lab.gibbsgreatly.xyz type=A address=192.168.30.10 ttl=5m comment=lab-zone-baseline
 #   # Or via the REST API using environment variables for credentials:
 #   #   curl -sk --user "$MIKROTIK_ADMIN:$MIKROTIK_ADMIN_PASSWORD" \
 #   #     -X POST https://192.168.1.251/rest/ip/dns/static/add \
 #   #     -H "Content-Type: application/json" \
-#   #     -d '{"name":"traefik.lab.gibbsgreatly.xyz","type":"A","address":"10.57.2.10","ttl":"5m","comment":"lab-zone-baseline"}'
+#   #     -d '{"name":"traefik.lab.gibbsgreatly.xyz","type":"A","address":"192.168.30.10","ttl":"5m","comment":"lab-zone-baseline"}'
 #   # When an internal authoritative DNS server is available, replace with FWD type:
 #   #   /ip dns static add regexp="(^|\\.)lab\\.gibbsgreatly\\.xyz$" type=FWD forward-to=<internal-auth-dns-ip> comment="delegate-lab-zone"
 #   # Verify delegation and resolver behavior from each SDN gateway path:
-#   # dig @10.57.0.1 +short traefik.lab.gibbsgreatly.xyz
-#   # dig @10.57.1.1 +short traefik.lab.gibbsgreatly.xyz
-#   # dig @10.57.2.1 +short traefik.lab.gibbsgreatly.xyz
-#   # dig @10.57.3.1 +short traefik.lab.gibbsgreatly.xyz
-#   # dig @10.57.1.1 +short github.com
+#   # dig @192.168.10.1 +short traefik.lab.gibbsgreatly.xyz
+#   # dig @192.168.20.1 +short traefik.lab.gibbsgreatly.xyz
+#   # dig @192.168.30.1 +short traefik.lab.gibbsgreatly.xyz
+#   # dig @192.168.40.1 +short traefik.lab.gibbsgreatly.xyz
+#   # dig @192.168.20.1 +short github.com
 #   # Inter-VLAN routing uses the MikroTik routing table (routes added automatically
 #   # for directly-connected VLAN interfaces). Enforce zone policies in the MikroTik
 #   # firewall — see policies section at the bottom of this file.
@@ -64,13 +64,11 @@ proxmox:
 
 attachments:
   # -------------------------------------------------------------------------
-  # vmbr0 — Bootstrap exception (Portainer only)
+  # vmbr0 — Legacy bridge attachment
   #
-  # Portainer (VMID 20020) — native bridge exception retained for documentation only
-  #   Bootstrap dependency: Portainer is deployed before any SDN zone exists,
-  #   so it cannot be placed in an SDN zone. All other services run in named
-  #   SDN zones. Access is controlled via Authentik forward-auth (Phase 04)
-  #   rather than network segmentation.
+  # This attachment remains only for legacy/test stacks that still use the
+  # default bridge path. Portainer now runs on `mgmt_seg`; it is no longer an
+  # active exception to the SDN zone model.
   # -------------------------------------------------------------------------
   lan:
     description: Default LAN bridge — used only by legacy/test stacks (test-lxc, test-docker).
@@ -81,13 +79,13 @@ attachments:
     firewall: true
 
   # -------------------------------------------------------------------------
-  # infra_seg — Infrastructure artifact services (VLAN 40, 10.57.3.0/24)
+  # infra_seg — Infrastructure artifact services (VLAN 40, 192.168.40.0/24)
   #
   # Purpose: Registry, artifact cache, and IPAM. Deployed early in the build
   #   sequence (second, after Portainer) because all other zones depend on
   #   Harbor for image pulls and apt-cacher for apt proxy.
-  # Gateway: MikroTik VLAN 40 interface (10.57.3.1)
-  # Containers: Harbor (10.57.3.10), apt-cacher (10.57.3.11), NetBox (10.57.3.12)
+  # Gateway: MikroTik VLAN 40 interface (192.168.40.1)
+  # Containers: Harbor (192.168.40.10), apt-cacher (192.168.40.11), NetBox (192.168.40.12)
   # Bootstrap note: Harbor's first deployment on a fresh pass pulls from
   #   Docker Hub directly. All subsequent containers pull from Harbor.
   # -------------------------------------------------------------------------
@@ -110,12 +108,12 @@ attachments:
       snat: false
 
   # -------------------------------------------------------------------------
-  # mgmt_seg — Management plane (VLAN 20, 10.57.1.0/24)
+  # mgmt_seg — Management plane (VLAN 20, 192.168.20.0/24)
   #
   # Purpose: Identity, PKI, and observability.
-  # Gateway: MikroTik VLAN 20 interface (10.57.1.1)
-  # Containers: Authentik (10.57.1.10), step-ca (10.57.1.11),
-  #             Monitoring (10.57.1.12)
+  # Gateway: MikroTik VLAN 20 interface (192.168.20.1)
+  # Containers: Authentik (192.168.20.10), step-ca (192.168.20.11),
+  #             Monitoring (192.168.20.12)
   # Cross-zone: Reachable from edge_seg (Traefik forward-auth) and build_seg
   #   (metrics/log push). step-ca httpChallenge requires outbound to edge_seg:80.
   # -------------------------------------------------------------------------
@@ -138,12 +136,12 @@ attachments:
       snat: false
 
   # -------------------------------------------------------------------------
-  # edge_seg — Public ingress (VLAN 30, 10.57.2.0/24)
+  # edge_seg — Public ingress (VLAN 30, 192.168.30.0/24)
   #
   # Purpose: The only ingress path from the LAN into internal services.
-  # Gateway: MikroTik VLAN 30 interface (10.57.2.1)
-  # Containers: Traefik (10.57.2.10)
-  # LAN access: Workstation reaches Traefik at 10.57.2.10:80/443 via
+  # Gateway: MikroTik VLAN 30 interface (192.168.30.1)
+  # Containers: Traefik (192.168.30.10)
+  # LAN access: Workstation reaches Traefik at 192.168.30.10:80/443 via
   #   MikroTik VLAN routing — no additional static routes required.
   # -------------------------------------------------------------------------
   edge_seg:
@@ -165,11 +163,11 @@ attachments:
       snat: false
 
   # -------------------------------------------------------------------------
-  # build_seg — CI build workloads (VLAN 10, 10.57.0.0/24)
+  # build_seg — CI build workloads (VLAN 10, 192.168.10.0/24)
   #
   # Purpose: Self-hosted CI runner execution environment.
-  # Gateway: MikroTik VLAN 10 interface (10.57.0.1)
-  # Containers: ci-runner-01 (10.57.0.63, VMID 10063)
+  # Gateway: MikroTik VLAN 10 interface (192.168.10.1)
+  # Containers: ci-runner-01 (192.168.10.63, VMID 10063)
   # -------------------------------------------------------------------------
   seg_c:
     description: CI build workload zone

--- a/terraform/lxc/templates/inventory.tpl
+++ b/terraform/lxc/templates/inventory.tpl
@@ -6,11 +6,12 @@ all:
           ansible_host: ${ip_address}
           ansible_user: root
           ansible_ssh_private_key_file: ${ssh_key}
-%{ if pve_host != "" ~}
+%{ if use_proxyjump ~}
           ansible_ssh_common_args: '-F /dev/null -o ProxyJump=root@${pve_host} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 %{ else ~}
           ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 %{ endif ~}
+          ssh_access_mode: ${ssh_access_mode}
           portainer_server_ip: ${portainer_server_ip}
           registry_host: "${registry_host}"
           apt_cacher_host: ${apt_cacher_host}
@@ -26,7 +27,7 @@ all:
           ansible_playbook: ${ansible_playbook}
 %{ endif ~}
           vmid: ${vmid}
-%{ if pve_host != "" ~}
+%{ if use_proxyjump ~}
           pve_host: ${pve_host}
 %{ endif ~}
 %{ if app_stack_name != "" ~}


### PR DESCRIPTION
## Summary
- remove the Proxmox host-route priming workaround from the active SDN provisioning model
- switch SDN-backed inventories to direct routed guest access by default and keep only explicit compatibility behavior where needed
- add the network refactor runbook, preflight tooling, representative validation evidence, and teardown/redeploy gate results

## Validation
- full teardown and redeploy validation passed on pve-test
- representative validation passed for apt-cacher-stack, dns-stack, and proxy-stack
- browser verification completed for 4 services after teardown
- `/home/steve/.local/bin/snyk iac test terraform/`
- `./with-secrets /home/steve/.local/bin/sonar-scanner`

## Key evidence
- `docs/network-refactor/session-8-summary.md` records the passed teardown/redeploy gate
- `scripts/preflight-network-refactor.sh` now validates the current VLAN-based addressing model
- `terraform/lxc/ansible/playbooks/configure-keyctl.yml` falls back to the Proxmox FQDN for delegated `pct` operations without restoring the old route hack
