### PR TITLE
fix(teardown): resolve post-cycle health-check and Harbor sysadmin blockers

### DIFF
--- a/docs/code-cleanup/sprint-plan.md
+++ b/docs/code-cleanup/sprint-plan.md
@@ -10,15 +10,15 @@
 
 | Session | Status | Branch / PR | Notes |
 |---|---|---|---|
-| CC-1 | **Partial** | `fix/sonar-suppressions` / PR #366 | CC-1f (#362) and CC-1g (#363) still open |
-| CC-2 | **Partial** | — | #355 #357 #361 closed; #356 (ruff lint) still open |
+| CC-1 | **Done** | `fix/sonar-suppressions` / PR #366 | #362 #363 closed 2026-06-15 |
+| CC-2 | **Done** | — | #355 #356 #357 #361 closed |
 | CC-3 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #359 closed |
 | CC-4 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #364 closed |
 | CC-5 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #365 closed |
 
 **`baseline/teardown-validated` is at `009e2b3` (teardown-validated 2026-06-14).**
 
-**Remaining open issues:** #362 (CC-1f), #363 (CC-1g), #356 (CC-2a-c)
+**All code-cleanup issues closed. Sprint complete.**
 
 See [findings.md](findings.md) for full classification rationale.
 See [docs/plan/sprint-plan.md](../plan/sprint-plan.md) for the main

--- a/docs/code-cleanup/sprint-plan.md
+++ b/docs/code-cleanup/sprint-plan.md
@@ -6,6 +6,20 @@
 **Prerequisite:** PR #358 (`fix/ci-pipeline-cleanup`) must merge first —
   it adds the `python-lint` CI job that gates sessions CC-1 and CC-2.
 
+## Sprint status (updated 2026-06-14)
+
+| Session | Status | Branch / PR | Notes |
+|---|---|---|---|
+| CC-1 | **Partial** | `fix/sonar-suppressions` / PR #366 | CC-1f (#362) and CC-1g (#363) still open |
+| CC-2 | **Partial** | — | #355 #357 #361 closed; #356 (ruff lint) still open |
+| CC-3 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #359 closed |
+| CC-4 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #364 closed |
+| CC-5 | **Done** | `fix/cognitive-complexity-cc5` / PR #370 | #365 closed |
+
+**`baseline/teardown-validated` is at `009e2b3` (teardown-validated 2026-06-14).**
+
+**Remaining open issues:** #362 (CC-1f), #363 (CC-1g), #356 (CC-2a-c)
+
 See [findings.md](findings.md) for full classification rationale.
 See [docs/plan/sprint-plan.md](../plan/sprint-plan.md) for the main
 infrastructure sprint; CC-3 is absorbed into that sprint's Session 2.
@@ -310,9 +324,10 @@ Closes [#361](https://github.com/stevedwray/proxmox-homelab/issues/361).
 
 ---
 
-## Session CC-3 — Authentik API HTTPS (absorbed into main sprint Session 2)
+## Session CC-3 — Authentik API HTTPS ✓ DONE
 
-**Branch:** `fix/tls-hardening` (main sprint Session 2)
+**Branch:** `fix/cognitive-complexity-cc5` / PR #370 (merged 2026-06-14)
+**Originally planned as:** `fix/tls-hardening` (main sprint Session 2)
 **Live infra required:** Yes — pve-test-vm must be up
 **Promotion gate:** Authentik playbook redeploy succeeds; no `ansible:S5332`
   findings for credential-carrying API calls; Authentik SSO still works
@@ -357,9 +372,10 @@ Closes [#359](https://github.com/stevedwray/proxmox-homelab/issues/359).
 
 ---
 
-## Session CC-4 — NetBox cognitive complexity
+## Session CC-4 — NetBox cognitive complexity ✓ DONE
 
-**Branch:** `fix/cognitive-complexity-netbox` from `baseline/teardown-validated`
+**Branch:** `fix/cognitive-complexity-cc5` / PR #370 (merged 2026-06-14)
+**Originally planned as:** `fix/cognitive-complexity-netbox` from `baseline/teardown-validated`
 **Live infra required:** No (unit tests provide the gate)
 **Promotion gate:** All existing tests in `test_populate_paths.py`,
   `test_populate_multi_source.py`, `test_augment.py` pass; no function in
@@ -417,9 +433,10 @@ helper. Extract per-object-type helpers following the same pattern as
 
 ---
 
-## Session CC-5 — Authentik reconciler and Harbor tooling complexity
+## Session CC-5 — Authentik reconciler and Harbor tooling complexity ✓ DONE
 
-**Branch:** `fix/cognitive-complexity-reconciler` from `baseline/teardown-validated`
+**Branch:** `fix/cognitive-complexity-cc5` / PR #370 (merged 2026-06-14)
+**Originally planned as:** `fix/cognitive-complexity-reconciler` from `baseline/teardown-validated`
 **Live infra required:** No (existing unit tests gate the reconciler;
   harbor tooling has no live dependency for the refactor itself)
 **Promotion gate:** No function in the target files exceeds complexity 40

--- a/scripts/check-proxmox-status.sh
+++ b/scripts/check-proxmox-status.sh
@@ -77,6 +77,7 @@ run_check() {
         if [[ "$optional" == "true" ]]; then
             log_warning "$check_name (optional - may need setup)"
             CHECKS_TOTAL=$((CHECKS_TOTAL - 1)) # Don't count optional failures
+            return 0
         else
             log_error "$check_name"
         fi
@@ -325,8 +326,11 @@ case "${1:-}" in
             return 0
         }
         ;;
+    "")
+        # No option; run main normally
+        ;;
     *)
-        echo "Unknown option: ${1}" >&2
+        echo "Unknown option: ${1:-}" >&2
         echo "Run '$0 --help' for usage." >&2
         exit 1
         ;;

--- a/terraform/lxc/ansible/files/harbor_findings_exporter.py
+++ b/terraform/lxc/ansible/files/harbor_findings_exporter.py
@@ -258,6 +258,103 @@ class SnapshotStore:
             return json.dumps(payload, default=str)
 
 
+def _determine_scan_state(
+    report: dict | None,
+    severity_counts: Counter[str],
+    last_scan_ts: float | None,
+    now: float,
+    scan_stale_after: int,
+) -> str:
+    if not report and not severity_counts:
+        return "unscanned"
+    if last_scan_ts is not None and now - last_scan_ts > scan_stale_after:
+        return "stale"
+    return "scanned"
+
+
+def _scanner_name_from_report(report_value: dict) -> str:
+    scanner = report_value.get("scanner")
+    if isinstance(scanner, dict):
+        return scanner.get("name") or scanner.get("vendor") or ""
+    return scanner or report_value.get("scanner_name") or ""
+
+
+def _extract_vuln_ids(vuln: dict) -> tuple[str, str]:
+    cve = vuln.get("vuln_id") or vuln.get("id") or vuln.get("vulnerability_id") or vuln.get("CVE") or vuln.get("cve") or ""
+    pkg = vuln.get("pkg_name") or vuln.get("package") or vuln.get("name") or ""
+    return cve, pkg
+
+
+def _extract_vuln_versions(vuln: dict) -> tuple[str, str]:
+    installed = vuln.get("installed_version") or vuln.get("pkg_version") or vuln.get("installedVersion") or vuln.get("version") or ""
+    fixed = vuln.get("fixed_version") or vuln.get("fix_version") or vuln.get("fixedVersion") or ""
+    return installed, fixed
+
+
+def _extract_vuln_text(vuln: dict) -> tuple[str, str, list[str] | str]:
+    severity = vuln.get("severity") or "Unknown"
+    summary = vuln.get("title") or vuln.get("description") or vuln.get("summary") or ""
+    links = vuln.get("links") or vuln.get("references") or []
+    return severity, summary, links
+
+
+def _extract_vuln_link(links: list[str] | str) -> str:
+    if isinstance(links, str):
+        return links
+    return links[0] if links else ""
+
+
+def _parse_vuln_entry(
+    project: str,
+    repository: str,
+    tag: str,
+    digest: str,
+    push_time: Any,
+    scanner_name: str,
+    generated_at: Any,
+    vuln: dict,
+) -> tuple[tuple, dict]:
+    cve, pkg = _extract_vuln_ids(vuln)
+    installed, fixed = _extract_vuln_versions(vuln)
+    severity, summary, links = _extract_vuln_text(vuln)
+    link = _extract_vuln_link(links)
+    key = (project, repository, digest, pkg, cve)
+    row = {
+        "project": project, "repository": repository, "tag": tag, "digest": digest,
+        "artifact_push_time": push_time, "scan_completed_at": generated_at or None,
+        "scanner": scanner_name, "cve_id": cve, "severity": severity,
+        "package": pkg, "installed_version": installed, "fixed_version": fixed,
+        "link": link, "summary": summary,
+    }
+    return key, row
+
+
+def _build_vuln_findings_rows(
+    project: str,
+    repository: str,
+    digest: str,
+    selected: dict,
+    artifacts: list,
+    vuln_payload: dict,
+) -> list[dict]:
+    rows: list[dict] = []
+    seen: set = set()
+    tag = _artifact_tag_name(selected, artifacts)
+    push_time = selected.get("push_time") or selected.get("extra_attrs", {}).get("created")
+    for _report_name, report_value in (vuln_payload or {}).items():
+        if not isinstance(report_value, dict):
+            continue
+        scanner_name = _scanner_name_from_report(report_value)
+        generated_at = report_value.get("generated_at")
+        for vuln in report_value.get("vulnerabilities") or []:
+            key, row = _parse_vuln_entry(project, repository, tag, digest, push_time, scanner_name, generated_at, vuln)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(row)
+    return rows
+
+
 class HarborFindingsExporter:
     def __init__(self) -> None:
         self.projects = [project.strip() for project in _env("HARBOR_FINDINGS_PROJECTS", "dockerhub,ghcr,quay,lscr").split(",") if project.strip()]
@@ -270,6 +367,92 @@ class HarborFindingsExporter:
             insecure=_parse_bool("HARBOR_API_INSECURE", default=False),
         )
         self.snapshot = SnapshotStore()
+
+    def _resolve_severity_and_timestamp(
+        self,
+        project: str,
+        repository: str,
+        digest: str,
+        report: dict | None,
+        severity_counts: Counter[str],
+        last_scan_ts: float | None,
+        lines: list[str],
+    ) -> tuple[Counter[str], float | None, dict | None, bool]:
+        if severity_counts or report:
+            return severity_counts, last_scan_ts, None, False
+        try:
+            payload = self.client.get_vulnerabilities(project, repository, digest)
+        except Exception:
+            lines.append(_metric_line(
+                "harbor_findings_repository_info", 1,
+                {"project": project, "repository": repository, "state": "error", "digest": digest},
+            ))
+            return Counter(), last_scan_ts, None, True
+        severity_counts = _severity_counts_from_vulnerability_payload(payload)
+        for report_value in (payload or {}).values():
+            if isinstance(report_value, dict):
+                last_scan_ts = _parse_rfc3339(report_value.get("generated_at")) or last_scan_ts
+                break
+        return severity_counts, last_scan_ts, payload, False
+
+    def _collect_repository_metrics(
+        self,
+        project: str,
+        repository: str,
+        now: float,
+        lines: list[str],
+        project_state_counts: dict,
+        findings_rows: list[dict],
+    ) -> None:
+        try:
+            artifacts = self.client.list_artifacts(project, repository)
+        except Exception:
+            project_state_counts[project]["error"] += 1
+            lines.append(_metric_line(
+                "harbor_findings_repository_info", 1,
+                {"project": project, "repository": repository, "state": "error", "digest": ""},
+            ))
+            return
+        selected = _choose_repository_artifact(artifacts)
+        if selected is None:
+            return
+        digest = selected.get("digest", "")
+        report = _scan_report_from_overview(selected)
+        severity_counts = _severity_counts_from_scan_overview(report)
+        last_scan_ts = _parse_rfc3339(report.get("end_time") if report else None)
+        severity_counts, last_scan_ts, api_payload, had_error = self._resolve_severity_and_timestamp(
+            project, repository, digest, report, severity_counts, last_scan_ts, lines,
+        )
+        if had_error:
+            project_state_counts[project]["error"] += 1
+            return
+        state = _determine_scan_state(report, severity_counts, last_scan_ts, now, self.scan_stale_after)
+        project_state_counts[project][state] += 1
+        lines.append(_metric_line(
+            "harbor_findings_repository_info", 1,
+            {"project": project, "repository": repository, "state": state, "digest": digest},
+        ))
+        if last_scan_ts is not None:
+            lines.append(_metric_line(
+                "harbor_findings_repository_last_scan_timestamp_seconds", last_scan_ts,
+                {"project": project, "repository": repository, "digest": digest},
+            ))
+        for severity in SEVERITIES:
+            count = int(severity_counts.get(severity, 0))
+            if count == 0:
+                continue
+            lines.append(_metric_line(
+                "harbor_findings_vulnerabilities_total", count,
+                {"project": project, "repository": repository, "severity": severity},
+            ))
+        vuln_payload = api_payload
+        if vuln_payload is None:
+            try:
+                vuln_payload = self.client.get_vulnerabilities(project, repository, digest)
+            except Exception:
+                vuln_payload = None
+        if vuln_payload:
+            findings_rows.extend(_build_vuln_findings_rows(project, repository, digest, selected, artifacts, vuln_payload))
 
     def _collect_metrics(self) -> tuple[str, list[dict[str, Any]]]:
         findings_rows: list[dict[str, Any]] = []
@@ -284,165 +467,23 @@ class HarborFindingsExporter:
             "# HELP harbor_findings_vulnerabilities_total Harbor vulnerability counts by repository and severity.",
             "# TYPE harbor_findings_vulnerabilities_total gauge",
         ]
-
         project_state_counts: dict[str, Counter[str]] = defaultdict(Counter)
-
         for project in self.projects:
             repositories = self.client.list_repositories(project)
             for repository_item in repositories:
                 repository_name = repository_item.get("name", "")
                 prefix = f"{project}/"
-                repository = repository_name[len(prefix) :] if repository_name.startswith(prefix) else repository_name
+                repository = repository_name[len(prefix):] if repository_name.startswith(prefix) else repository_name
                 if not repository:
                     continue
