### PR TITLE
fix(harness): add Bats tests, concurrency lock, and NetBox static hosts

### DIFF
--- a/scripts/teardown-deploy-test.sh
+++ b/scripts/teardown-deploy-test.sh
@@ -51,6 +51,8 @@ EVIDENCE_DIR="${EVIDENCE_ROOT}/${STAMP}"
 LOG_DIR="${EVIDENCE_DIR}/logs"
 RUN_LOG="${LOG_DIR}/teardown-deploy-test-${STAMP}.log"
 STATE_FILE="${EVIDENCE_DIR}/state.json"
+LOCK_FILE="${EVIDENCE_ROOT}/.harness.lock"
+LOCK_HELD=false
 
 TRACKED_PHASES=(
   "source-preflight"
@@ -1094,6 +1096,44 @@ wait_for_authentik_api_ready() {
       echo "Authentik API token-auth probe did not return 200 after ${max_attempts} attempts" >&2
       exit 1
     ' _ "${authentik_url}" "${max_attempts}" "${delay_seconds}"
+}
+
+acquire_harness_lock() {
+  mkdir -p "${EVIDENCE_ROOT}"
+  if [[ -f "${LOCK_FILE}" ]]; then
+    local existing_pid existing_stamp
+    existing_pid="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('pid',''))" "${LOCK_FILE}" 2>/dev/null || true)"
+    existing_stamp="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('stamp',''))" "${LOCK_FILE}" 2>/dev/null || true)"
+    if [[ -n "${existing_pid}" ]] && kill -0 "${existing_pid}" 2>/dev/null; then
+      printf '[harness] ERROR: another harness run is active (PID %s, stamp %s)\n' \
+        "${existing_pid}" "${existing_stamp}" >&2
+      printf '[harness] Lock file: %s\n' "${LOCK_FILE}" >&2
+      printf '[harness] If the other process is no longer running, remove the lock file and retry.\n' >&2
+      return 1
+    fi
+    printf '[harness] WARNING: stale lock file (PID %s no longer running); removing.\n' "${existing_pid}" >&2
+    rm -f "${LOCK_FILE}"
+  fi
+  python3 -c "
+import json, os, sys
+data = {
+    'stamp': sys.argv[1],
+    'pid': str(os.getppid()),
+    'branch': sys.argv[2],
+    'commit': sys.argv[3],
+}
+print(json.dumps(data))
+" "${STAMP}" "$(git_current_branch)" "$(git_current_commit)" > "${LOCK_FILE}"
+  LOCK_HELD=true
+  printf '[harness] lock acquired: %s\n' "${LOCK_FILE}" >&2
+}
+
+release_harness_lock() {
+  if [[ "${LOCK_HELD}" == "true" ]]; then
+    rm -f "${LOCK_FILE}"
+    LOCK_HELD=false
+    printf '[harness] lock released\n' >&2
+  fi
 }
 
 require_execute_approval() {
@@ -2285,26 +2325,21 @@ main() {
     status)
       phase_status
       ;;
-    destroy)
-      run_phase_handler "destroy" phase_destroy
-      ;;
-    deploy-foundation)
-      run_phase_handler "deploy-foundation" phase_deploy_foundation
-      ;;
-    deploy-edge)
-      run_phase_handler "deploy-edge" phase_deploy_edge
-      ;;
-    activate-edge)
-      run_phase_handler "activate-edge" phase_activate_edge
-      ;;
-    deploy-platform)
-      run_phase_handler "deploy-platform" phase_deploy_platform
+    destroy|deploy-foundation|deploy-edge|activate-edge|deploy-platform|cycle)
+      acquire_harness_lock
+      trap 'release_harness_lock' EXIT
+      case "${PHASE}" in
+        destroy)          run_phase_handler "destroy"           phase_destroy ;;
+        deploy-foundation) run_phase_handler "deploy-foundation" phase_deploy_foundation ;;
+        deploy-edge)      run_phase_handler "deploy-edge"       phase_deploy_edge ;;
+        activate-edge)    run_phase_handler "activate-edge"     phase_activate_edge ;;
+        deploy-platform)  run_phase_handler "deploy-platform"   phase_deploy_platform ;;
+        cycle)            run_phase_handler "cycle"             phase_cycle ;;
+      esac
+      release_harness_lock
       ;;
     final-validation)
       run_phase_handler "final-validation" phase_final_validation
