### PR TITLE
fix(harbor): default external_url scheme to http:// until TLS is wired

### DIFF
--- a/terraform/lxc/ansible/playbooks/deploy-harbor-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-harbor-stack.yml
@@ -54,7 +54,7 @@
   gather_facts: false
   vars:
     harbor_installer_hostname: "{{ lookup('env', 'HARBOR_HOSTNAME') | mandatory('HARBOR_HOSTNAME env var not set') }}"
-    harbor_installer_external_url: "{{ lookup('env', 'HARBOR_EXTERNAL_URL') | default('https://' ~ harbor_installer_hostname, true) }}"
+    harbor_installer_external_url: "{{ lookup('env', 'HARBOR_EXTERNAL_URL') | default('http://' ~ harbor_installer_hostname, true) }}"
   roles:
     - harbor_installer
 


### PR DESCRIPTION
## Summary

Fixes #208 — Harbor HTTP-only registry causing HTTPS token auth failure on fresh host image pulls.

**Root cause**: When `HARBOR_EXTERNAL_URL` is not set, the playbook was defaulting to `https://<hostname>`. Harbor then advertises `https://<hostname>/service/token` in its `WWW-Authenticate: Bearer realm=...` response. Docker's `insecure-registries` tells it to use HTTP for the image pull itself, but the token service URL comes from the registry's response header — so Docker still tries HTTPS for the token and hits connection refused.

**Fix**: Changed the default fallback from `https://` to `http://`. Harbor now advertises `http://<hostname>/service/token`, which Docker follows over HTTP. The existing `insecure-registries` daemon config on each host handles the rest.

**Migration path**: When Traefik TLS termination is added for Harbor, set `HARBOR_EXTERNAL_URL=https://<hostname>` in the env file. That restores HTTPS realm advertising without any playbook change.

## Test plan

- [ ] Deploy Harbor with `HARBOR_EXTERNAL_URL` unset — confirm `docker pull <harbor-host>/dockerhub/library/alpine:latest` succeeds on a fresh host
- [ ] Confirm Harbor API still reachable at `http://<harbor-host>/api/v2.0/`
- [ ] (Future) Set `HARBOR_EXTERNAL_URL=https://harbor.lab.gibbsgreatly.xyz` and verify HTTPS token auth works once Traefik terminates TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)