-
-                try:
-                    artifacts = self.client.list_artifacts(project, repository)
-                except Exception:
-                    project_state_counts[project]["error"] += 1
-                    lines.append(
-                        _metric_line(
-                            "harbor_findings_repository_info",
-                            1,
-                            {"project": project, "repository": repository, "state": "error", "digest": ""},
-                        )
-                    )
-                    continue
-
-                selected = _choose_repository_artifact(artifacts)
-                if selected is None:
-                    continue
-
-                digest = selected.get("digest", "")
-                report = _scan_report_from_overview(selected)
-                severity_counts = _severity_counts_from_scan_overview(report)
-                last_scan_ts = _parse_rfc3339(report.get("end_time") if report else None)
-
-                if not severity_counts and not report:
-                    try:
-                        payload = self.client.get_vulnerabilities(project, repository, digest)
-                    except Exception:
-                        payload = None
-                        project_state_counts[project]["error"] += 1
-                        lines.append(
-                            _metric_line(
-                                "harbor_findings_repository_info",
-                                1,
-                                {"project": project, "repository": repository, "state": "error", "digest": digest},
-                            )
-                        )
-                        continue
-                    severity_counts = _severity_counts_from_vulnerability_payload(payload)
-                    for report_value in (payload or {}).values():
-                        if isinstance(report_value, dict):
-                            last_scan_ts = _parse_rfc3339(report_value.get("generated_at")) or last_scan_ts
-                            break
-
-                state = "unscanned"
-                if report or severity_counts:
-                    state = "scanned"
-                    if last_scan_ts is not None and now - last_scan_ts > self.scan_stale_after:
-                        state = "stale"
-
-                project_state_counts[project][state] += 1
-                lines.append(
-                    _metric_line(
-                        "harbor_findings_repository_info",
-                        1,
-                        {"project": project, "repository": repository, "state": state, "digest": digest},
-                    )
-                )
-
-                if last_scan_ts is not None:
-                    lines.append(
-                        _metric_line(
-                            "harbor_findings_repository_last_scan_timestamp_seconds",
-                            last_scan_ts,
-                            {"project": project, "repository": repository, "digest": digest},
-                        )
-                    )
-
-                for severity in SEVERITIES:
-                    count = int(severity_counts.get(severity, 0))
-                    if count == 0:
-                        continue
-                    lines.append(
-                        _metric_line(
-                            "harbor_findings_vulnerabilities_total",
-                            count,
-                            {"project": project, "repository": repository, "severity": severity},
-                        )
-                    )
-
-                # Attempt to fetch full vulnerability payload for detailed rows.
-                vuln_payload = None
-                try:
-                    vuln_payload = self.client.get_vulnerabilities(project, repository, digest)
-                except Exception:
-                    vuln_payload = None
-
-                # Build detailed findings rows from vulnerability payload when present.
-                if vuln_payload:
-                    seen = set()
-                    tag_name = _artifact_tag_name(selected, artifacts)
-                    for report_name, report_value in (vuln_payload or {}).items():
-                        if not isinstance(report_value, dict):
-                            continue
-                        scanner = report_value.get("scanner")
-                        if isinstance(scanner, dict):
-                            scanner_name = scanner.get("name") or scanner.get("vendor") or ""
-                        else:
-                            scanner_name = scanner or report_value.get("scanner_name") or ""
-                        generated_at = report_value.get("generated_at")
-                        for vuln in report_value.get("vulnerabilities") or []:
-                            # Try multiple common keys for fields.
-                            cve = vuln.get("vuln_id") or vuln.get("id") or vuln.get("vulnerability_id") or vuln.get("CVE") or vuln.get("cve") or ""
-                            pkg = vuln.get("pkg_name") or vuln.get("package") or vuln.get("name") or ""
-                            installed = vuln.get("installed_version") or vuln.get("pkg_version") or vuln.get("installedVersion") or vuln.get("version") or ""
-                            fixed = vuln.get("fixed_version") or vuln.get("fix_version") or vuln.get("fixedVersion") or ""
-                            severity = vuln.get("severity") or "Unknown"
-                            summary = vuln.get("title") or vuln.get("description") or vuln.get("summary") or ""
-                            links = vuln.get("links") or vuln.get("references") or []
-                            if isinstance(links, str):
-                                link = links
-                            else:
-                                link = links[0] if links else ""
-                            push_time = selected.get("push_time") or selected.get("extra_attrs", {}).get("created") or None
-
-                            key = (project, repository, digest, pkg, cve)
-                            if key in seen:
-                                continue
-                            seen.add(key)
-
-                            row = {
-                                "project": project,
-                                "repository": repository,
-                                "tag": tag_name,
-                                "digest": digest,
-                                "artifact_push_time": push_time,
-                                "scan_completed_at": generated_at or None,
-                                "scanner": scanner_name,
-                                "cve_id": cve,
-                                "severity": severity,
-                                "package": pkg,
-                                "installed_version": installed,
-                                "fixed_version": fixed,
-                                "link": link,
-                                "summary": summary,
-                            }
-                            findings_rows.append(row)
-
+                self._collect_repository_metrics(project, repository, now, lines, project_state_counts, findings_rows)
         for project, counts in project_state_counts.items():
             for state in ("scanned", "unscanned", "stale", "error"):
-                lines.append(
-                    _metric_line(
-                        "harbor_findings_repositories_total",
-                        int(counts.get(state, 0)),
-                        {"project": project, "state": state},
-                    )
-                )
-
-        # attach findings rows to exporter snapshot by returning it alongside
+                lines.append(_metric_line(
+                    "harbor_findings_repositories_total",
+                    int(counts.get(state, 0)),
+                    {"project": project, "state": state},
+                ))
         return "\n".join(lines), findings_rows
 
     def refresh_forever(self) -> None:

--- a/terraform/lxc/ansible/roles/harbor_postconfigure/files/harbor_scan_smoke.py
+++ b/terraform/lxc/ansible/roles/harbor_postconfigure/files/harbor_scan_smoke.py
@@ -338,6 +338,65 @@ def _trigger_manual_scan_all(base_url: str, username: str, password: str) -> str
     return "already-running" if status == 409 else "started"
 
 
+def _fetch_child_manifests(
+    registry_url: str,
+    project: str,
+    repository: str,
+    manifests: list,
+    username: str,
+    password: str,
+    registry_insecure: bool,
+) -> None:
+    for child in manifests:
+        digest = child.get("digest")
+        if digest:
+            try:
+                _fetch_registry_manifest(registry_url, project, repository, digest, username, password, registry_insecure=registry_insecure)
+            except Exception:
+                pass
+
+
+def _collect_blob_candidates(mjson: dict | None) -> list[str]:
+    if not isinstance(mjson, dict):
+        return []
+    candidates = []
+    for layer in mjson.get("layers", []) or []:
+        d = layer.get("digest")
+        if d:
+            candidates.append(d)
+    return candidates
+
+
+def _fetch_blobs(registry_url: str, project: str, repository: str, candidates: list[str], registry_insecure: bool) -> None:
+    for digest in candidates:
+        try:
+            _request(f"{registry_url}/v2/{project}/{repository}/blobs/{digest}", insecure=registry_insecure)
+        except Exception:
+            pass
+
+
+def _populate_harbor_cache(registry_url: str, manifest_body: str, project: str, repository: str, username: str, password: str, registry_insecure: bool) -> None:
+    try:
+        mjson: dict | None = json.loads(manifest_body)
+    except Exception:
+        mjson = None
+
+    if isinstance(mjson, dict) and mjson.get("manifests"):
+        _fetch_child_manifests(registry_url, project, repository, mjson.get("manifests", []), username, password, registry_insecure)
+    else:
+        try:
+            if mjson is None:
+                mjson = json.loads(manifest_body)
+        except Exception:
+            mjson = None
+
+    try:
+        candidates = _collect_blob_candidates(mjson)
+        _fetch_blobs(registry_url, project, repository, candidates, registry_insecure)
+    except Exception:
+        pass
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -386,62 +445,8 @@ def main() -> int:
     except Exception:
         pulled = False
 
-    # If no OCI client was available or the pull failed, try explicitly
-    # fetching referenced child manifests and blobs to force Harbor to
-    # materialize the proxy-cached artifact. This is more aggressive than a
-    # manifest-only probe and often triggers Harbor to fetch upstream layers.
     if not pulled and manifest_body:
-        try:
-            mjson = json.loads(manifest_body)
-        except Exception:
-            mjson = None
-
-        if isinstance(mjson, dict) and mjson.get("manifests"):
-            # manifest list: fetch each child manifest by digest
-            for child in mjson.get("manifests", []):
-                digest = child.get("digest")
-                if digest:
-                    try:
-                        _fetch_registry_manifest(
-                            registry_url,
-                            args.project,
-                            args.repository,
-                            digest,
-                            args.username,
-                            args.password,
-                            registry_insecure=args.registry_insecure,
-                        )
-                    except Exception:
-                        pass
-        else:
-            # single manifest — parse layers below
-            try:
-                # ensure we have a manifest JSON for layer extraction
-                if mjson is None:
-                    mjson = json.loads(manifest_body)
-            except Exception:
-                mjson = None
-
-        # Attempt to GET each blob referenced by the manifest (or child manifests)
-        try:
-            candidates = []
-            if isinstance(mjson, dict):
-                # OCI/Docker manifest: 'layers' key
-                for layer in mjson.get("layers", []) or []:
-                    d = layer.get("digest")
-                    if d:
-                        candidates.append(d)
-
-            for digest in candidates:
-                try:
-                    _request(
-                        f"{registry_url}/v2/{args.project}/{args.repository}/blobs/{digest}",
-                        insecure=args.registry_insecure,
-                    )
-                except Exception:
-                    pass
-        except Exception:
-            pass
+        _populate_harbor_cache(registry_url, manifest_body, args.project, args.repository, args.username, args.password, args.registry_insecure)
 
     parent_artifact = None
     while time.monotonic() < deadline:

--- a/terraform/lxc/ansible/roles/harbor_postconfigure/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/harbor_postconfigure/tasks/main.yml
@@ -278,6 +278,57 @@
   delegate_to: localhost
   no_log: true
 
+- name: Warn — OIDC steve user not found; sysadmin deferred to first login
+  ansible.builtin.debug:
+    msg: >-
+      Harbor OIDC user '{{ harbor_postconfigure_steve_username }}' does not exist yet.
+      This is normal on a fresh deploy — the account is created on first OIDC login.
+      Harbor is configured with oidc_admin_group='{{ harbor_postconfigure_oidc_admin_group }}'.
+      On first login, if the oidc_admin_group feature grants sysadmin automatically, no further
+      action is needed. If not, re-run this postconfigure playbook after the first OIDC login
+      to apply the sysadmin assignment.
+  when:
+    - harbor_postconfigure_oidc_enabled
+    - (harbor_postconfigure_steve_candidates | default([]) | length) == 0
+  delegate_to: localhost
+
+- name: Verify Harbor OIDC admin group is configured for deferred sysadmin
+  ansible.builtin.uri:
+    url: "http://{{ harbor_postconfigure_host }}:{{ harbor_postconfigure_port }}/api/v2.0/configurations"
+    method: GET
+    url_username: "{{ harbor_postconfigure_admin_user }}"
+    url_password: "{{ harbor_postconfigure_admin_password }}"
+    force_basic_auth: true
+    status_code: 200
+  register: harbor_postconfigure_config_verify
+  when:
+    - harbor_postconfigure_oidc_enabled
+    - (harbor_postconfigure_steve_candidates | default([]) | length) == 0
+  delegate_to: localhost
+  no_log: true
+
+- name: Assert Harbor OIDC admin group matches expected value
+  ansible.builtin.assert:
+    that:
+      - >-
+        (
+          harbor_postconfigure_config_verify.json.oidc_admin_group.value
+          | default('')
+        ) == harbor_postconfigure_oidc_admin_group
+    fail_msg: >-
+      Harbor oidc_admin_group is '{{
+        harbor_postconfigure_config_verify.json.oidc_admin_group.value | default('(not set)')
+      }}' but expected '{{ harbor_postconfigure_oidc_admin_group }}'.
+      Sysadmin will NOT be granted automatically on first login. Fix the OIDC configuration.
+    success_msg: >-
+      Harbor oidc_admin_group='{{ harbor_postconfigure_oidc_admin_group }}' confirmed.
+      Sysadmin will be granted on first OIDC login for members of that group.
+  when:
+    - harbor_postconfigure_oidc_enabled
+    - (harbor_postconfigure_steve_candidates | default([]) | length) == 0
+    - harbor_postconfigure_config_verify is not skipped
+  delegate_to: localhost
+
 # -----------------------------------------------------------------------
 # Docker Hub proxy cache registry endpoint
 # -----------------------------------------------------------------------

--- a/terraform/lxc/reconcile-authentik-edge.py
+++ b/terraform/lxc/reconcile-authentik-edge.py
@@ -126,6 +126,14 @@ class ReconcileResult:
         }
 
 
+@dataclass(frozen=True)
+class _Prereqs:
+    auth_pk: str | None
+    inval_pk: str | None
+    signing_pk: str | None
+    scope_ids: list[str] | None
+
+
 class AuthentikApiClient:
     """Minimal Authentik client with read + create/update support."""
 