-      ;;
-    cycle)
-      run_phase_handler "cycle" phase_cycle
       ;;
     *)
       printf 'Unknown phase: %s\n\n' "${PHASE}" >&2

--- a/terraform/lxc/network/pve-test-vm.yaml
+++ b/terraform/lxc/network/pve-test-vm.yaml
@@ -190,6 +190,14 @@ inventory:
       role: workstation
       ip: 192.168.1.104
       description: "Linux desktop workstation"
+    - name: argon-01
+      role: iot
+      ip: 192.168.1.22
+      description: "Raspberry Pi — argon-01"
+    - name: argon-02
+      role: iot
+      ip: 192.168.1.23
+      description: "Raspberry Pi — argon-02"
 
 policies:
   - from: edge_seg

--- a/terraform/lxc/network/pve-test-vm.yaml
+++ b/terraform/lxc/network/pve-test-vm.yaml
@@ -181,7 +181,11 @@ inventory:
       token_secret_env: PVE_READONLY_TOKEN_SECRET
       portainer_url: "https://management-stack.gibbsgreatly.xyz:9443"
       portainer_api_key_env: PORTAINER_TOKEN
-  static_hosts: []
+  static_hosts:
+    - name: pve-test-vm
+      role: hypervisor-vm
+      ip: 192.168.1.41
+      description: "Proxmox test hypervisor — VM on pve (LAN management IP)"
 
 policies:
   - from: edge_seg

--- a/terraform/lxc/network/pve-test-vm.yaml
+++ b/terraform/lxc/network/pve-test-vm.yaml
@@ -186,6 +186,10 @@ inventory:
       role: hypervisor-vm
       ip: 192.168.1.41
       description: "Proxmox test hypervisor — VM on pve (LAN management IP)"
+    - name: linux-desktop
+      role: workstation
+      ip: 192.168.1.104
+      description: "Linux desktop workstation"
 
 policies:
   - from: edge_seg

--- a/terraform/lxc/stacks/netbox-stack/integrations/populate.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/populate.py
@@ -85,6 +85,7 @@ CLUSTERS = [
 NETWORK_INTENT_FILES = {
     "pve": "pve.yaml",
     "pve-test": "pve-test.yaml",
+    "pve-test-vm": "pve-test-vm.yaml",
 }
 
 try:

--- a/tests/mocks/curl
+++ b/tests/mocks/curl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Mock curl: output 401 for /v2/ checks, 200 for everything else
+for arg in "$@"; do
+  case "${arg}" in
+    *"/v2/"*)
+      printf 'HTTP/1.1 401 Unauthorized\r\n'
+      exit 0
+      ;;
+  esac
+done
+printf '{"status": "ok"}\n'
+exit 0

--- a/tests/mocks/dig
+++ b/tests/mocks/dig
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Mock dig: return a generic A record answer
+printf ';; ANSWER SECTION:\nexample.test. 5 IN A 192.168.30.10\n'
+exit 0

--- a/tests/mocks/ssh
+++ b/tests/mocks/ssh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Mock: exit 0 for any ssh invocation
+exit 0

--- a/tests/mocks/terragrunt
+++ b/tests/mocks/terragrunt
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Mock: exit 0 for any terragrunt command
+exit 0

--- a/tests/mocks/with-secrets
+++ b/tests/mocks/with-secrets
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Mock: pass through all arguments
+exec "$@"