@@ -926,6 +934,391 @@ def _validate_forwardauth_endpoint_serving(
     return tuple(issues)
 
 
+def _call_create_provider(client: Any, intent: RouteIntent, payload: dict[str, Any]) -> dict[str, Any]:
+    if intent.auth_mode == "forwardAuth":
+        return client.create_proxy_provider(payload)
+    return client.create_oauth2_provider(payload)
+
+
+def _call_update_provider(client: Any, intent: RouteIntent, provider_id: str, patch: dict[str, Any]) -> dict[str, Any]:
+    if intent.auth_mode == "forwardAuth":
+        return client.update_proxy_provider(provider_id, patch)
+    return client.update_oauth2_provider(provider_id, patch)
+
+
+def _handle_delete_reports_for_intent(
+    intent: RouteIntent,
+    applications: list[dict[str, Any]],
+    providers: list[dict[str, Any]],
+    actions: list[ReconcileAction],
+    consumed: dict[str, set[str]],
+    stop_conditions: list[str],
+) -> None:
+    app_matches, provider_matches, route_stops = _resolve_delete_reports(intent, applications, providers)
+    stop_conditions.extend(route_stops)
+    _reason = "route auth mode is not Authentik-managed; object would be deleted in cleanup task"
+    for app in app_matches:
+        app_id = _as_id(app)
+        if app_id:
+            consumed["application"].add(app_id)
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="application", object_name=_DISCOVER._get_name(app),
+            operation="delete-report", reason=_reason, object_id=app_id,
+        ))
+    for provider in provider_matches:
+        provider_id = _as_id(provider)
+        if provider_id:
+            consumed["provider"].add(provider_id)
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="provider", object_name=_DISCOVER._get_name(provider),
+            operation="delete-report", reason=_reason, object_id=provider_id,
+        ))
+
+
+def _resolve_intent_provider_payload(
+    intent: RouteIntent,
+    authorization_flow_pk: str,
+    invalidation_flow_pk: str,
+    oidc_signing_key_pk: str | None,
+    oidc_scope_property_mapping_ids: list[str] | None,
+) -> tuple[dict[str, Any] | None, ReconcileIssue | None]:
+    if intent.auth_mode == "forwardAuth":
+        return _provider_payload(
+            intent,
+            authorization_flow_pk=authorization_flow_pk,
+            invalidation_flow_pk=invalidation_flow_pk,
+        ), None
+    client_secret, secret_issue = _oidc_provider_secret(intent)
+    if secret_issue is not None:
+        return None, secret_issue
+    assert client_secret is not None
+    return _oidc_provider_payload(
+        intent,
+        authorization_flow_pk=authorization_flow_pk,
+        invalidation_flow_pk=invalidation_flow_pk,
+        client_secret=client_secret,
+        signing_key_pk=oidc_signing_key_pk,
+        property_mapping_ids=oidc_scope_property_mapping_ids,
+    ), None
+
+
+def _reconcile_provider_for_intent(
+    client: Any,
+    intent: RouteIntent,
+    provider_obj: dict[str, Any] | None,
+    provider_payload: dict[str, Any],
+    route_stops: list[str],
+    stop_conditions: list[str],
+    apply: bool,
+    actions: list[ReconcileAction],
+    providers: list[dict[str, Any]],
+    consumed: dict[str, set[str]],
+) -> tuple[dict[str, Any] | None, int, str | None]:
+    write_count = 0
+    if provider_obj is None:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="provider", object_name=intent.provider_name,
+            operation="create", reason="owned provider is missing",
+        ))
+        if apply and not route_stops and not stop_conditions:
+            created = _call_create_provider(client, intent, provider_payload)
+            write_count += 1
+            providers.append(created)
+            provider_obj = created
+        return provider_obj, write_count, None
+
+    provider_id = _as_id(provider_obj)
+    if provider_id:
+        consumed["provider"].add(provider_id)
+    provider_patch = _patch_from_existing(provider_obj, provider_payload)
+    if provider_patch:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="provider", object_name=intent.provider_name,
+            operation="update", reason="owned provider differs from desired state",
+            object_id=provider_id,
+        ))
+        if apply and not route_stops and not stop_conditions and provider_id:
+            updated = _call_update_provider(client, intent, provider_id, provider_patch)
+            write_count += 1
+            provider_obj.update(updated)
+    else:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="provider", object_name=intent.provider_name,
+            operation="noop", reason="owned provider already matches desired state",
+            object_id=provider_id,
+        ))
+    return provider_obj, write_count, provider_id
+
+
+def _reconcile_application_for_intent(
+    client: Any,
+    intent: RouteIntent,
+    app_obj: dict[str, Any] | None,
+    app_payload: dict[str, Any],
+    route_stops: list[str],
+    stop_conditions: list[str],
+    apply: bool,
+    actions: list[ReconcileAction],
+    applications: list[dict[str, Any]],
+    consumed: dict[str, set[str]],
+) -> int:
+    write_count = 0
+    if app_obj is None:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="application", object_name=intent.app_name,
+            operation="create", reason="owned application is missing",
+        ))
+        if apply and not route_stops and not stop_conditions:
+            created = client.create_application(app_payload)
+            write_count += 1
+            applications.append(created)
+            created_id = _as_id(created)
+            if created_id:
+                consumed["application"].add(created_id)
+        return write_count
+
+    app_id = _as_id(app_obj)
+    app_patch = _patch_from_existing(app_obj, app_payload)
+    if app_patch:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="application", object_name=intent.app_name,
+            operation="update", reason="owned application differs from desired state",
+            object_id=app_id,
+        ))
+        if apply and not route_stops and not stop_conditions and app_id:
+            app_slug = app_obj.get("slug") or intent.app_slug
+            updated = client.update_application(app_slug, app_patch)
+            write_count += 1
+            app_obj.update(updated)
+    else:
+        actions.append(ReconcileAction(
+            stack=intent.stack, route=intent.route,
+            object_kind="application", object_name=intent.app_name,
+            operation="noop", reason="owned application already matches desired state",
+            object_id=app_id,
+        ))
+    return write_count
+
+
+def _build_outpost_update_patch(
+    shared_outpost: dict[str, Any],
+    required_provider_ids: set[str],
+) -> tuple[dict[str, Any], str]:
+    linked = _DISCOVER._provider_references(shared_outpost)
+    missing_links = sorted(required_provider_ids - linked)
+    desired_links = sorted(linked | required_provider_ids)
+    outpost_config = shared_outpost.get("config")
+    outpost_config = outpost_config if isinstance(outpost_config, dict) else {}
+    desired_config = dict(outpost_config)
+    config_changed = False
+    for key, value in OUTPOST_DEFAULT_CONFIG.items():
+        if outpost_config.get(key) in (None, ""):
+            desired_config[key] = value
+            config_changed = True
+    patch: dict[str, Any] = {}
+    reason_parts: list[str] = []
+    if missing_links:
+        patch["providers"] = desired_links
+        reason_parts.append("shared outpost missing provider links")
+    if config_changed:
+        patch["config"] = desired_config
+        reason_parts.append("shared outpost host config missing required values")
+    return patch, "; ".join(reason_parts) if reason_parts else ""
+
+
+def _reconcile_shared_outpost(
+    client: Any,
+    outposts: list[dict[str, Any]],
+    required_provider_ids: set[str],
+    apply: bool,
+    stop_conditions: list[str],
+    actions: list[ReconcileAction],
+    consumed: dict[str, set[str]],
+) -> tuple[list[dict[str, Any]], int]:
+    write_count = 0
+    shared_outpost, outpost_stop = _find_single_shared_outpost(outposts)
+    if outpost_stop:
+        stop_conditions.append(outpost_stop)
+        return outposts, 0
+    if shared_outpost is None:
+        actions.append(ReconcileAction(
+            stack="_shared", route="forwardAuth",
+            object_kind="outpost", object_name=SHARED_FORWARD_OUTPOST,
+            operation="create", reason="shared forward-auth outpost is missing",
+        ))
+        if apply and not stop_conditions:
+            created = client.create_outpost({
+                "name": SHARED_FORWARD_OUTPOST,
+                "type": SHARED_OUTPOST_TYPE,
+                "providers": sorted(required_provider_ids),
+                "config": OUTPOST_DEFAULT_CONFIG,
+            })
+            write_count += 1
+            outposts.append(created)
+        return outposts, write_count
+
+    outpost_id = _as_id(shared_outpost)
+    if outpost_id:
+        consumed["outpost"].add(outpost_id)
+    outpost_patch, reason = _build_outpost_update_patch(shared_outpost, required_provider_ids)
+    if outpost_patch:
+        actions.append(ReconcileAction(
+            stack="_shared", route="forwardAuth",
+            object_kind="outpost", object_name=SHARED_FORWARD_OUTPOST,
+            operation="update", reason=reason, object_id=outpost_id,
+        ))
+        if apply and not stop_conditions and outpost_id:
+            updated = client.update_outpost(outpost_id, outpost_patch)
+            write_count += 1
+            shared_outpost.update(updated)
+    else:
+        actions.append(ReconcileAction(
+            stack="_shared", route="forwardAuth",
+            object_kind="outpost", object_name=SHARED_FORWARD_OUTPOST,
+            operation="noop", reason="shared outpost already linked to all managed providers",
+            object_id=outpost_id,
+        ))
+    return outposts, write_count
+
+
+def _check_app_provider_link(
+    app_obj: dict[str, Any] | None,
+    provider_id: str | None,
+    intent: "RouteIntent",
+    consumed: dict[str, set[str]],
+    stop_conditions: list[str],
+) -> None:
+    if app_obj is None:
+        return
+    app_id = _as_id(app_obj)
+    if app_id:
+        consumed["application"].add(app_id)
+    linked_provider = _DISCOVER._get_provider_id_from_application(app_obj)
+    if linked_provider and provider_id and linked_provider != provider_id:
+        stop_conditions.append(f"{intent.stack}/{intent.route}: application links a different provider id")
+
+
+def _detect_unmanaged_orphans(
+    applications: list[dict[str, Any]],
+    providers: list[dict[str, Any]],
+    intents: list[Any],
+    consumed: dict[str, set[str]],
+    stop_conditions: list[str],
+) -> None:
+    for item in applications:
+        item_id = _as_id(item)
+        if not item_id or item_id in consumed["application"]:
+            continue
+        name = _DISCOVER._get_name(item)
+        if _DISCOVER._is_owned_object(name) and any(f"edge-{intent.stack}-" in name for intent in intents):
+            stop_conditions.append(f"unmanaged owned application detected: {name}")
+    for item in providers:
+        item_id = _as_id(item)
+        if not item_id or item_id in consumed["provider"]:
+            continue
+        name = _DISCOVER._get_name(item)
+        if _DISCOVER._is_owned_object(name) and any(f"edge-{intent.stack}-" in name for intent in intents):
+            stop_conditions.append(f"unmanaged owned provider detected: {name}")
+
+
+def _process_intent(
+    client: Any,
+    intent: Any,
+    applications: list[dict[str, Any]],
+    providers: list[dict[str, Any]],
+    actions: list[ReconcileAction],
+    issues: list[ReconcileIssue],
+    stop_conditions: list[str],
+    consumed: dict[str, set[str]],
+    required_provider_ids: set[str],
+    prereqs: _Prereqs,
+    apply: bool,
+) -> int:
+    if intent.stack == "authentik-stack" and intent.auth_mode == "forwardAuth":
+        stop_conditions.append(f"{intent.stack}/{intent.route}: Authentik self-route must not use forwardAuth")
+        return 0
+    if intent.auth_mode not in {"forwardAuth", "oidc"}:
+        _handle_delete_reports_for_intent(intent, applications, providers, actions, consumed, stop_conditions)
+        return 0
+    if intent.auth_mode == "forwardAuth":
+        app_obj, provider_obj, route_stops = _resolve_forwardauth_candidates(intent, applications, providers)
+    else:
+        if not _DISCOVER._oidc_route_supported(intent):
+            issues.append(ReconcileIssue(
+                code="AKR005",
+                message=f"native OIDC route {intent.stack}/{intent.route} has no repo-managed Authentik mapping",
+                manifest=intent.manifest, route=intent.route,
+                object_kind="provider", object_name=intent.provider_name,
+            ))
+            return 0
+        app_obj, provider_obj, route_stops = _resolve_oidc_candidates(intent, applications, providers)
+    stop_conditions.extend(route_stops)
+    provider_payload, payload_issue = _resolve_intent_provider_payload(
+        intent, prereqs.auth_pk, prereqs.inval_pk, prereqs.signing_pk, prereqs.scope_ids,
+    )
+    if payload_issue is not None:
+        issues.append(payload_issue)
+        return 0
+    provider_obj, wc, provider_id = _reconcile_provider_for_intent(
+        client, intent, provider_obj, provider_payload, route_stops, stop_conditions, apply, actions, providers, consumed,
+    )
+    write_count = wc
+    provider_id = _as_id(provider_obj) if provider_obj is not None else provider_id
+    if provider_id:
+        required_provider_ids.add(provider_id)
+        consumed["provider"].add(provider_id)
+    _check_app_provider_link(app_obj, provider_id, intent, consumed, stop_conditions)
+    write_count += _reconcile_application_for_intent(
+        client, intent, app_obj, _application_payload(intent, provider_id),
+        route_stops, stop_conditions, apply, actions, applications, consumed,
+    )
+    return write_count
+
+
+def _resolve_prerequisite_ids(
+    client: Any,
+    intents: list[Any],
+    authorization_flow_slug_override: str | None,
+    invalidation_flow_slug_override: str | None,
+) -> tuple[_Prereqs | None, tuple[ReconcileIssue, ...] | None]:
+    has_managed = any(intent.auth_mode in {"forwardAuth", "oidc"} for intent in intents)
+    has_oidc = any(intent.auth_mode == "oidc" for intent in intents)
+    auth_pk = inval_pk = None
+    if has_managed:
+        flow_ids, flow_issues = _resolve_proxy_flow_ids(
+            client,
+            authorization_flow_slug_override=authorization_flow_slug_override,
+            invalidation_flow_slug_override=invalidation_flow_slug_override,
+        )
+        if flow_issues:
+            return None, flow_issues
+        assert flow_ids is not None
+        auth_pk, inval_pk = flow_ids
+    signing_pk: str | None = None
+    scope_ids: tuple[str, ...] | None = None
+    if has_oidc:
+        signing_pk, signing_issue = _resolve_oidc_signing_key_id(
+            client,
+            signing_key_name_override=_resolve_slug_override(OIDC_SIGNING_KEY_NAME_ENV),
+        )
+        if signing_issue is not None:
+            return None, (signing_issue,)
+        assert signing_pk is not None
+        raw_scope_ids, scope_mapping_issue = _resolve_oidc_scope_property_mapping_ids(client)
+        if scope_mapping_issue is not None:
+            return None, (scope_mapping_issue,)
+        assert raw_scope_ids is not None
+        scope_ids = list(raw_scope_ids)
+    return _Prereqs(auth_pk=auth_pk, inval_pk=inval_pk, signing_pk=signing_pk, scope_ids=scope_ids), None
+
+
 def reconcile_authentik(
     manifest_paths: list[Path],
     client: Any,
@@ -967,381 +1360,42 @@ def reconcile_authentik(
     write_count = 0
     consumed: dict[str, set[str]] = {"application": set(), "provider": set(), "outpost": set()}
     required_provider_ids: set[str] = set()
-    has_managed_authentik = any(intent.auth_mode in {"forwardAuth", "oidc"} for intent in intents)
-    has_oidc_managed = any(intent.auth_mode == "oidc" for intent in intents)
 
-    authorization_flow_pk: str | None = None
-    invalidation_flow_pk: str | None = None
-    if has_managed_authentik:
-        flow_ids, flow_issues = _resolve_proxy_flow_ids(
-            client,
-            authorization_flow_slug_override=authorization_flow_slug_override,
-            invalidation_flow_slug_override=invalidation_flow_slug_override,
+    prereqs, prereq_issues = _resolve_prerequisite_ids(
+        client, intents, authorization_flow_slug_override, invalidation_flow_slug_override,
+    )
+    if prereq_issues is not None:
+        return ReconcileResult(
+            apply=apply,
+            actions=(),
+            issues=prereq_issues,
+            stop_conditions=(),
+            request_methods=tuple(client.request_methods),
+            write_count=0,
         )
-        if flow_issues:
-            return ReconcileResult(
-                apply=apply,
-                actions=(),
-                issues=flow_issues,
-                stop_conditions=(),
-                request_methods=tuple(client.request_methods),
-                write_count=0,
-            )
-        assert flow_ids is not None
-        authorization_flow_pk, invalidation_flow_pk = flow_ids
-
-    oidc_signing_key_pk: str | None = None
-    oidc_scope_property_mapping_ids: list[str] | None = None
-    if has_oidc_managed:
-        oidc_signing_key_pk, signing_issue = _resolve_oidc_signing_key_id(
-            client,
-            signing_key_name_override=_resolve_slug_override(OIDC_SIGNING_KEY_NAME_ENV),
-        )
-        if signing_issue is not None:
-            return ReconcileResult(
-                apply=apply,
-                actions=(),
-                issues=(signing_issue,),
-                stop_conditions=(),
-                request_methods=tuple(client.request_methods),
-                write_count=0,
-            )
-        assert oidc_signing_key_pk is not None
-        oidc_scope_property_mapping_ids, scope_mapping_issue = _resolve_oidc_scope_property_mapping_ids(client)
-        if scope_mapping_issue is not None:
-            return ReconcileResult(
-                apply=apply,
-                actions=(),
-                issues=(scope_mapping_issue,),
-                stop_conditions=(),
-                request_methods=tuple(client.request_methods),
-                write_count=0,
-            )
-        assert oidc_scope_property_mapping_ids is not None
+    assert prereqs is not None
 
     intents = sorted(intents, key=lambda item: (item.stack, item.route, item.host))
     for intent in intents:
-        if intent.stack == "authentik-stack" and intent.auth_mode == "forwardAuth":
-            stop_conditions.append(
-                f"{intent.stack}/{intent.route}: Authentik self-route must not use forwardAuth"
-            )
-            continue
+        write_count += _process_intent(
+            client, intent, applications, providers, actions, issues,
+            stop_conditions, consumed, required_provider_ids, prereqs, apply,
+        )
 
-        if intent.auth_mode not in {"forwardAuth", "oidc"}:
-            app_matches, provider_matches, route_stops = _resolve_delete_reports(
-                intent,
-                applications,
-                providers,
-            )
-            stop_conditions.extend(route_stops)
-            for app in app_matches:
-                app_id = _as_id(app)
-                if app_id:
-                    consumed["application"].add(app_id)
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="application",
-                        object_name=_DISCOVER._get_name(app),
-                        operation="delete-report",
-                        reason="route auth mode is not Authentik-managed; object would be deleted in cleanup task",
-                        object_id=app_id,
-                    )
-                )
-            for provider in provider_matches:
-                provider_id = _as_id(provider)
-                if provider_id:
-                    consumed["provider"].add(provider_id)
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="provider",
-                        object_name=_DISCOVER._get_name(provider),
-                        operation="delete-report",
-                        reason="route auth mode is not Authentik-managed; object would be deleted in cleanup task",
-                        object_id=provider_id,
-                    )
-                )
-            continue
+    has_forwardauth = any(intent.auth_mode == "forwardAuth" for intent in intents)
+    if has_forwardauth:
+        outposts, wc = _reconcile_shared_outpost(
+            client, outposts, required_provider_ids, apply, stop_conditions, actions, consumed,
+        )
+        write_count += wc
 
-        if intent.auth_mode == "forwardAuth":
-            app_obj, provider_obj, route_stops = _resolve_forwardauth_candidates(intent, applications, providers)
-        else:
-            if not _DISCOVER._oidc_route_supported(intent):
-                issues.append(
-                    ReconcileIssue(
-                        code="AKR005",
-                        message=f"native OIDC route {intent.stack}/{intent.route} has no repo-managed Authentik mapping",
-                        manifest=intent.manifest,
-                        route=intent.route,
-                        object_kind="provider",
-                        object_name=intent.provider_name,
-                    )
-                )
-                continue
-            app_obj, provider_obj, route_stops = _resolve_oidc_candidates(intent, applications, providers)
-        stop_conditions.extend(route_stops)
-
-        assert authorization_flow_pk is not None
-        assert invalidation_flow_pk is not None
-        if intent.auth_mode == "forwardAuth":
-            provider_payload = _provider_payload(
-                intent,
-                authorization_flow_pk=authorization_flow_pk,
-                invalidation_flow_pk=invalidation_flow_pk,
-            )
-        else:
-            client_secret, secret_issue = _oidc_provider_secret(intent)
-            if secret_issue is not None:
-                issues.append(secret_issue)
-                continue
-            assert client_secret is not None
-            provider_payload = _oidc_provider_payload(
-                intent,
-                authorization_flow_pk=authorization_flow_pk,
-                invalidation_flow_pk=invalidation_flow_pk,
-                client_secret=client_secret,
-                signing_key_pk=oidc_signing_key_pk,
-                property_mapping_ids=oidc_scope_property_mapping_ids,
-            )
-        provider_id: str | None = None
-
-        if provider_obj is None:
-            actions.append(
-                ReconcileAction(
-                    stack=intent.stack,
-                    route=intent.route,
-                    object_kind="provider",
-                    object_name=intent.provider_name,
-                    operation="create",
-                    reason="owned provider is missing",
-                )
-            )
-            if apply and not route_stops and not stop_conditions:
-                if intent.auth_mode == "forwardAuth":
-                    created = client.create_proxy_provider(provider_payload)
-                else:
-                    created = client.create_oauth2_provider(provider_payload)
-                write_count += 1
-                providers.append(created)
-                provider_obj = created
-        else:
-            provider_id = _as_id(provider_obj)
-            if provider_id:
-                consumed["provider"].add(provider_id)
-            provider_patch = _patch_from_existing(provider_obj, provider_payload)
-            if provider_patch:
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="provider",
-                        object_name=intent.provider_name,
-                        operation="update",
-                        reason="owned provider differs from desired state",
-                        object_id=provider_id,
-                    )
-                )
-                if apply and not route_stops and not stop_conditions and provider_id:
-                    if intent.auth_mode == "forwardAuth":
-                        updated = client.update_proxy_provider(provider_id, provider_patch)
-                    else:
-                        updated = client.update_oauth2_provider(provider_id, provider_patch)
-                    write_count += 1
-                    provider_obj.update(updated)
-            else:
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="provider",
-                        object_name=intent.provider_name,
-                        operation="noop",
-                        reason="owned provider already matches desired state",
-                        object_id=provider_id,
-                    )
-                )
-
-        provider_id = _as_id(provider_obj) if provider_obj is not None else provider_id
-        if provider_id:
-            required_provider_ids.add(provider_id)
-            consumed["provider"].add(provider_id)
-
-        if app_obj is not None:
-            app_id = _as_id(app_obj)
-            if app_id:
-                consumed["application"].add(app_id)
-            linked_provider = _DISCOVER._get_provider_id_from_application(app_obj)
-            if linked_provider and provider_id and linked_provider != provider_id:
-                stop_conditions.append(
-                    f"{intent.stack}/{intent.route}: application links a different provider id"
-                )
-
-        app_payload = _application_payload(intent, provider_id)
-        if app_obj is None:
-            actions.append(
-                ReconcileAction(
-                    stack=intent.stack,
-                    route=intent.route,
-                    object_kind="application",
-                    object_name=intent.app_name,
-                    operation="create",
-                    reason="owned application is missing",
-                )
-            )
-            if apply and not route_stops and not stop_conditions:
-                created = client.create_application(app_payload)
-                write_count += 1
-                applications.append(created)
-                created_id = _as_id(created)
-                if created_id:
-                    consumed["application"].add(created_id)
-        else:
-            app_id = _as_id(app_obj)
-            app_patch = _patch_from_existing(app_obj, app_payload)
-            if app_patch:
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="application",
-                        object_name=intent.app_name,
-                        operation="update",
-                        reason="owned application differs from desired state",
-                        object_id=app_id,
-                    )
-                )
-                if apply and not route_stops and not stop_conditions and app_id:
-                    app_slug = app_obj.get("slug") or intent.app_slug
-                    updated = client.update_application(app_slug, app_patch)
-                    write_count += 1
-                    app_obj.update(updated)
-            else:
-                actions.append(
-                    ReconcileAction(
-                        stack=intent.stack,
-                        route=intent.route,
-                        object_kind="application",
-                        object_name=intent.app_name,
-                        operation="noop",
-                        reason="owned application already matches desired state",
-                        object_id=app_id,
-                    )
-                )
-
-    if any(intent.auth_mode == "forwardAuth" for intent in intents):
-        shared_outpost, outpost_stop = _find_single_shared_outpost(outposts)
-        if outpost_stop:
-            stop_conditions.append(outpost_stop)
-        elif shared_outpost is None:
-            actions.append(
-                ReconcileAction(
-                    stack="_shared",
-                    route="forwardAuth",
-                    object_kind="outpost",
-                    object_name=SHARED_FORWARD_OUTPOST,
-                    operation="create",
-                    reason="shared forward-auth outpost is missing",
-                )
-            )
-            if apply and not stop_conditions:
-                payload = {
-                    "name": SHARED_FORWARD_OUTPOST,
-                    "type": SHARED_OUTPOST_TYPE,
-                    "providers": sorted(required_provider_ids),
-                    "config": OUTPOST_DEFAULT_CONFIG,
-                }
-                created = client.create_outpost(payload)
-                write_count += 1
-                outposts.append(created)
-        else:
-            outpost_id = _as_id(shared_outpost)
-            if outpost_id:
-                consumed["outpost"].add(outpost_id)
-            linked = _DISCOVER._provider_references(shared_outpost)
-            missing_links = sorted(required_provider_ids - linked)
-            desired_links = sorted(linked | required_provider_ids)
-
-            outpost_config_raw = shared_outpost.get("config")
-            outpost_config = outpost_config_raw if isinstance(outpost_config_raw, dict) else {}
-            desired_config = dict(outpost_config)
-            config_changed = False
-            for key, value in OUTPOST_DEFAULT_CONFIG.items():
-                existing = outpost_config.get(key)
-                if existing in (None, ""):
-                    desired_config[key] = value
-                    config_changed = True
-
-            outpost_patch: dict[str, Any] = {}
-            reason_parts: list[str] = []
-            if missing_links:
-                outpost_patch["providers"] = desired_links
-                reason_parts.append("shared outpost missing provider links")
-            if config_changed:
-                outpost_patch["config"] = desired_config
-                reason_parts.append("shared outpost host config missing required values")
-
-            if outpost_patch:
-                reason = "; ".join(reason_parts)
-                actions.append(
-                    ReconcileAction(
-                        stack="_shared",
-                        route="forwardAuth",
-                        object_kind="outpost",
-                        object_name=SHARED_FORWARD_OUTPOST,
-                        operation="update",
-                        reason=reason,
-                        object_id=outpost_id,
-                    )
-                )
-                if apply and not stop_conditions and outpost_id:
-                    updated = client.update_outpost(outpost_id, outpost_patch)
-                    write_count += 1
-                    shared_outpost.update(updated)
-            else:
-                actions.append(
-                    ReconcileAction(
-                        stack="_shared",
-                        route="forwardAuth",
-                        object_kind="outpost",
-                        object_name=SHARED_FORWARD_OUTPOST,
-                        operation="noop",
-                        reason="shared outpost already linked to all managed providers",
-                        object_id=outpost_id,
-                    )
-                )
-
-    for item in applications:
-        item_id = _as_id(item)
-        if not item_id or item_id in consumed["application"]:
-            continue
-        name = _DISCOVER._get_name(item)
-        if _DISCOVER._is_owned_object(name) and any(
-            f"edge-{intent.stack}-" in name for intent in intents
-        ):
-            stop_conditions.append(f"unmanaged owned application detected: {name}")
-    for item in providers:
-        item_id = _as_id(item)
-        if not item_id or item_id in consumed["provider"]:
-            continue
-        name = _DISCOVER._get_name(item)
-        if _DISCOVER._is_owned_object(name) and any(
-            f"edge-{intent.stack}-" in name for intent in intents
-        ):
-            stop_conditions.append(f"unmanaged owned provider detected: {name}")
+    _detect_unmanaged_orphans(applications, providers, intents, consumed, stop_conditions)
 
     stop_conditions = sorted(set(stop_conditions))
-    if stop_conditions:
-        # Applies must fail closed; do not permit partial writes after stop detection.
-        # Writes are prevented by guarded apply branches above.
-        pass
-
-    if any(intent.auth_mode == "forwardAuth" for intent in intents) and not apply:
+    if has_forwardauth and not apply:
         issues.extend(_validate_forwardauth_endpoint_serving(client, intents))
 