--- a/tests/teardown-harness.bats
+++ b/tests/teardown-harness.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+# Bats tests for scripts/teardown-deploy-test.sh
+#
+# Run with: bats tests/teardown-harness.bats
+# Requires bats-core >= 1.5.0  (https://github.com/bats-core/bats-core)
+# No live network, Proxmox, or secrets access required.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+HARNESS="${REPO_ROOT}/scripts/teardown-deploy-test.sh"
+EVIDENCE_ROOT="${REPO_ROOT}/docs/teardown-test/artifacts/evidence"
+MOCK_DIR="${REPO_ROOT}/tests/mocks"
+
+# Minimal env for offline runs: no real IPs, no secrets.
+# Tests that exercise approval/execute guards do not reach any live command.
+export LAB_IP_PROXY=192.168.30.10
+export LAB_IP_AUTHENTIK=192.168.20.10
+export LAB_IP_DNS=192.168.40.1
+export LAB_IP_PORTAINER=192.168.20.20
+export LAB_GW_MGMT=192.168.20.1
+export LAB_DOMAIN=lab.example.test
+export PVE_ENV=pve-test-vm
+
+setup() {
+  # Prepend mocks so they shadow real executables for network/infra calls.
+  export PATH="${MOCK_DIR}:${PATH}"
+  # Use a unique stamp per test to avoid cross-test evidence collision.
+  export TEARDOWN_TEST_STAMP="bats-test-$$-${BATS_TEST_NUMBER}"
+  export TEARDOWN_INVENTORY_FILE="${REPO_ROOT}/docs/teardown-test/inventory.md"
+}
+
+teardown() {
+  local evidence_dir="${EVIDENCE_ROOT}/${TEARDOWN_TEST_STAMP}"
+  rm -rf "${evidence_dir}"
+  rm -f "${EVIDENCE_ROOT}/.harness.lock"
+}
+
+# ---------------------------------------------------------------------------
+# 1. --help is side-effect free
+# ---------------------------------------------------------------------------
+
+@test "--help exits 0 and prints usage" {
+  run bash "${HARNESS}" --help
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"Usage:"* ]]
+}
+
+@test "--help writes no evidence directory" {
+  local stamp="bats-help-$$"
+  TEARDOWN_TEST_STAMP="${stamp}" run bash "${HARNESS}" --help
+  [ "${status}" -eq 0 ]
+  [ ! -d "${EVIDENCE_ROOT}/${stamp}" ]
+}
+
+# ---------------------------------------------------------------------------
+# 2. Missing --approval-text fails before live commands
+# ---------------------------------------------------------------------------
+
+@test "destroy --execute without --approval-text fails before any live command" {
+  run bash "${HARNESS}" destroy --execute
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"approval"* ]] || [[ "${output}" == *"approve"* ]]
+}
+
+@test "cycle --execute without --approval-text fails before any live command" {
+  run bash "${HARNESS}" cycle --execute
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"approval"* ]] || [[ "${output}" == *"approve"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# 3. Mutating phase without --execute fails
+# ---------------------------------------------------------------------------
+
+@test "destroy without --execute fails" {
+  run bash "${HARNESS}" destroy
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+@test "deploy-foundation without --execute fails" {
+  run bash "${HARNESS}" deploy-foundation
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+@test "deploy-edge without --execute fails" {
+  run bash "${HARNESS}" deploy-edge
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+@test "activate-edge without --execute fails" {
+  run bash "${HARNESS}" activate-edge
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+@test "deploy-platform without --execute fails" {
+  run bash "${HARNESS}" deploy-platform
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+@test "cycle without --execute fails" {
+  run bash "${HARNESS}" cycle
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"--execute"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# 4. Approval phrase matching is case-insensitive
+# ---------------------------------------------------------------------------
+# These tests stop at the approval-packet gate (not live), which is fine —
+# the approval-text guard ran and accepted the phrase before that check.
+
+@test "approval phrase 'approve' (lowercase) is accepted" {
+  run bash "${HARNESS}" destroy --execute --approval-text "approve" --disposable
+  # disposable skips packet validation; should fail at guard_target (no live env)
+  # but NOT at require_execute_approval — so error must NOT mention 'approval-text'
+  [[ "${output}" != *"requires approval text"* ]]
+}
+
+@test "approval phrase 'APPROVE' (uppercase) is accepted" {
+  run bash "${HARNESS}" destroy --execute --approval-text "APPROVE" --disposable
+  [[ "${output}" != *"requires approval text"* ]]
+}
+
+@test "approval phrase 'I Approve this change' (mixed) is accepted" {
+  run bash "${HARNESS}" destroy --execute --approval-text "I Approve this change" --disposable
+  [[ "${output}" != *"requires approval text"* ]]
+}
+
+@test "wrong approval phrase 'nope' is rejected" {
+  run bash "${HARNESS}" destroy --execute --approval-text "nope"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"approval text"* ]] || [[ "${output}" == *"approve"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# 5. --stamp routes evidence to the named directory
+# ---------------------------------------------------------------------------
+
+@test "--stamp routes state.json to the stamped evidence directory" {
+  local stamp="bats-stamp-fixed-9999"
+  TEARDOWN_TEST_STAMP="" LAB_IP_PROXY=192.168.30.10 \
+    run bash "${HARNESS}" source-preflight --stamp "${stamp}"
+  local evidence_dir="${EVIDENCE_ROOT}/${stamp}"
+  [ -f "${evidence_dir}/state.json" ]
+  rm -rf "${evidence_dir}"
+}
+
+@test "--stamp routes run log to the stamped evidence directory" {
+  local stamp="bats-stamp-runlog-9999"
+  TEARDOWN_TEST_STAMP="" LAB_IP_PROXY=192.168.30.10 \
+    run bash "${HARNESS}" source-preflight --stamp "${stamp}"
+  local log_file="${EVIDENCE_ROOT}/${stamp}/logs/teardown-deploy-test-${stamp}.log"
+  [ -f "${log_file}" ]
+  rm -rf "${EVIDENCE_ROOT}/${stamp}"
+}
+
+# ---------------------------------------------------------------------------
+# 6. Concurrency lock: second harness run blocked while first holds lock
+# ---------------------------------------------------------------------------
+
+@test "second destructive run blocked when lock file is held by live PID" {
+  # Simulate a live lock held by the current shell ($$)
+  mkdir -p "${EVIDENCE_ROOT}"
+  python3 -c "
+import json, os, sys
+data = {'stamp': 'fake-20260101-000000', 'pid': str(os.getpid()), 'branch': 'test', 'commit': 'abc123'}
+print(json.dumps(data))
+" > "${EVIDENCE_ROOT}/.harness.lock"
+
+  run bash "${HARNESS}" destroy --execute --approval-text "approve" --disposable
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"another harness run is active"* ]] || \
+    [[ "${output}" == *"lock"* ]]
+
+  rm -f "${EVIDENCE_ROOT}/.harness.lock"
+}
+
+@test "stale lock (dead PID) is cleared and run proceeds past lock check" {
+  # Write a lock with a PID that doesn't exist
+  mkdir -p "${EVIDENCE_ROOT}"
+  python3 -c "
+import json
+data = {'stamp': 'fake-stale', 'pid': '99999999', 'branch': 'test', 'commit': 'abc123'}
+print(json.dumps(data))
+" > "${EVIDENCE_ROOT}/.harness.lock"
+
+  # Should get past the lock check (stale cleared) and fail for other reasons
+  run bash "${HARNESS}" destroy --execute --approval-text "approve"
+  # Must NOT fail with "another harness run is active"
+  [[ "${output}" != *"another harness run is active"* ]]
+  rm -f "${EVIDENCE_ROOT}/.harness.lock"
+}


### PR DESCRIPTION
## Summary

- **5a**: New `tests/teardown-harness.bats` — 14 offline Bats tests covering: `--help` side-effect free, all 6 mutating phases require `--execute`, approval phrase case-insensitivity, `--stamp` evidence routing, and concurrency lock (active PID blocks, dead PID clears with warning).
- **5b**: Concurrency lock in `scripts/teardown-deploy-test.sh` — `acquire_harness_lock()` / `release_harness_lock()` with PID-based liveness check; acquired in `main()` before all destructive phases; released on EXIT trap.
- **5c**: `pve-test-vm.yaml` `static_hosts` populated with 4 LAN hosts: `pve-test-vm` (192.168.1.41), `linux-desktop` (192.168.1.104), `argon-01` (192.168.1.22, Raspberry Pi), `argon-02` (192.168.1.23, Raspberry Pi). Hostnames confirmed via SSH.
- **5d**: Added `pve-test-vm` entry to `NETWORK_INTENT_FILES` in `populate.py` — without this `PVE_ENV=pve-test-vm` failed with "Unsupported NETBOX network environment".

## Promotion gate

- Teardown test validated per operator confirmation 2026-06-15

## Test plan

- [ ] `bats tests/teardown-harness.bats` — all 14 tests pass
- [ ] `PVE_ENV=pve-test-vm python3 populate.py --dry-run` resolves `pve-test-vm.yaml` without error
- [ ] NetBox populate run: `argon-01`, `argon-02`, `linux-desktop`, `pve-test-vm` appear as managed devices with correct IPs
- [ ] Second concurrent harness run blocked by lock; stale lock cleared automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)