-    actions.sort(key=lambda action: (action.stack, action.route, action.object_kind, action.object_name, action.operation))
+    actions.sort(key=lambda a: (a.stack, a.route, a.object_kind, a.object_name, a.operation))
     return ReconcileResult(
         apply=apply,
         actions=tuple(actions),
@@ -1350,6 +1404,29 @@ def reconcile_authentik(
         request_methods=tuple(client.request_methods),
         write_count=write_count,
     )
+
+
+def _print_reconcile_summary(result: ReconcileResult, args: Any) -> None:
+    mode = "apply" if args.apply else "dry-run"
+    print(f"Authentik reconciliation {mode} completed.")
+    print(f"Actions: {len(result.actions)} (writes={result.write_count})")
+    if result.issues:
+        print(f"Issues: {len(result.issues)}")
+        for issue in result.issues:
+            print(f"- [{issue.code}] {issue.message}")
+    if result.stop_conditions:
+        print(f"Stop conditions: {len(result.stop_conditions)}")
+        for stop in result.stop_conditions:
+            print(f"- [STOP] {stop}")
+    for action in result.actions:
+        if action.operation == "noop":
+            continue
+        print(
+            f"- [{action.operation}] {action.stack}/{action.route} "
+            f"{action.object_kind} {action.object_name}: {action.reason}"
+        )
+    if any(action.operation == "delete-report" for action in result.actions):
+        print("Note: delete actions are reported only and never applied by this tool.")
 
 
 def main() -> int:
@@ -1390,29 +1467,7 @@ def main() -> int:
         print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
         return 0 if result.ok else 1
 
-    mode = "apply" if args.apply else "dry-run"
-    print(f"Authentik reconciliation {mode} completed.")
-    print(f"Actions: {len(result.actions)} (writes={result.write_count})")
-    if result.issues:
-        print(f"Issues: {len(result.issues)}")
-        for issue in result.issues:
-            print(f"- [{issue.code}] {issue.message}")
-    if result.stop_conditions:
-        print(f"Stop conditions: {len(result.stop_conditions)}")
-        for stop in result.stop_conditions:
-            print(f"- [STOP] {stop}")
-
-    for action in result.actions:
-        if action.operation == "noop":
-            continue
-        print(
-            f"- [{action.operation}] {action.stack}/{action.route} "
-            f"{action.object_kind} {action.object_name}: {action.reason}"
-        )
-
-    if any(action.operation == "delete-report" for action in result.actions):
-        print("Note: delete actions are reported only and never applied by this tool.")
-
+    _print_reconcile_summary(result, args)
     return 0 if result.ok else 1
 
 

--- a/terraform/lxc/stacks/netbox-stack/integrations/client.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/client.py
@@ -121,48 +121,48 @@ class NetBoxClient:
             return obj.get(key[:-3])
         return obj.get(key)
 
+    def _coerce_existing_dict(self, existing: dict, expected):
+        """Coerce an existing NetBox dict value to match a primitive expected type.
+
+        Called only when expected is neither dict nor list — so expected is a
+        primitive (int, str, or other). Normalises NetBox choice-field wrappers
+        ({value/slug/name}) into the comparable primitive.
+        """
+        if "id" in existing and isinstance(expected, int):
+            return existing["id"]
+        if isinstance(expected, str):
+            for key in ("value", "slug", "name"):
+                if key in existing:
+                    val = existing.get(key)
+                    return val.lower() if isinstance(val, str) else val
+        return existing
+
+    def _coerce_dict_items(self, existing: dict, expected: dict) -> dict:
+        return {k: self._coerce_existing(existing.get(k), v) for k, v in expected.items()}
+
+    def _coerce_list_items(self, existing: list, expected: list) -> list:
+        return [self._coerce_existing(item, expected[0]) if expected else item for item in existing]
+
     def _coerce_existing(self, existing, expected):
-        if isinstance(expected, dict):
-            if not isinstance(existing, dict):
-                return existing
-            if set(expected).issubset({"id", "name", "slug"}):
-                return {key: existing.get(key) for key in expected}
-            return {k: self._coerce_existing(existing.get(k), v) for k, v in expected.items()}
-
-        if isinstance(expected, list):
-            if not isinstance(existing, list):
-                return existing
-            return [self._coerce_existing(item, expected[0]) if expected else item for item in existing]
-
         # Normalize dict wrappers commonly returned by NetBox into the
         # comparable primitive types expected by callers. When the expected
         # value is a string, perform case-insensitive normalization so that
         # NetBox-presented labels/names (which may be Title Case) compare
         # equal to lowercase expected literals such as 'virtual'.
+        if isinstance(expected, dict):
+            if not isinstance(existing, dict):
+                return existing
+            if set(expected).issubset({"id", "name", "slug"}):
+                return {key: existing.get(key) for key in expected}
+            return self._coerce_dict_items(existing, expected)
+        if isinstance(expected, list):
+            if not isinstance(existing, list):
+                return existing
+            return self._coerce_list_items(existing, expected)
         if isinstance(existing, dict):
-            if "id" in existing and isinstance(expected, int):
-                return existing["id"]
-            if isinstance(expected, str):
-                # Prefer canonical keys that NetBox commonly uses for choice
-                # style fields.
-                if "value" in existing:
-                    val = existing.get("value")
-                    return val.lower() if isinstance(val, str) else val
-                if "slug" in existing:
-                    val = existing.get("slug")
-                    return val.lower() if isinstance(val, str) else val
-                if "name" in existing:
-                    val = existing.get("name")
-                    return val.lower() if isinstance(val, str) else val
-            # For non-string expected types, fall through to nested coercion.
-            return {k: self._coerce_existing(v, expected.get(k) if isinstance(expected, dict) else expected)
-                    for k, v in existing.items()} if isinstance(expected, dict) else existing
-
-        # If expected is a string, and the existing value is a plain string,
-        # compare case-insensitively by normalizing to lowercase.
+            return self._coerce_existing_dict(existing, expected)
         if isinstance(expected, str) and isinstance(existing, str):
             return existing.lower()
-
         return existing
 
     def _canonical(self, value):
@@ -273,6 +273,37 @@ class NetBoxClient:
             combined = [obj for obj in combined if self._object_matches_lookup(obj, params)]
         return {"count": len(combined), "results": combined}
 
+    def _resolve_with_legacy_lookups(self, path, lookup, legacy_lookups):
+        results = self.get(path, **lookup)
+        if results["count"] == 0 and legacy_lookups:
+            for legacy_lookup in legacy_lookups:
+                legacy_results = self.get(path, **legacy_lookup)
+                if legacy_results["count"] > 0:
+                    return legacy_results
+        return results
+
+    def _log_create(self, path, desired):
+        if self.dry_run:
+            obj = {"id": self._next_synthetic(), **desired}
+            self._cache_object(path, obj)
+        else:
+            obj = self.post(path, desired)
+        print(f"  {'would create' if self.dry_run else 'created'}: {path} → {self._label(obj)} (id={obj['id']})")
+        return obj
+
+    def _log_patch(self, path, obj, changes):
+        if self.dry_run:
+            obj = {**copy.deepcopy(obj), **changes}
+            self._cache_object(path, obj)
+        else:
+            self.patch(f"{path}{obj['id']}/", changes)
+            obj = {**copy.deepcopy(obj), **changes}
+        print(
+            f"  {'would update' if self.dry_run else 'updated'}: {path} → "
+            f"{self._label(obj)} (id={obj['id']}) fields={sorted(changes)}"
+        )
+        return obj
+
     def ensure(
         self,
         path,
@@ -286,44 +317,18 @@ class NetBoxClient:
         """Create or reconcile an object and log the resulting action."""
         self._record_desired_lookup(path, lookup)
         desired = {**lookup, **(defaults or {})}
-        results = self.get(path, **lookup)
-
-        if results["count"] == 0 and legacy_lookups:
-            for legacy_lookup in legacy_lookups:
-                legacy_results = self.get(path, **legacy_lookup)
-                if legacy_results["count"] > 0:
-                    results = legacy_results
-                    break
+        results = self._resolve_with_legacy_lookups(path, lookup, legacy_lookups)
 
         if results["count"] == 0:
-            if self.dry_run:
-                obj = {"id": self._next_synthetic(), **desired}
-                self._cache_object(path, obj)
-            else:
-                obj = self.post(path, desired)
-            print(f"  {'would create' if self.dry_run else 'created'}: {path} → {self._label(obj)} (id={obj['id']})")
-            return obj
+            return self._log_create(path, desired)
 
         obj = results["results"][0]
         changes = self._build_patch(obj, desired, allowed_patch_fields=allowed_patch_fields)
         if changes and managed_tag_slug and not allow_unmanaged_patch and managed_tag_slug not in self._tag_slugs(obj):
-            print(
-                f"  skip unmanaged: {path} → {self._label(obj)} "
-                f"(id={obj['id']}) fields={sorted(changes)}"
-            )
+            print(f"  skip unmanaged: {path} → {self._label(obj)} (id={obj['id']}) fields={sorted(changes)}")
             return obj
         if changes:
-            if self.dry_run:
-                obj = {**copy.deepcopy(obj), **changes}
-                self._cache_object(path, obj)
-            else:
-                self.patch(f"{path}{obj['id']}/", changes)
-                obj = {**copy.deepcopy(obj), **changes}
-            print(
-                f"  {'would update' if self.dry_run else 'updated'}: {path} → "
-                f"{self._label(obj)} (id={obj['id']}) fields={sorted(changes)}"
-            )
-            return obj
+            return self._log_patch(path, obj, changes)
 
         print(f"  exists: {path} → {self._label(obj)} (id={obj['id']})")
         return obj

--- a/terraform/lxc/stacks/netbox-stack/integrations/discover.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/discover.py
@@ -322,6 +322,92 @@ def _build_portainer_services(portainer, portainer_ep: dict) -> list[dict]:
     return deduped
 
 
+def _fetch_container_summaries(base: str) -> list:
+    """GET /containers/json?all=1 from a Docker socket proxy; return list or []."""
+    # TODO: when DOCKER_SOCKET_PROXY_URL_TEMPLATE is upgraded to https://,
+    # pass an ssl context that verifies against the step-ca or LE cert.
+    try:
+        req = urllib.request.Request(f"{base}/containers/json?all=1")
+        with urllib.request.urlopen(req) as resp:  # nosec B310 — Docker socket proxy on private SDN
+            summaries = json.loads(resp.read().decode())
+    except Exception:
+        return []
+    return summaries if isinstance(summaries, list) else []
+
+
+def _inspect_container_data(base: str, cid: str) -> dict | None:
+    """GET /containers/{cid}/json from a Docker socket proxy; return dict or None."""
+    try:
+        req = urllib.request.Request(f"{base}/containers/{cid}/json")
+        with urllib.request.urlopen(req) as resp:  # nosec B310 — Docker socket proxy on private SDN
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+
+def _resolve_container_name(data: dict, summary: dict, cid: str) -> str:
+    """Return the canonical container name from an inspect response."""
+    cname = (data.get("Name") or "").lstrip("/")
+    if cname:
+        return cname
+    names = data.get("Names") or summary.get("Names") or []
+    return names[0].lstrip("/") if names else cid
+
+
+def _container_matches_guest(
+    data: dict,
+    summary: dict,
+    container: dict,
+    guest_ip: str | None,
+    guest_scoped: bool,
+) -> bool:
+    """Return True if a container belongs to the Proxmox guest."""
+    if guest_scoped:
+        return True
+    if guest_ip:
+        networks = (data.get("NetworkSettings") or {}).get("Networks") or {}
+        if isinstance(networks, dict):
+            for net in networks.values():
+                if isinstance(net, dict) and net.get("IPAddress") == guest_ip:
+                    return True
+    pve_name = container.get("name")
+    if pve_name:
+        names = data.get("Names") or summary.get("Names") or []
+        return any(pve_name in nn for nn in names)
+    return False
+
+
+def _extract_port_services(ports_map: dict, cname: str, seen: set) -> list[dict]:
+    """Convert a container Ports dict into service dicts, deduplicating via seen."""
+    services = []
+    for port_key, mappings in (ports_map or {}).items():
+        if not re.match(r"\d+/(tcp|udp)$", port_key):
+            continue
+        proto = port_key.split("/", 1)[1]
+        if not mappings:
+            continue
+        for mapping in mappings:
+            host_port_raw = mapping.get("HostPort")
+            if not host_port_raw:
+                continue
+            try:
+                host_port = int(host_port_raw)
+            except Exception:
+                continue
+            key = (cname, host_port, proto)
+            if key in seen:
+                continue
+            seen.add(key)
+            svc_name = f"{cname}-{host_port}" if host_port != 9001 else cname
+            services.append({
+                "name": svc_name,
+                "port": host_port,
+                "protocol": proto,
+                "source": "socket-proxy",
+            })
+    return services
+
+
 def _build_socket_proxy_services(proxy_url: str, container: dict, guest_scoped: bool = False) -> list[dict]:
     """Query a docker-socket-proxy HTTP API and return services for a guest.
 
@@ -344,109 +430,20 @@ def _build_socket_proxy_services(proxy_url: str, container: dict, guest_scoped: 
 
     base = proxy_url.rstrip("/")
     services = []
-    seen = set()
+    seen: set = set()
 
-    try:
-        # TODO: when DOCKER_SOCKET_PROXY_URL_TEMPLATE is upgraded to https://,
-        # pass an ssl context here that verifies against the step-ca or LE cert.
-        # Currently HTTP only; context= omitted so urllib uses no TLS at all.
-        list_req = urllib.request.Request(f"{base}/containers/json?all=1")
-        with urllib.request.urlopen(list_req) as resp:  # nosec B310 — Docker socket proxy on private SDN
-            summaries = json.loads(resp.read().decode())
-    except Exception:
-        return []
-
-    if not isinstance(summaries, list):
-        return []
-
-    for summary in summaries:
-        cid = summary.get("Id") or summary.get("ID") or summary.get("Id")
+    for summary in _fetch_container_summaries(base):
+        cid = summary.get("Id") or summary.get("ID")
         if not cid:
             continue
-
-        try:
-            req = urllib.request.Request(f"{base}/containers/{cid}/json")
-            with urllib.request.urlopen(req) as resp:  # nosec B310 — Docker socket proxy on private SDN
-                data = json.loads(resp.read().decode())
-        except Exception:
-            # skip containers we can't inspect
+        data = _inspect_container_data(base, cid)
+        if data is None:
             continue
-
-        # Determine canonical container name
-        cname = (data.get("Name") or "").lstrip("/")
-        if not cname:
-            # try the Names list from summary or inspect
-            names = data.get("Names") or summary.get("Names") or []
-            if names:
-                cname = names[0].lstrip("/")
-            else:
-                cname = cid
-
-        # Determine whether this container maps to the Proxmox guest. When the
-        # proxy endpoint is guest-scoped (resolved from a per-guest template),
-        # treat all returned containers as belonging to the guest and skip
-        # any name/IP matching. For single-endpoint proxies, fall back to the
-        # Docker-inspect IP match and a conservative name substring fallback.
-        matches = False
-        if guest_scoped:
-            matches = True
-        else:
-            if guest_ip:
-                network_settings = data.get("NetworkSettings") or {}
-                networks = network_settings.get("Networks") or {}
-                if isinstance(networks, dict):
-                    for net in networks.values():
-                        if not isinstance(net, dict):
-                            continue
-                        c_ip = net.get("IPAddress")
-                        if c_ip == guest_ip:
-                            matches = True
-                            break
-
-            # Fallback: check whether the Proxmox guest name appears in container names
-            if not matches:
-                pve_name = container.get("name")
-                if pve_name:
-                    names = data.get("Names") or summary.get("Names") or []
-                    for nn in names:
-                        if pve_name and pve_name in nn:
-                            matches = True
-                            break
-
-        if not matches:
+        cname = _resolve_container_name(data, summary, cid)
+        if not _container_matches_guest(data, summary, container, guest_ip, guest_scoped):
             continue
-
-        # Extract Ports mapping from inspect response
-        network = data.get("NetworkSettings") or {}
-        ports_map = network.get("Ports") or {}
-
-        for port_key, mappings in (ports_map or {}).items():
-            m = re.match(r"(?P<port>\d+)/(tcp|udp)$", port_key)
-            if not m:
-                continue
-            proto = port_key.split("/", 1)[1]
-            if not mappings:
-                # Not published to the host
-                continue
-            for mapping in mappings:
-                host_port_raw = mapping.get("HostPort")
-                if not host_port_raw:
-                    continue
-                try:
-                    host_port = int(host_port_raw)
-                except Exception:
-                    continue
-                key = (cname, host_port, proto)
-                if key in seen:
-                    continue
-                seen.add(key)
-                svc_name = f"{cname}-{host_port}" if host_port != 9001 else cname
-                services.append({
-                    "name": svc_name,
-                    "port": host_port,
-                    "protocol": proto,
-                    "source": "socket-proxy",
-                })
+        ports_map = (data.get("NetworkSettings") or {}).get("Ports") or {}
+        services.extend(_extract_port_services(ports_map, cname, seen))
 
     return services
 
@@ -473,6 +470,25 @@ class RuntimeInspector:
             "DOCKER_SOCKET_PROXY_URL_TEMPLATE"
         )
 
+    def _probe_via_template(self, container: dict, template: str) -> list[dict]:
+        """Probe per-guest socket-proxy using a URL template; return services or []."""
+        guest_ip = _get_container_ip(container)
+        if guest_ip and "/" in guest_ip:
+            guest_ip = guest_ip.split("/", 1)[0]
+        if not guest_ip:
+            return []
+        try:
+            proxy_url = template.format(guest_ip=guest_ip)
+        except Exception:
+            return []
+        if not proxy_url:
+            return []
+        try:
+            return _build_socket_proxy_services(proxy_url, container, guest_scoped=True)
+        except Exception as exc:
+            print(f"  warn: socket-proxy inspection failed for {container.get('name', 'unknown')} via template {template}: {exc}")
+            return []
+
     def inspect(self, container: dict, portainer_ep: dict | None = None) -> list[dict]:
         """Return a list of observed services for `container`.
 
@@ -483,34 +499,17 @@ class RuntimeInspector:
         if self.portainer and portainer_ep:
             return _build_portainer_services(self.portainer, portainer_ep)
 
-        # Next preference: docker socket proxy (read-only Docker API).
         # Preferred: per-guest URL template with `{guest_ip}` placeholder.
         # Note: this template is expected to be provided via environment by
         # the populate job (e.g. /etc/netbox-populate/env when provisioned) or
         # by CI via GitHub Actions secrets. It is intentionally optional and
         # should remain unset on real stacks until the disposable proof and
         # rollout gates have been satisfied.
-        template = self.socket_proxy_url_template or _resolved_env_value(
-            "DOCKER_SOCKET_PROXY_URL_TEMPLATE"
-        )
+        template = self.socket_proxy_url_template or _resolved_env_value("DOCKER_SOCKET_PROXY_URL_TEMPLATE")
         if template:
-            guest_ip = _get_container_ip(container)
-            if guest_ip and "/" in guest_ip:
-                guest_ip = guest_ip.split("/", 1)[0]
-            if guest_ip:
-                try:
-                    proxy_url = template.format(guest_ip=guest_ip)
-                except Exception:
-                    proxy_url = None
-                if proxy_url:
-                    try:
-                        services = _build_socket_proxy_services(proxy_url, container, guest_scoped=True)
-                        if services:
-                            return services
-                    except Exception as exc:
-                        print(
-                            f"  warn: socket-proxy inspection failed for {container.get('name', 'unknown')} via template {template}: {exc}"
-                        )
+            services = self._probe_via_template(container, template)
+            if services:
+                return services
 
         # Fallback: single configured proxy endpoint (legacy)
         proxy_url = self.socket_proxy_url or _resolved_env_value("DOCKER_SOCKET_PROXY_URL")

--- a/terraform/lxc/stacks/netbox-stack/integrations/populate.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/populate.py
@@ -280,47 +280,42 @@ def _resolve_env_token(raw_value):
     return raw_value
 
 
+def _get_zone_prefix(zone_def: dict, attachments: dict) -> str | None:
+    """Return the resolved CIDR prefix for one zone, or None if it's a bridge or unresolvable."""
+    attachment_name = zone_def.get("attachment")
+    attachment: dict = {}
+    if isinstance(attachment_name, str):
+        candidate = attachments.get(attachment_name, {})
+        if isinstance(candidate, dict):
+            attachment = candidate
+    if attachment.get("type") == "bridge":
+        return None
+    attachment_sdn = attachment.get("sdn", {})
+    if not isinstance(attachment_sdn, dict):
+        attachment_sdn = {}
+    prefix = (
+        zone_def.get("prefix")
+        or zone_def.get("cidr")
+        or zone_def.get("network")
+        or attachment_sdn.get("subnet")
+    )
+    return _resolve_env_token(prefix)
+
+
 def _extract_routed_segment_prefixes(network_intent: dict) -> list[dict]:
     """Extract one prefix per routed segment from network intent."""
     attachments = network_intent.get("attachments", {})
     zones = network_intent.get("zones", {})
     if not isinstance(attachments, dict) or not isinstance(zones, dict):
         return []
-
     prefixes = []
     for segment_name, zone_def in zones.items():
         if not isinstance(zone_def, dict):
             continue
-
-        attachment = {}
-        attachment_name = zone_def.get("attachment")
-        if isinstance(attachment_name, str):
-            candidate = attachments.get(attachment_name, {})
-            if isinstance(candidate, dict):
-                attachment = candidate
-
-        if attachment.get("type") == "bridge":
-            continue
-
-        attachment_sdn = attachment.get("sdn", {})
-        if not isinstance(attachment_sdn, dict):
-            attachment_sdn = {}
-
-        # Support direct zone CIDR keys plus the repo's attachment.sdn.subnet shape.
-        prefix = (
-            zone_def.get("prefix")
-            or zone_def.get("cidr")
-            or zone_def.get("network")
-            or attachment_sdn.get("subnet")
-        )
-        prefix = _resolve_env_token(prefix)
+        prefix = _get_zone_prefix(zone_def, attachments)
         if not isinstance(prefix, str) or not prefix.strip():
             continue
-        prefixes.append({
-            "prefix": prefix.strip(),
-            "description": zone_def.get("description", segment_name),
-        })
-
+        prefixes.append({"prefix": prefix.strip(), "description": zone_def.get("description", segment_name)})
     return prefixes
 
 
@@ -466,6 +461,22 @@ def _node_name_from_proxmox_data(proxmox_data: dict) -> str | None:
     return None
 
 
+def _build_portainer_for_node(node_def: dict):
+    """Instantiate a PortainerClient for one node declaration, or return None."""
+    portainer_url = node_def.get("portainer_url")
+    portainer_api_key_env = node_def.get("portainer_api_key_env")
+    if not portainer_url or not portainer_api_key_env:
+        return None
+    api_key = os.environ.get(portainer_api_key_env)
+    if not api_key:
+        return None
+    try:
+        return PortainerClient(url=portainer_url, api_key=api_key)
+    except Exception as exc:
+        print(f"  warning: Portainer client for {portainer_url} failed: {exc}")
+        return None
+
+
 def _build_topology_from_nodes(proxmox_nodes: list) -> dict:
     """Build topology by querying each declared Proxmox node and merging results."""
     all_vms = []
@@ -480,7 +491,6 @@ def _build_topology_from_nodes(proxmox_nodes: list) -> dict:
         url = f"https://{host}:8006"
         token_id = os.environ.get(node_def.get("token_id_env", ""))
         token_secret = os.environ.get(node_def.get("token_secret_env", ""))
-
         try:
             proxmox_data = discover_from_proxmox(url=url, token_id=token_id, token_secret=token_secret)
         except Exception as exc:
@@ -491,17 +501,8 @@ def _build_topology_from_nodes(proxmox_nodes: list) -> dict:
         if node_name:
             discovered_node_names.append(node_name)
 
-        portainer = None
+        portainer = _build_portainer_for_node(node_def)
         portainer_url = node_def.get("portainer_url")
-        portainer_api_key_env = node_def.get("portainer_api_key_env")
-        if portainer_url and portainer_api_key_env:
-            api_key = os.environ.get(portainer_api_key_env)
-            if api_key:
-                try:
-                    portainer = PortainerClient(url=portainer_url, api_key=api_key)
-                except Exception as exc:
-                    print(f"  warning: Portainer client for {portainer_url} failed: {exc}")
-
         if primary_proxmox_data is None:
             primary_proxmox_data = proxmox_data
         all_vms.extend(build_topology(proxmox_data=proxmox_data, portainer=portainer, portainer_url=portainer_url))
@@ -652,34 +653,18 @@ def _vm_description(vm_def: dict) -> str:
     return description[:200]
 
 
-def _try_reparent_runtime_service(nb, vm, svc_def, vm_env) -> bool:
-    """Conservatively reparent an existing runtime-sourced service to `vm`.
-
-    Returns True when a single, unambiguous existing managed service matching
-    `(name, protocol, port)` and carrying a `runtime-source-*` tag is found
-    and successfully patched to reference the provided `vm`.
-    """
-    # Only perform for socket-proxy discovered services and when the
-    # feature flag is explicitly enabled in the environment.
-    if svc_def.get("source") != "socket-proxy":
-        return False
-    if os.environ.get("REPARENT_RUNTIME_SOCKET_PROXY", "").lower() not in ("1", "true", "yes", "on"):
-        return False
-
+def _find_reparentable_service_candidate(nb, vm: dict, svc_def: dict) -> dict | None:
+    """Return the single unambiguous socket-proxy service to reparent, or None."""
     try:
         results = nb.get(NB_IPAM_SERVICES, name=svc_def.get("name"), protocol=svc_def.get("protocol"))
     except Exception:
-        return False
+        return None
     candidates = results.get("results", []) if isinstance(results, dict) else []
-
     matches = []
     for cand in candidates:
         slugs = _tag_slugs(cand)
         if MANAGED_TAG_SLUG not in slugs:
             continue
-        # Only consider services that were discovered by the socket-proxy
-        # runtime. This avoids accidentally reparenting services created by
-        # other runtime sources.
         if "runtime-source-socket-proxy" not in slugs:
             continue
         if _service_first_port(cand) != svc_def.get("port"):
@@ -690,12 +675,23 @@ def _try_reparent_runtime_service(nb, vm, svc_def, vm_env) -> bool:
         if not parent_id or parent_id == vm.get("id"):
             continue
         matches.append(cand)
+    return matches[0] if len(matches) == 1 else None
 
-    if len(matches) != 1:
-        # Ambiguous or none — do not reparent in these cases
+
+def _try_reparent_runtime_service(nb, vm, svc_def, vm_env) -> bool:
+    """Conservatively reparent an existing runtime-sourced service to `vm`.
+
+    Returns True when a single, unambiguous existing managed service matching
+    `(name, protocol, port)` and carrying a `runtime-source-*` tag is found
+    and successfully patched to reference the provided `vm`.
+    """
+    if svc_def.get("source") != "socket-proxy":
         return False
-
-    candidate = matches[0]
+    if os.environ.get("REPARENT_RUNTIME_SOCKET_PROXY", "").lower() not in ("1", "true", "yes", "on"):
+        return False
+    candidate = _find_reparentable_service_candidate(nb, vm, svc_def)
+    if candidate is None:
+        return False
     runtime_slugs = [s for s in _tag_slugs(candidate) if s.startswith("runtime-source-")]
     new_tags = _managed_tag_refs(extra_tags=runtime_slugs, environment=vm_env)
     nb.patch_object(NB_IPAM_SERVICES, candidate, {
@@ -916,6 +912,24 @@ def _ensure_proxmox_hypervisor(nb, site, node_name: str) -> None:
     }, **_managed_patch_guard())
 
 
+def _select_router_primary_ip(internal_candidates: list[dict], router: dict) -> dict | None:
+    """Select one internal IP candidate dict as the router primary IP object."""
+    if not internal_candidates:
+        return None
+    router_host_ip = None
+    host_field = router.get("host") if isinstance(router, dict) else None
+    if isinstance(host_field, str) and host_field.strip():
+        router_host_ip = host_field.rsplit(":", 1)[0]
+    if router_host_ip:
+        preferred = [c for c in internal_candidates if c["address"].split("/")[0] == router_host_ip]
+    else:
+        preferred = []
+    if not preferred:
+        preferred = [c for c in internal_candidates if c["address"].split("/")[0].startswith("192.168.1.")]
+    pool = preferred if preferred else internal_candidates
+    return sorted(pool, key=lambda c: int(ipaddress.ip_address(c["address"].split("/")[0])))[0]["ip"]
+
+
 def populate_network(nb, site, network):
     """Create router device, interfaces, VLANs, and router IPs from Mikrotik discovery."""
     print("\n=== Network Infrastructure ===")
@@ -1019,40 +1033,7 @@ def populate_network(nb, site, network):
         if _is_internal_ip(address):
             internal_candidates.append({"ip": ip_obj, "address": address, "iface": iface})
 
-    def _is_mgmt_addr(addr: str) -> bool:
-        return addr.split("/")[0].startswith("192.168.1.")
-
-    def _addr_key(addr: str) -> int:
-        # numeric ordering of IPv4 address for stable selection
-        return int(ipaddress.ip_address(addr.split("/")[0]))
-
-    selected_ip_obj = None
-    if internal_candidates:
-        # Policy preference order:
-        # 1) If the discovered router management/API host address (router['host'])
-        #    appears among the discovered router IPs, prefer that exact IP.
-        # 2) Otherwise prefer management/LAN 192.168.1.x addresses.
-        # 3) Otherwise fall back to numerically lowest internal IP.
-        router_host_ip = None
-        host_field = router.get("host") if isinstance(router, dict) else None
-        if isinstance(host_field, str) and host_field.strip():
-            # router['host'] is formatted as "<host>[:<port>]" in discovery;
-            # strip an optional port portion.
-            router_host_ip = host_field.rsplit(":", 1)[0]
-
-        preferred: list[dict] = []
-        if router_host_ip:
-            preferred = [c for c in internal_candidates if c["address"].split("/")[0] == router_host_ip]
-
-        if not preferred:
-            preferred = [c for c in internal_candidates if _is_mgmt_addr(c["address"])]
-
-        if preferred:
-            chosen = sorted(preferred, key=lambda c: _addr_key(c["address"]))[0]
-        else:
-            chosen = sorted(internal_candidates, key=lambda c: _addr_key(c["address"]))[0]
-
-        selected_ip_obj = chosen["ip"]
+    selected_ip_obj = _select_router_primary_ip(internal_candidates, router)
 
     if selected_ip_obj and _primary_ip_id(router_device) != selected_ip_obj.get("id"):
         router_device = _patch_managed_object(
@@ -1115,6 +1096,122 @@ def populate_virtual(nb, vms, inventory):
         }, **_managed_patch_guard())
 
 
+def _populate_proxmox_host_ip(nb, population_intent: dict, env_managed_tags: list, inventory: dict) -> None:
+    """Create/reconcile the Proxmox hypervisor host IP and prune stale IPs on its interface."""
+    proxmox_host = population_intent.get("proxmox_host", {})
+    host_address = proxmox_host.get("address")
+    if not host_address:
+        return
+    device_results = nb.get(
+        NB_DCIM_DEVICES,
+        name=proxmox_host.get("device_name", DEVICES[0]["name"]),
+    )["results"]
+    if not device_results:
+        return
+    device = device_results[0]
+    iface_name = proxmox_host.get("interface_name") or DEVICES[0]["interfaces"][0]["name"]
+    iface_results = nb.get(NB_DCIM_INTERFACES, device_id=device["id"], name=iface_name)["results"]
+    if not iface_results:
+        return
+    iface = iface_results[0]
+    existing_ip_results = nb.get(NB_IPAM_IP_ADDRESSES, address=host_address)["results"]
+    ip = next((c for c in existing_ip_results if c.get("address") == host_address), None)
+    if ip is None:
+        ip = nb.ensure(NB_IPAM_IP_ADDRESSES, {"address": host_address}, {
+            "assigned_object_type": ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE,
+            "assigned_object_id": iface["id"],
+            "status": "active",
+            "description": device["name"],
+            "tags": env_managed_tags,
+        }, **_managed_patch_guard())
+    if (
+        _primary_ip_id(device) != ip["id"]
+        and ip.get("assigned_object_type") == ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE
+        and ip.get("assigned_object_id") == iface["id"]
+    ):
+        _patch_managed_object(nb, NB_DCIM_DEVICES, device, {"primary_ip4": ip["id"]})
+
+    desired_tags = {MANAGED_TAG_SLUG, inventory["environment_tag"]}
+    for assigned_ip in nb.get(
+        NB_IPAM_IP_ADDRESSES,
+        assigned_object_type=ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE,
+        assigned_object_id=iface["id"],
+    )["results"]:
+        if assigned_ip.get("address") == host_address:
+            continue
+        if desired_tags.issubset(_tag_slugs(assigned_ip)):
+            nb.delete_object(NB_IPAM_IP_ADDRESSES, assigned_ip)
+
+
+def _reconcile_vm_services(
+    nb,
+    vm: dict,
+    vm_def: dict,
+    vm_env: str,
+    vm_env_managed_tags: list,
+    service_observed_at: str,
+) -> None:
+    """Upsert desired services and delete stale ones for a single VM."""
+    desired_service_keys = {
+        (svc["name"], svc["protocol"], svc["port"])
+        for svc in vm_def.get("services", [])
+    }
+    desired_env_tag = _environment_tag_name(vm_env)
+
+    for svc_def in vm_def.get("services", []):
+        service_tags = list(vm_env_managed_tags)
+        svc_source = svc_def.get("source")
+        if svc_source:
+            source_tag_name = f"runtime-source-{svc_source}"
+            _ensure_tags(nb, [source_tag_name])
+            service_tags.append(_tag_ref(source_tag_name))
+        try:
+            if _try_reparent_runtime_service(nb, vm, svc_def, vm_env):
+                continue
+        except Exception:
+            pass
+        nb.ensure(NB_IPAM_SERVICES, {
+            "name": svc_def["name"],
+            "parent_object_type": "virtualization.virtualmachine",
+            "parent_object_id": vm["id"],
+            "protocol": svc_def["protocol"],
+        }, {
+            "name": svc_def["name"],
+            "parent_object_type": "virtualization.virtualmachine",
+            "parent_object_id": vm["id"],
+            "ports": [svc_def["port"]],
+            "protocol": svc_def["protocol"],
+            "description": _service_last_seen_description(vm_def["name"], service_observed_at),
+            "tags": service_tags,
+        }, **_managed_patch_guard())
+
+    for existing_service in nb.get(
+        NB_IPAM_SERVICES,
+        parent_object_type="virtualization.virtualmachine",
+        parent_object_id=vm["id"],
+    )["results"]:
+        existing_slugs = _tag_slugs(existing_service)
+        if MANAGED_TAG_SLUG not in existing_slugs:
+            continue
+        existing_env_tags = [s for s in existing_slugs if s.startswith(ENV_TAG_PREFIX)]
+        existing_env_tag = existing_env_tags[0] if existing_env_tags else None
+        existing_key = (
+            existing_service.get("name"),
+            _service_protocol_value(existing_service),
+            _service_first_port(existing_service),
+        )
+        if existing_env_tag == desired_env_tag:
+            if existing_key not in desired_service_keys:
+                nb.delete_object(NB_IPAM_SERVICES, existing_service)
+            continue
+        if existing_key in desired_service_keys:
+            runtime_slugs = [s for s in existing_slugs if s.startswith("runtime-source-")]
+            new_tags = _managed_tag_refs(extra_tags=runtime_slugs, environment=vm_env)
+            nb.patch_object(NB_IPAM_SERVICES, existing_service, {"tags": new_tags})
+        else:
+            nb.delete_object(NB_IPAM_SERVICES, existing_service)
+
+
 def populate_ipam(nb, site, vms, population_intent, inventory):
     """Create prefix, assign IPs to interfaces, and register services."""
     print("\n=== IPAM ===")
@@ -1130,74 +1227,11 @@ def populate_ipam(nb, site, vms, population_intent, inventory):
             "tags": shared_managed_tags,
         }, **_managed_patch_guard())
 
-    # Proxmox host IP from environment/repo-driven population intent.
-    proxmox_host = population_intent.get("proxmox_host", {})
-    host_address = proxmox_host.get("address")
-    if host_address:
-        device_results = nb.get(
-            NB_DCIM_DEVICES,
-            name=proxmox_host.get("device_name", DEVICES[0]["name"]),
-        )["results"]
-        if device_results:
-            device = device_results[0]
-            iface_name = proxmox_host.get("interface_name") or DEVICES[0]["interfaces"][0]["name"]
-            iface_results = nb.get(
-                NB_DCIM_INTERFACES,
-                device_id=device["id"],
-                name=iface_name,
-            )["results"]
-            if iface_results:
-                iface = iface_results[0]
-                existing_ip_results = nb.get(
-                    NB_IPAM_IP_ADDRESSES,
-                    address=host_address,
-                )["results"]
-                ip = next(
-                    (
-                        candidate
-                        for candidate in existing_ip_results
-                        if candidate.get("address") == host_address
-                    ),
-                    None,
-                )
-                if ip is None:
-                    ip = nb.ensure(NB_IPAM_IP_ADDRESSES, {"address": host_address}, {
-                        "assigned_object_type": ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE,
-                        "assigned_object_id": iface["id"],
-                        "status": "active",
-                        "description": device["name"],
-                        "tags": env_managed_tags,
-                    }, **_managed_patch_guard())
-                if (
-                    _primary_ip_id(device) != ip["id"]
-                    and ip.get("assigned_object_type") == ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE
-                    and ip.get("assigned_object_id") == iface["id"]
-                ):
-                    device = _patch_managed_object(
-                        nb,
-                        NB_DCIM_DEVICES,
-                        device,
-                        {"primary_ip4": ip["id"]},
-                    )
+    _populate_proxmox_host_ip(nb, population_intent, env_managed_tags, inventory)
 
-                desired_tags = {MANAGED_TAG_SLUG, inventory["environment_tag"]}
-                assigned_ips = nb.get(
-                    NB_IPAM_IP_ADDRESSES,
-                    assigned_object_type=ASSIGNED_OBJECT_TYPE_DCIM_INTERFACE,
-                    assigned_object_id=iface["id"],
-                )["results"]
-                for assigned_ip in assigned_ips:
-                    if assigned_ip.get("address") == host_address:
-                        continue
-                    if not desired_tags.issubset(_tag_slugs(assigned_ip)):
-                        continue
-                    nb.delete_object(NB_IPAM_IP_ADDRESSES, assigned_ip)
-
-    # VM IPs and services
     for vm_def in vms:
         if not vm_def.get("ip"):
             continue
-        # Determine VM-specific environment for IP/service tagging.
         vm_env = vm_def.get("node")
         if not vm_env or vm_env == "external":
             vm_env = inventory["environment"]
@@ -1217,103 +1251,9 @@ def populate_ipam(nb, site, vms, population_intent, inventory):
             "tags": vm_env_managed_tags,
         }, **_managed_patch_guard())
         if _primary_ip_id(vm) != ip["id"]:
-            vm = _patch_managed_object(
-                nb,
-                NB_VIRT_VIRTUAL_MACHINES,
-                vm,
-                {"primary_ip4": ip["id"]},
-            )
+            vm = _patch_managed_object(nb, NB_VIRT_VIRTUAL_MACHINES, vm, {"primary_ip4": ip["id"]})
 
-        for svc_def in vm_def.get("services", []):
-            # Compose tags: keep existing managed/environment tags, and
-            # optionally add a single runtime-source tag when discovery source
-            # metadata is available on the observed service.
-            service_tags = list(vm_env_managed_tags)
-            svc_source = svc_def.get("source")
-            if svc_source:
-                source_tag_name = f"runtime-source-{svc_source}"
-                _ensure_tags(nb, [source_tag_name])
-                service_tags.append(_tag_ref(source_tag_name))
-
-            # Conservative reparent: if an existing runtime-sourced service
-            # already exists elsewhere in NetBox that matches this observed
-            # service, reparent it to the current VM instead of creating a
-            # duplicate. This is gated behind the REPARENT_RUNTIME_SOCKET_PROXY
-            # environment flag and only applies to unambiguous matches.
-            try:
-                if _try_reparent_runtime_service(nb, vm, svc_def, vm_env):
-                    # Reparent performed; skip creation step for this service.
-                    continue
-            except Exception:
-                # Non-fatal: fall back to standard ensure behavior.
-                pass
-
-            nb.ensure(NB_IPAM_SERVICES, {
-                "name": svc_def["name"],
-                "parent_object_type": "virtualization.virtualmachine",
-                "parent_object_id": vm["id"],
-                "protocol": svc_def["protocol"],
-            }, {
-                "name": svc_def["name"],
-                "parent_object_type": "virtualization.virtualmachine",
-                "parent_object_id": vm["id"],
-                "ports": [svc_def["port"]],
-                "protocol": svc_def["protocol"],
-                "description": _service_last_seen_description(vm_def["name"], service_observed_at),
-                "tags": service_tags,
-            }, **_managed_patch_guard())
-
-        desired_service_keys = {
-            (svc["name"], svc["protocol"], svc["port"])
-            for svc in vm_def.get("services", [])
-        }
-        # Only consider services that are managed and carry the VM's
-        # environment tag (derived from the VM's source node). Previously
-        # this used the inventory-level environment tag which caused
-        # cross-node VMs to be reconciled against the wrong environment
-        # during cleanup. Use the per-VM environment here.
-        desired_tags = {MANAGED_TAG_SLUG, _environment_tag_name(vm_env)}
-        existing_services = nb.get(
-            NB_IPAM_SERVICES,
-            parent_object_type="virtualization.virtualmachine",
-            parent_object_id=vm["id"],
-        )["results"]
-        for existing_service in existing_services:
-            existing_slugs = _tag_slugs(existing_service)
-            # Only consider automation-managed services.
-            if MANAGED_TAG_SLUG not in existing_slugs:
-                continue
-
-            # Detect any environment tag currently present on the service.
-            existing_env_tags = [s for s in existing_slugs if s.startswith(ENV_TAG_PREFIX)]
-            existing_env_tag = existing_env_tags[0] if existing_env_tags else None
-            desired_env_tag = _environment_tag_name(vm_env)
-
-            existing_key = (
-                existing_service.get("name"),
-                _service_protocol_value(existing_service),
-                _service_first_port(existing_service),
-            )
-
-            if existing_env_tag == desired_env_tag:
-                # Service already carries the VM's environment tag; apply
-                # standard reconciliation (delete if not desired).
-                if existing_key in desired_service_keys:
-                    continue
-                nb.delete_object(NB_IPAM_SERVICES, existing_service)
-                continue
-
-            # Service is managed but either missing an environment tag or
-            # tagged for a different environment (cross-node). If it matches
-            # a desired service, retag it to the current VM environment while
-            # preserving any runtime-source tags. Otherwise delete it so it
-            # will be recreated correctly.
-            if existing_key in desired_service_keys:
-                runtime_slugs = [s for s in existing_slugs if s.startswith("runtime-source-")]
-                new_tags = _managed_tag_refs(extra_tags=runtime_slugs, environment=vm_env)
-                nb.patch_object(NB_IPAM_SERVICES, existing_service, {"tags": new_tags})
-            else:
-                nb.delete_object(NB_IPAM_SERVICES, existing_service)
+        _reconcile_vm_services(nb, vm, vm_def, vm_env, vm_env_managed_tags, service_observed_at)
 
 
 # ---------------------------------------------------------------------------
@@ -1341,6 +1281,24 @@ WIPE_ORDER = [
 ]
 
 
+def _delete_objects_at_path(nb, path: str, filters: dict) -> int:
+    """Delete all objects at `path` matching `filters`, retrying until none remain."""
+    total = 0
+    while True:
+        items = nb.get(path, **filters).get("results", [])
+        if not items:
+            break
+        for obj in items:
+            name = obj.get("name") or obj.get("display") or obj.get("address") or obj.get("prefix") or str(obj["id"])
+            try:
+                nb.delete(f"{path}{obj['id']}/")
+                print(f"  deleted: {path} → {name} (id={obj['id']})")
+                total += 1
+            except RuntimeError as e:
+                print(f"  skip: {path} → {name} (id={obj['id']}): {e}")
+    return total
+
+
 def clean(nb, inventory):
     """Delete automation-owned objects for the current environment, in reverse dependency order."""
     print(f"NetBox: {nb.url}\n=== Cleaning ===")
@@ -1358,109 +1316,164 @@ def clean(nb, inventory):
             if filters.get("tag") == MANAGED_TAG_SLUG and not managed_tag_exists:
                 continue
         else:
-            filters = _environment_filters(path, inventory)
             if not environment_tag_exists:
                 continue
+            filters = _environment_filters(path, inventory)
         if filters.get("tag") == MANAGED_TAG_SLUG and not managed_tag_exists:
             continue
-        while True:
-            results = nb.get(path, **filters)
-            items = results.get("results", [])
-            if not items:
-                break
-            for obj in items:
-                name = (obj.get("name") or obj.get("display") or
-                        obj.get("address") or obj.get("prefix") or str(obj["id"]))
-                try:
-                    nb.delete(f"{path}{obj['id']}/")
-                    print(f"  deleted: {path} → {name} (id={obj['id']})")
-                    total += 1
-                except RuntimeError as e:
-                    print(f"  skip: {path} → {name} (id={obj['id']}): {e}")
+        total += _delete_objects_at_path(nb, path, filters)
     print(f"\n=== Deleted {total} objects ===")
+
+
+def _print_stale_for_paths(nb, paths: list, tag: str) -> int:
+    """Print and count stale managed objects for each path filtered by tag."""
+    total = 0
+    for path in paths:
+        for obj in nb.find_stale(path, tag=tag):
+            label = obj.get("name") or obj.get("display") or obj.get("address") or obj.get("prefix")
+            print(f"  {'would mark stale' if nb.dry_run else 'stale'}: {path} → {label} (id={obj['id']})")
+            total += 1
+    return total
 
 
 def report_stale_managed_objects(nb, inventory):
     """Report currently managed objects that no longer match desired lookups."""
     print(f"\n=== {'Planned' if nb.dry_run else 'Managed'} Drift Report ===")
-    managed_tag_exists = _managed_tag_exists_live(nb)
-    environment_tag_exists = _environment_tag_exists_live(nb, inventory)
-    if not managed_tag_exists:
+    if not _managed_tag_exists_live(nb):
         print(f"  no stale managed objects detected (ownership tag {MANAGED_TAG_NAME!r} not present live)")
         return 0
-
-    total = 0
-    for path in SHARED_STALE_TRACKED_PATHS:
-        stale = nb.find_stale(path, tag=MANAGED_TAG_SLUG)
-        if not stale:
-            continue
-        total += len(stale)
-        for obj in stale:
-            print(
-                f"  {'would mark stale' if nb.dry_run else 'stale'}: "
-                f"{path} → {obj.get('name') or obj.get('display') or obj.get('address') or obj.get('prefix')} "
-                f"(id={obj['id']})"
-            )
-    if environment_tag_exists:
-        for path in ENV_STALE_TRACKED_PATHS:
-            stale = nb.find_stale(path, tag=inventory["environment_tag"])
-            if not stale:
-                continue
-            total += len(stale)
-            for obj in stale:
-                print(
-                    f"  {'would mark stale' if nb.dry_run else 'stale'}: "
-                    f"{path} → {obj.get('name') or obj.get('display') or obj.get('address') or obj.get('prefix')} "
-                    f"(id={obj['id']})"
-                )
+    total = _print_stale_for_paths(nb, SHARED_STALE_TRACKED_PATHS, MANAGED_TAG_SLUG)
+    if _environment_tag_exists_live(nb, inventory):
+        total += _print_stale_for_paths(nb, ENV_STALE_TRACKED_PATHS, inventory["environment_tag"])
     if total == 0:
         print("  no stale managed objects detected")
     return total
 
 
+def _reconcile_services_for_vm(nb, vm: dict) -> None:
+    """Enforce that managed services on `vm` carry the same environment tag as their VM."""
+    vm_slugs = _tag_slugs(vm)
+    vm_env_tags = [s for s in vm_slugs if s.startswith(ENV_TAG_PREFIX)]
+    if not vm_env_tags:
+        return
+    vm_env_tag = vm_env_tags[0]
+    env_value = vm_env_tag[len(ENV_TAG_PREFIX):]
+    for svc in nb.get(
+        NB_IPAM_SERVICES,
+        parent_object_type="virtualization.virtualmachine",
+        parent_object_id=vm["id"],
+    ).get("results", []):
+        svc_slugs = _tag_slugs(svc)
+        if MANAGED_TAG_SLUG not in svc_slugs:
+            continue
+        svc_env_tags = [s for s in svc_slugs if s.startswith(ENV_TAG_PREFIX)]
+        if svc_env_tags and svc_env_tags[0] == vm_env_tag:
+            continue
+        runtime_slugs = [s for s in svc_slugs if s.startswith("runtime-source-")]
+        nb.patch_object(NB_IPAM_SERVICES, svc, {"tags": _managed_tag_refs(extra_tags=runtime_slugs, environment=env_value)})
+
+
 def reconcile_service_env_tags(nb):
-    """Ensure managed services carry the same environment tag as their parent VM.
-
-    This is a narrowly scoped reconciliation that patches service objects which
-    are owned by the automation but carry an environment tag different from
-    their VM parent. Runtime-source tags are preserved where present.
-    """
-    vms = nb.get(NB_VIRT_VIRTUAL_MACHINES, tag=MANAGED_TAG_SLUG).get("results", [])
-    for vm in vms:
-        vm_id = vm.get("id")
-        if not vm_id:
-            continue
-        vm_slugs = _tag_slugs(vm)
-        vm_env_tags = [s for s in vm_slugs if s.startswith(ENV_TAG_PREFIX)]
-        if not vm_env_tags:
-            continue
-        vm_env_tag = vm_env_tags[0]
-        # Derive environment token to pass to _managed_tag_refs
-        env_value = vm_env_tag[len(ENV_TAG_PREFIX):]
-
-        services = nb.get(
-            NB_IPAM_SERVICES,
-            parent_object_type="virtualization.virtualmachine",
-            parent_object_id=vm_id,
-        ).get("results", [])
-
-        for svc in services:
-            svc_slugs = _tag_slugs(svc)
-            if MANAGED_TAG_SLUG not in svc_slugs:
-                continue
-            svc_env_tags = [s for s in svc_slugs if s.startswith(ENV_TAG_PREFIX)]
-            if svc_env_tags and svc_env_tags[0] == vm_env_tag:
-                continue
-
-            # Preserve runtime-source tags while enforcing managed + VM env tag.
-            runtime_slugs = [s for s in svc_slugs if s.startswith("runtime-source-")]
-            new_tags = _managed_tag_refs(extra_tags=runtime_slugs, environment=env_value)
-            nb.patch_object(NB_IPAM_SERVICES, svc, {"tags": new_tags})
+    """Ensure managed services carry the same environment tag as their parent VM."""
+    for vm in nb.get(NB_VIRT_VIRTUAL_MACHINES, tag=MANAGED_TAG_SLUG).get("results", []):
+        if vm.get("id"):
+            _reconcile_services_for_vm(nb, vm)
 
 
 # ---------------------------------------------------------------------------
 # Augmentation helpers
 # ---------------------------------------------------------------------------
+
+
+def _get_stack_ip_candidates(stack: dict) -> list:
+    """Collect declared candidate probe addresses from a stack YAML definition."""
+    candidates = []
+    ip_raw = stack.get("ip_address")
+    if ip_raw:
+        candidates.append(ip_raw)
+    extra = stack.get("docker_socket_proxy_targets")
+    if isinstance(extra, list):
+        candidates.extend(extra)
+    elif isinstance(extra, str):
+        candidates.append(extra)
+    return candidates
+
+
+def _find_netbox_vms_for_ip(nb, ip: str) -> list[tuple]:
+    """Return (nb_vm, base_name, node_part) tuples for every VM reachable via `ip`."""
+    try:
+        ip_objs = nb.live_get(NB_IPAM_IP_ADDRESSES, address=ip)
+        if not isinstance(ip_objs, dict):
+            ip_objs = nb.get(NB_IPAM_IP_ADDRESSES, address=ip)
+        ip_results = ip_objs.get("results", []) if isinstance(ip_objs, dict) else []
+    except Exception:
+        return []
+
+    found = []
+    for ip_obj in ip_results:
+        if ip_obj.get("assigned_object_type") != "virtualization.vminterface":
+            continue
+        assigned_id = ip_obj.get("assigned_object_id")
+        if not assigned_id:
+            continue
+        try:
+            iface_res = nb.get(NB_VIRT_INTERFACES, id=assigned_id).get("results", [])
+        except Exception:
+            continue
+        if not iface_res:
+            continue
+        vm_ref = iface_res[0].get("virtual_machine")
+        vm_id = vm_ref.get("id") if isinstance(vm_ref, dict) else vm_ref
+        if not vm_id:
+            continue
+        try:
+            vm_res = nb.get(NB_VIRT_VIRTUAL_MACHINES, id=vm_id).get("results", [])
+        except Exception:
+            continue
+        if not vm_res:
+            continue
+        nb_vm = vm_res[0]
+        nb_name = nb_vm.get("name") or ""
+        if isinstance(nb_name, str) and "@" in nb_name:
+            base, nodepart = nb_name.split("@", 1)
+        else:
+            base = nb_name
+            nodepart = None  # caller fills from stack context
+        found.append((nb_vm, base, nodepart))
+    return found
+
+
+def _build_declared_vm_def(base: str, nodepart: str, ip: str, stack: dict) -> dict:
+    return {
+        "name": base,
+        "ip": ip if "/" in ip else f"{ip}/24",
+        "status": "unknown",
+        "vcpus": stack.get("cores", 1) or 1,
+        "memory": stack.get("memory", 0) or 0,
+        "disk": stack.get("rootfs_size", 0) or 0,
+        "description": stack.get("description", "declared in stack.yaml"),
+        "tags": stack.get("tags", []),
+        "services": [],
+        "mounts": [],
+        "vmid": stack.get("vmid") or 0,
+        "vm_type": "declared",
+        "node": nodepart,
+    }
+
+
+def _probe_socket_services_for_declared_vm(ip_addr: str, base: str, vm_ip: str, template: str) -> list[dict]:
+    """Probe a declared VM via socket-proxy template and return discovered services."""
+    try:
+        proxy_url = template.format(guest_ip=ip_addr)
+    except Exception:
+        return []
+    if not proxy_url:
+        return []
+    try:
+        probe_container = {"name": base, "config": {"net0": f"ip={vm_ip}"}}
+        return _build_socket_proxy_services(proxy_url, probe_container, guest_scoped=True)
+    except Exception:
+        return []
 
 
 def _augment_vms_with_declared_socket_proxy_targets(nb, vms, stacks):
@@ -1477,25 +1490,12 @@ def _augment_vms_with_declared_socket_proxy_targets(nb, vms, stacks):
     This function will not create new NetBox VM objects.
     """
     existing_ips = {vm.get("ip") for vm in vms if vm.get("ip")}
+    template = os.environ.get("DOCKER_SOCKET_PROXY_URL_TEMPLATE") or os.environ.get("DOCKER_SOCKET_PROXY_URL")
 
     for name, stack in stacks.items():
-        # Collect declared candidate probe addresses from common stack fields
-        candidates = []
-        ip_raw = stack.get("ip_address")
-        if ip_raw:
-            candidates.append(ip_raw)
-
-        extra_targets = stack.get("docker_socket_proxy_targets")
-        if isinstance(extra_targets, list):
-            candidates.extend(extra_targets)
-        elif isinstance(extra_targets, str):
-            candidates.append(extra_targets)
-
+        candidates = _get_stack_ip_candidates(stack)
         if not candidates:
             continue
-
-        # Preserve original behavior: if the stack name is already present in
-        # discovered VMs, skip the stack entirely (do not attempt augmentation).
         if any(vm.get("name") == name for vm in vms):
             continue
 
@@ -1503,106 +1503,20 @@ def _augment_vms_with_declared_socket_proxy_targets(nb, vms, stacks):
             ip = str(_resolve_env_token(ip_candidate)) if isinstance(ip_candidate, str) else None
             if not ip:
                 continue
-
-            # Normalize to address/prefix if template expects guest_ip without prefix
             ip_addr = ip.split("/", 1)[0]
             if ip in existing_ips or ip_addr in existing_ips:
-                # Skip candidates whose address is already present in discovered VMs
                 continue
 
-            # Try to map the declared IP to an existing NetBox VM; if an
-            # existing VM is found by IP, append a vm_def that points to that
-            # VM so the runtime inspection will attach services to the
-            # existing inventory object. Do NOT create new VMs here.
-            try:
-                # Use live_get to avoid client-side lookup coercion filtering
-                # when address tokens are provided without CIDR suffixes.
-                ip_objs = nb.live_get(NB_IPAM_IP_ADDRESSES, address=ip)
-                if not isinstance(ip_objs, dict):
-                    ip_objs = nb.get(NB_IPAM_IP_ADDRESSES, address=ip)
-                ip_results = ip_objs.get("results", []) if isinstance(ip_objs, dict) else []
-            except Exception:
-                ip_results = []
-
-            for ip_obj in ip_results:
-                if ip_obj.get("assigned_object_type") != "virtualization.vminterface":
-                    continue
-                assigned_id = ip_obj.get("assigned_object_id")
-                if not assigned_id:
-                    continue
-                try:
-                    iface_q = nb.get(NB_VIRT_INTERFACES, id=assigned_id)
-                    iface_res = iface_q.get("results", []) if isinstance(iface_q, dict) else []
-                except Exception:
-                    iface_res = []
-                if not iface_res:
-                    continue
-                iface = iface_res[0]
-                vm_ref = iface.get("virtual_machine")
-                vm_id = vm_ref.get("id") if isinstance(vm_ref, dict) else vm_ref
-                if not vm_id:
-                    continue
-                try:
-                    vm_q = nb.get(NB_VIRT_VIRTUAL_MACHINES, id=vm_id)
-                    vm_res = vm_q.get("results", []) if isinstance(vm_q, dict) else []
-                except Exception:
-                    vm_res = []
-                if not vm_res:
-                    continue
-                nb_vm = vm_res[0]
-                nb_name = nb_vm.get("name") or name
-                # Split NetBox name `foo@node` into base and node when present
-                if isinstance(nb_name, str) and "@" in nb_name:
-                    base, nodepart = nb_name.split("@", 1)
-                else:
-                    base = nb_name
+            for _nb_vm, base, nodepart in _find_netbox_vms_for_ip(nb, ip):
+                if nodepart is None:
                     nodepart = stack.get("proxmox", {}).get("target_node") or "external"
-
-                vm_def = {
-                    "name": base,
-                    "ip": ip if "/" in ip else f"{ip}/24",
-                    "status": "unknown",
-                    "vcpus": stack.get("cores", 1) or 1,
-                    "memory": stack.get("memory", 0) or 0,
-                    "disk": stack.get("rootfs_size", 0) or 0,
-                    "description": stack.get("description", "declared in stack.yaml"),
-                    "tags": stack.get("tags", []),
-                    "services": [],
-                    "mounts": [],
-                    "vmid": stack.get("vmid") or 0,
-                    "vm_type": "declared",
-                    "node": nodepart,
-                }
-
-                # Avoid duplicate appends for the same VM/ip
+                vm_def = _build_declared_vm_def(base, nodepart, ip, stack)
                 if not any(v.get("ip") == vm_def["ip"] and v.get("name") == vm_def["name"] for v in vms):
                     vms.append(vm_def)
-                # After appending a declared VM mapping, attempt a conservative
-                # re-probe via the configured socket-proxy template so that
-                # runtime services are available on the vm_def for later
-                # ensure/reconciliation steps. This avoids re-running the
-                # entire discovery pipeline.
-                template = os.environ.get("DOCKER_SOCKET_PROXY_URL_TEMPLATE") or os.environ.get("DOCKER_SOCKET_PROXY_URL")
                 if template:
-                    try:
-                        guest_ip = ip_addr
-                        try:
-                            proxy_url = template.format(guest_ip=guest_ip)
-                        except Exception:
-                            proxy_url = None
-                        if proxy_url:
-                            # Construct a minimal container-like object that
-                            # provides enough context for the socket-proxy
-                            # probe helper. Use guest_scoped=True to treat
-                            # returned containers as belonging to the guest.
-                            probe_container = {"name": base, "config": {"net0": f"ip={vm_def['ip']}"}}
-                            services = _build_socket_proxy_services(proxy_url, probe_container, guest_scoped=True)
-                            if services:
-                                vm_def["services"].extend(services)
-                    except Exception:
-                        # Non-fatal: do not fail augmentation for probe errors
-                        pass
-                # Candidate mapped; mark ip as seen and continue
+                    services = _probe_socket_services_for_declared_vm(ip_addr, base, vm_def["ip"], template)
+                    if services:
+                        vm_def["services"].extend(services)
                 existing_ips.add(ip)
 
 

--- a/terraform/lxc/stacks/netbox-stack/integrations/test_discover.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/test_discover.py
@@ -386,7 +386,7 @@ class TestBuildTopology(unittest.TestCase):
             )
 
         self.assertEqual(result, [])
-        build_vm_list.assert_called_once_with(fake_proxmox, {}, portainer=fake_portainer)
+        build_vm_list.assert_called_once_with(fake_proxmox, {}, portainer=fake_portainer, portainer_url=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **#204** (`check-proxmox-status.sh`): fixed two `set -euo pipefail` bugs — unbound `${1}` when called with no args, and optional `run_check` failures propagating as hard errors
- **#228** (Harbor password complexity): already fixed in a prior session. Closed without code change.
- **#254/#256** (Harbor OIDC steve sysadmin): postconfigure role now emits a clear warning when steve doesn't exist on fresh deploy, and asserts `oidc_admin_group` is configured correctly

## What changed

`scripts/check-proxmox-status.sh`:
- Added `""` case before `*)` in argument parser — no-arg invocation no longer hits unbound `${1}` under `set -u`
- Changed optional `run_check` to `return 0` instead of `return 1` — optional SSH warning no longer exits the whole script under `set -e`

`terraform/lxc/ansible/roles/harbor_postconfigure/tasks/main.yml`:
- Added warning debug task when OIDC steve user not found, explaining the deferred-to-first-login path and oidc_admin_group fallback
- Added `oidc_admin_group` verification assertion — misconfigured group now fails loudly

## Test plan

- [ ] Run `check-proxmox-status.sh` with no args against pve-test-vm — should complete without unbound variable or early exit on optional SSH check
- [ ] Run `deploy-harbor-stack.yml` on a fresh cycle — postconfigure should emit the warning + assert oidc_admin_group passes
- [ ] Run `deploy-harbor-stack.yml` after steve's first OIDC login — sysadmin assignment task should fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)