### PR TITLE
feat(portainer): Sprint 01 — backup/restore validated

### DIFF
--- a/docs/monitoring-stack/design.md
+++ b/docs/monitoring-stack/design.md
@@ -2,29 +2,37 @@
 
 ## Overview
 
-The monitoring-stack LXC (192.168.20.12, `mgmt_seg`) runs VictoriaMetrics, Loki, Grafana, and Promtail via Docker Compose. Grafana is the sole browser-facing service (via Traefik + Authentik). VictoriaMetrics and Loki are internal-only data stores — they receive data from agents and are queried by Grafana.
-
-This document started as the implementation plan and now also records the live
-state, remaining gaps, and post-deploy fixes.
+The monitoring-stack LXC (192.168.20.12, `mgmt_seg`) runs VictoriaMetrics, Loki, Grafana, and Promtail via Docker Compose. Grafana is the sole browser-facing service (via Traefik + Authentik). VictoriaMetrics and Loki are internal-only data stores.
 
 ---
 
-## Current State (as of 2026-05-31)
+## Location
 
-**All five implementation phases are complete.** The monitoring stack is fully deployed and collecting metrics and logs from all lab stacks.
+| | |
+|---|---|
+| VMID | 20012 |
+| Zone | mgmt_seg (192.168.20.12) |
+| URL | https://grafana.lab.gibbsgreatly.xyz |
+| Auth | Authentik OIDC |
+| RAM | 1536 MB |
+| Docker mount | 52 GB at `/var/lib/docker` (`infrastructure-containers:subvol-20012-disk-1`) |
+
+---
+
+## Current State
+
+**All five implementation phases are complete.** Metrics and logs are collected from all lab stacks.
 
 ### Running services
 
-| Service | Status | Notes |
-|---------|--------|-------|
-| VictoriaMetrics | Running, `:8428` | `--retentionPeriod=90d`; scrape config at `/etc/vm/scrape.yml` mounted into container |
-| Loki | Running, `:3100` | Filesystem storage, schema v13; **no retention period configured** (see Remaining Work) |
-| Grafana | Running, `:3000` | OAuth via Authentik; accessible at `https://grafana.lab.gibbsgreatly.xyz` via Traefik |
-| Promtail (self) | Running | Docker discovery + `/var/log` on monitoring-stack |
+| Service | Port | Notes |
+|---------|------|-------|
+| VictoriaMetrics | `:8428` | `--retentionPeriod=90d`; scrape config at `/etc/vm/scrape.yml` |
+| Loki | `:3100` | Filesystem storage, schema v13; no retention period set (see Remaining Work) |
+| Grafana | `:3000` | OAuth via Authentik |
+| Promtail (self) | — | Docker discovery + `/var/log` on monitoring-stack |
 
 ### Active scrape targets
-
-All targets below are `up` unless noted:
 
 | Job | Instance | Status |
 |-----|----------|--------|
@@ -34,54 +42,50 @@ All targets below are `up` unless noted:
 | coredns | 192.168.20.13:9153 | ✅ up |
 | traefik | 192.168.30.10:8082 | ✅ up |
 | authentik | 192.168.20.10:9300 | ✅ up |
-| harbor-exporter | 192.168.40.10:9090 | ✅ implemented in code |
-| harbor-core | 192.168.40.10:9090?comp=core | ✅ implemented in code |
-| harbor-registry | 192.168.40.10:9090?comp=registry | ✅ implemented in code |
-| harbor-jobservice | 192.168.40.10:9090?comp=jobservice | ✅ implemented in code |
-| harbor-findings-exporter | monitoring-stack internal service | ✅ implemented in code |
+| harbor-exporter | 192.168.40.10:9090 | ✅ up |
+| harbor-core | 192.168.40.10:9090?comp=core | ✅ up |
+| harbor-registry | 192.168.40.10:9090?comp=registry | ✅ up |
+| harbor-jobservice | 192.168.40.10:9090?comp=jobservice | ✅ up |
+| harbor-findings-exporter | monitoring-stack internal | ✅ up |
 | netbox | 192.168.40.12:8080 | ✅ up |
 | victoriametrics | 192.168.20.12:8428 | ✅ up |
 | loki | 192.168.20.12:3100 | ✅ up |
 | grafana | 192.168.20.12:3000 | ✅ up |
-| step-ca | — | ❌ absent — step-ca scrape job was not deployed (see Remaining Work) |
+| step-ca | — | ❌ not deployed — TLS complexity deferred (see Remaining Work) |
 
 ### Deployed dashboards
 
-| Dashboard | Variable | Notes |
-|-----------|----------|-------|
-| Lab Overview | — | Per-host CPU/mem/disk across all stacks |
-| Node Detail | `stack` (node_exporter stack label) | Full node_exporter breakdown for selected stack |
-| Docker Containers | `stack` (cadvisor stack label) | Per-container CPU/mem/net/disk |
-| Traefik Ingress | — | Request rate, latency, error rate |
-| CoreDNS | — | Query rate, NXDOMAIN rate, cache hit % |
-| Harbor Operations | — | Component health, queue state, proxy-cache activity, registry/API traffic |
-| Harbor Scan Coverage | `project` | Findings exporter health, scan coverage, stale scans, severity totals |
-| Harbor CVE Inventory | — | Detailed CVE rows from the live Harbor findings feed |
-| Lab Logs | — | Full-stack log explorer |
-| Auth Logs | — | SSH/sudo/auth.log across all hosts |
+| Dashboard | Notes |
+|-----------|-------|
+| Lab Overview | Per-host CPU/mem/disk across all stacks |
+| Node Detail | Full node_exporter breakdown for selected stack |
+| Docker Containers | Per-container CPU/mem/net/disk (cAdvisor) |
+| Traefik Ingress | Request rate, latency, error rate |
+| CoreDNS | Query rate, NXDOMAIN rate, cache hit % |
+| Harbor Operations | Component health, queue state, proxy-cache activity |
+| Harbor Scan Coverage | Findings exporter health, scan coverage, severity totals |
+| Harbor CVE Inventory | Detailed CVE rows from the live Harbor findings feed |
+| Lab Logs | Full-stack log explorer (Loki) |
+| Auth Logs | SSH/sudo/auth.log across all hosts (Loki) |
 
-> Harbor now has operations, scan-coverage, and CVE inventory dashboards.
-> The remaining Harbor monitoring gaps are alerting and dashboard refinement,
-> not basic Harbor visibility or datasource wiring.
+### Notable deviations from original plan
 
-### Deviations from the original plan
+- **Stack labels**: Both `node_exporter` and `cadvisor` use per-target `static_configs` with `labels: {stack: <name>}` rather than flat IP lists.
+- **Traefik metrics**: Added `metrics: prometheus` block on `:8082` post-deploy when Traefik Ingress dashboard showed no data.
+- **step-ca scrape job**: Deferred — TLS complexity (homelab CA mount into VictoriaMetrics).
+- **Scrape config written inline**: `deploy-monitoring-stack.yml` writes scrape config via `ansible.builtin.copy` with inline `content:` block, not a separate `.j2` template.
 
-- **Stack labels on scrape targets**: Both `node_exporter` and `cadvisor` scrape jobs use per-target `static_configs` with `labels: {stack: <name>}` rather than flat IP lists. Dashboard variables use the `stack` label for host selection (not the raw `instance` label).
-- **Traefik metrics endpoint**: Added `metrics: prometheus` block in Traefik static config on `:8082`. The playbook was not originally planned to include this — it was added post-deploy when the Traefik Ingress dashboard showed no data.
-- **step-ca scrape job**: Not deployed. The TLS complexity (homelab CA mount into VictoriaMetrics container) was deferred.
-- **Scrape config written inline** (not a `.j2` template file): The `deploy-monitoring-stack.yml` playbook writes the scrape config via `ansible.builtin.copy` with an inline `content:` block, using Jinja2 `lookup('env', ...)` — not a separate `.j2` template file as originally planned. Both approaches work; the inline approach keeps all monitoring config in one playbook.
+### Post-deploy fixes
 
-### Post-deploy fixes applied
-
-| Fix | Commit | Issue |
-|-----|--------|-------|
-| `grafana` DNS record pointed to monitoring IP instead of proxy | d7c8a8d | `ERR_CONNECTION_REFUSED` in browser |
-| `portainer` and `netbox` DNS A records missing from seed zone | 14003fa | `DNS_PROBE_POSSIBLE` in browser |
-| `provision.sh` now regenerates CoreDNS zone from EdgeManifests before every dns-stack deploy | 90f9ead | Seed zone and generated zone could diverge |
-| Traefik metrics endpoint not configured | d884991 | Traefik Ingress dashboard showed no data |
-| node_exporter and cadvisor scrape jobs had no stack labels | d884991, 9cc83dc | Dashboards showed raw IP addresses instead of stack names |
-| `notify: Restart VictoriaMetrics` placed between `content: \|` and block content | 9cc83dc | YAML parse error; scrape config was never written |
-| `docker-containers.json` and `node-detail.json` used `instance` variable | d884991, 9cc83dc | Variable queries returned IPs, not stack names |
+| Fix | Commit |
+|-----|--------|
+| `grafana` DNS record pointed to monitoring IP instead of proxy | d7c8a8d |
+| `portainer` and `netbox` DNS A records missing from seed zone | 14003fa |
+| `provision.sh` regenerates CoreDNS zone before dns-stack deploy | 90f9ead |
+| Traefik metrics endpoint not configured | d884991 |
+| node_exporter and cadvisor scrape jobs had no stack labels | d884991, 9cc83dc |
+| `notify: Restart VictoriaMetrics` placed inside `content: \|` block | 9cc83dc |
+| `docker-containers.json` and `node-detail.json` used `instance` variable | d884991, 9cc83dc |
 
 ---
 
@@ -107,45 +111,27 @@ All targets below are `up` unless noted:
  └──────────────┘
 ```
 
-**Metrics flow**: VictoriaMetrics scrapes node_exporter (port 9100) and cAdvisor (port 8080) running on each LXC, plus application metrics endpoints directly. Pull model — VictoriaMetrics initiates all scrapes. No push agents (vmagent) required at this scale.
+**Metrics flow**: VictoriaMetrics scrapes node_exporter (:9100) and cAdvisor (:8080) on each LXC, plus application metrics endpoints directly. Pull model — VictoriaMetrics initiates all scrapes.
 
-**Log flow**: A Promtail instance on each LXC pushes log lines to Loki at `http://192.168.20.12:3100/loki/api/v1/push`. Promtail runs as a Docker container on Docker stacks and as a systemd service on non-Docker stacks.
-
-**Note on step-ca metrics**: step-ca exposes Prometheus metrics at `https://192.168.20.11:9443/metrics` (HTTPS with TLS). VictoriaMetrics must be configured with `tls_config.insecure_skip_verify: true` for this target, or the homelab root CA must be mounted into the VictoriaMetrics container. The homelab CA path is already available on the host at `/usr/local/share/ca-certificates/homelab-root.crt`.
+**Log flow**: Promtail on each LXC pushes to Loki at `http://192.168.20.12:3100/loki/api/v1/push`. Docker stacks run Promtail as a Docker container; non-Docker stacks run it as a systemd service.
 
 ---
 
 ## Network Reachability
 
-VictoriaMetrics and Loki need to reach all segments. Inter-VLAN routing is handled by MikroTik. The MikroTik forward chain has **no inter-VLAN rules** — only WAN and parental-control rules targeting `bridgeLocal`. Traffic between vlan10-build, vlan20-mgmt, vlan30-edge, and vlan40-infra is unrestricted, which is already demonstrated by every stack reaching apt-cacher and Harbor across segments.
+Inter-VLAN routing via MikroTik. No firewall changes required — the forward chain has no inter-VLAN rules, so all VLAN segments can reach monitoring-stack freely.
 
-**No MikroTik firewall changes are required.** The following ports will be reachable from 192.168.20.12 as soon as the exporters are deployed:
-
-| Port | Service | Stacks |
-|------|---------|--------|
+| Port | Service | Notes |
+|------|---------|-------|
 | 9100 | node_exporter | All LXCs |
-| 8080 | cAdvisor | Docker stacks (except netbox-stack — see port conflict note below) |
-| 8081 | cAdvisor (netbox-stack only) | netbox-stack exposes app metrics on :8080, so cAdvisor uses host port 8081 |
+| 8080 | cAdvisor | Docker stacks |
+| 8081 | cAdvisor (netbox-stack only) | Port conflict with NetBox app on :8080 |
 | 9153 | CoreDNS metrics | dns-stack |
 | 8082 | Traefik metrics | proxy-stack |
-| 9090 | Harbor metrics | harbor-stack — enabled and scrapeable today |
-| 9300 | Authentik metrics | authentik-stack — port not published in compose; must be added |
-| 9443 | step-ca metrics (HTTPS) | step-ca-stack — TLS, needs CA or skip-verify in scrape config |
-| 3100 | Loki ingest (from Promtail) | monitoring-stack receives only |
-
-**Port conflict — netbox-stack**: NetBox's web service is published on `:8080`. cAdvisor also defaults to `:8080`. On netbox-stack, cAdvisor must be published on host port `8081` (`8081:8080`) to avoid the collision. VictoriaMetrics scrapes cAdvisor on netbox-stack at `:8081`.
-
-**Authentik metrics not yet published**: The `server` container in `authentik-stack/docker-compose.yml` only publishes port `9000`. Port `9300` needs to be added and `AUTHENTIK_LISTEN__METRICS: "0.0.0.0:9300"` must be set in the Authentik server environment.
-
-**Harbor metrics enabled**: The `harbor_installer` role's `harbor.yml.j2`
-template now includes a `metric:` block and Harbor metrics are currently being
-scraped successfully. The monitoring playbook now splits Harbor into
-`harbor-exporter`, `harbor-core`, `harbor-registry`, and
-`harbor-jobservice` scrape jobs. The remaining Harbor gap is no longer basic
-operations visibility; it is artifact-level scan coverage beyond native Harbor
-metrics.
-
-**NetBox has no native Prometheus metrics**: NetBox does not expose `:8080/metrics` out of the box. The `django-prometheus` middleware must be added to the NetBox configuration (via `METRICS_ENABLED: true` in the netbox-docker stack) before VictoriaMetrics can scrape it. This is a prerequisite for that scrape job; see Phase 3 notes.
+| 9090 | Harbor metrics | harbor-stack |
+| 9300 | Authentik metrics | authentik-stack |
+| 9443 | step-ca metrics (HTTPS) | step-ca-stack — TLS, needs CA or skip-verify |
+| 3100 | Loki ingest | monitoring-stack receives from Promtail agents |
 
 ---
 
@@ -157,270 +143,60 @@ metrics.
 |-------|------|:---:|:---:|---|:---:|
 | dns-stack | mgmt_seg | ✓ | — | CoreDNS :9153 | ✓ (systemd) |
 | step-ca-stack | mgmt_seg | ✓ | — | step-ca :9443/metrics | ✓ (systemd) |
-| monitoring-stack | mgmt_seg | ✓ | ✓ | VM :8428, Loki :3100, Grafana :3000 | ✓ (already deployed) |
+| monitoring-stack | mgmt_seg | ✓ | ✓ | VM :8428, Loki :3100, Grafana :3000 | ✓ |
 | portainer-stack | mgmt_seg | ✓ | ✓ | — | ✓ (Docker) |
-| authentik-stack | mgmt_seg | ✓ | ✓ | Authentik :9300/metrics ⚠️ | ✓ (Docker) |
+| authentik-stack | mgmt_seg | ✓ | ✓ | Authentik :9300/metrics | ✓ (Docker) |
 | proxy-stack | edge_seg | ✓ | ✓ | Traefik :8082/metrics | ✓ (Docker) |
-| harbor-stack | infra_seg | ✓ | ✓ | Harbor :9090/metrics ⚠️ | ✓ (Docker) |
+| harbor-stack | infra_seg | ✓ | ✓ | Harbor :9090/metrics | ✓ (Docker) |
 | apt-cacher-stack | infra_seg | ✓ | — | — | ✓ (systemd) |
-| netbox-stack | infra_seg | ✓ | ✓ | NetBox :8080/metrics ⚠️ | ✓ (Docker) |
+| netbox-stack | infra_seg | ✓ | ✓ | NetBox :8080/metrics | ✓ (Docker) |
 | ci-runner-01 | build_seg | ✓ | — | — | ✓ (systemd) |
 
-**Proxmox host** (192.168.1.2 / pve.gibbsgreatly.xyz): node_exporter will be installed directly on the Proxmox host to monitor hypervisor-level CPU, memory, disk, and LXC/VM count. This is a manual one-time bootstrap, not managed by the LXC provisioning pipeline.
+**Proxmox host** (192.168.1.2): node_exporter must be installed manually — not managed by LXC provisioning pipeline.
 
-### Application metric endpoints
-
-Where Prometheus scrape endpoints exist (or will be enabled), they will be scraped directly by VictoriaMetrics:
+### Application metrics endpoints
 
 | Service | Endpoint | Ready? | Notes |
 |---------|----------|--------|-------|
-| CoreDNS | `:9153/metrics` | ✓ | Enabled by default in CoreDNS config |
-| Traefik | `:8082/metrics` | ✓ | Enabled via `--metrics.prometheus` flag |
-| Authentik | `:9300/metrics` | ✗ | Port not published; needs `AUTHENTIK_LISTEN__METRICS` env var + port 9300 added to compose |
-| Harbor exporter | `:9090/metrics` | ✓ | Project totals, queue state, Harbor component health |
-| Harbor core | `:9090/metrics?comp=core` | ✓ | Core API request rate and latency |
-| Harbor registry | `:9090/metrics?comp=registry` | ✓ | Registry request/storage metrics |
-| Harbor jobservice | `:9090/metrics?comp=jobservice` | ✓ | Scan/job throughput and processing time |
-| NetBox | `:8080/metrics` | ✗ | Requires `django-prometheus`; needs `METRICS_ENABLED: true` in netbox-docker env |
-| step-ca | `:9443/metrics` | ✓ | HTTPS; scrape requires homelab CA in VictoriaMetrics container |
-| VictoriaMetrics (self) | `:8428/metrics` | ✓ | Always available |
-| Loki (self) | `:3100/metrics` | ✓ | Always available |
-| Grafana (self) | `:3000/metrics` | ✓ | Always available |
-
----
-
-## Implementation Phases
-
-### Phase 1 — node_exporter on all LXCs ✅
-
-**Goal**: Every managed LXC exposes OS metrics on :9100.
-
-Tasks:
-- Add a `node_exporter` role (new) that installs the node_exporter binary via apt or a downloaded release, creates a systemd unit, and starts it
-- Apply the role from `lxc_base` using a conditional variable `monitoring_enabled: true` (default true) so it can be skipped for template/test containers
-- Verify port 9100 is accessible from monitoring-stack after provisioning
-- Re-provision all platform stacks to pick up the role
-
-Role behaviour:
-- Install `prometheus-node-exporter` from apt (available in Debian 13)
-- Enable and start `prometheus-node-exporter.service`
-- Expose metrics on all interfaces, port 9100
-- No authentication needed — mgmt_seg firewall restricts access
-
-### Phase 2 — cAdvisor on Docker stacks ✅
-
-**Goal**: Each Docker-based LXC exposes container-level CPU/memory/net/disk metrics on :8080.
-
-Tasks:
-- Add a `cadvisor` service to the Docker Compose definition in each Docker stack's deploy playbook (harbor, authentik, monitoring, netbox, proxy, portainer)
-- Image: `gcr.io/cadvisor/cadvisor:v0.49.1` (pinned) — mirrored to Harbor as `harbor.lab.gibbsgreatly.xyz/dockerhub/cadvisor/cadvisor:v0.49.1`
-- Mount `/:/rootfs:ro`, `/var/run:/var/run:ro`, `/sys:/sys:ro`, `/var/lib/docker:/var/lib/docker:ro`
-- Port: `8080:8080` on all stacks **except** netbox-stack where it must be `8081:8080` (port conflict with NetBox web service on :8080)
-- Restart policy: `unless-stopped`
-- Harbor mirror must have the image available before stacks redeploy
-
-### Phase 2a — Enable application metrics endpoints ✅
-
-**Goal**: Enable the Prometheus endpoints on Authentik, Harbor, and NetBox so that Phase 3 can scrape them.
-
-**Authentik** (`stacks/authentik-stack/docker-compose.yml`):
-- Add `- "9300:9300"` to the `server` service `ports` section
-- Add `AUTHENTIK_LISTEN__METRICS: "0.0.0.0:9300"` to the `server` service `environment` block
-
-**Harbor** (`ansible/roles/harbor_installer/templates/harbor.yml.j2`):
-- Add the following block to the template:
-  ```yaml
-  metric:
-    enabled: true
-    port: 9090
-    path: /metrics
-  ```
-- Re-run `deploy-harbor-stack.yml` to regenerate harbor configuration and restart Harbor
-
-**NetBox** (`stacks/netbox-stack/docker-compose.yml`):
-- Add `METRICS_ENABLED: "True"` to the `netbox` service environment block
-- Note: `netbox-docker` v4.x includes `django-prometheus` and respects `METRICS_ENABLED`. Verify against the upstream `netbox-docker` changelog for the exact variable name.
-
-### Phase 3 — VictoriaMetrics scrape config ✅
-
-**Goal**: VictoriaMetrics pulls metrics from all targets on a schedule.
-
-Tasks:
-- Write a `victoria-metrics/scrape.yml` (via Ansible template) to the monitoring-stack compose directory
-- Mount the file into the VictoriaMetrics container at `/etc/vm/scrape.yml`
-- Mount the homelab root CA into VictoriaMetrics at `/etc/ssl/certs/homelab-root.crt:ro` (needed for step-ca TLS scrape)
-- Add `--promscrape.config=/etc/vm/scrape.yml` to the VictoriaMetrics `command` flags in the compose definition
-- Scrape interval: 30s globally, 15s for Traefik/CoreDNS (higher-frequency services)
-
-Scrape config template (use `lookup('env', 'LAB_IP_*')` variables — all already defined in `.env`):
-
-```yaml
-global:
-  scrape_interval: 30s
-
-scrape_configs:
-  - job_name: node_exporter
-    static_configs:
-      - targets:
-          - "{{ lookup('env', 'LAB_IP_AUTHENTIK') }}:9100"    # authentik-stack
-          - "{{ lookup('env', 'LAB_IP_STEP_CA') }}:9100"      # step-ca-stack
-          - "{{ lookup('env', 'LAB_IP_MONITORING') }}:9100"   # monitoring-stack (self)
-          - "{{ lookup('env', 'LAB_IP_DNS') }}:9100"          # dns-stack
-          - "{{ lookup('env', 'LAB_IP_PORTAINER') }}:9100"    # portainer-stack
-          - "{{ lookup('env', 'LAB_IP_PROXY') }}:9100"        # proxy-stack
-          - "{{ lookup('env', 'LAB_IP_HARBOR') }}:9100"       # harbor-stack
-          - "{{ lookup('env', 'LAB_IP_APT_CACHER') }}:9100"  # apt-cacher-stack
-          - "{{ lookup('env', 'LAB_IP_NETBOX') }}:9100"       # netbox-stack
-          - "{{ lookup('env', 'LAB_IP_CI_RUNNER') }}:9100"   # ci-runner-01
-          - "{{ lookup('env', 'LAB_IP_PROXMOX_HOST') }}:9100" # proxmox host (pve)
-
-  - job_name: cadvisor
-    static_configs:
-      - targets:
-          - "{{ lookup('env', 'LAB_IP_AUTHENTIK') }}:8080"    # authentik-stack
-          - "{{ lookup('env', 'LAB_IP_MONITORING') }}:8080"   # monitoring-stack (self)
-          - "{{ lookup('env', 'LAB_IP_PORTAINER') }}:8080"    # portainer-stack
-          - "{{ lookup('env', 'LAB_IP_PROXY') }}:8080"        # proxy-stack
-          - "{{ lookup('env', 'LAB_IP_HARBOR') }}:8080"       # harbor-stack
-          - "{{ lookup('env', 'LAB_IP_NETBOX') }}:8081"       # netbox-stack (8081 — port conflict with NetBox app metrics)
-
-  - job_name: coredns
-    scrape_interval: 15s
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_DNS') }}:9153"]
-
-  - job_name: traefik
-    scrape_interval: 15s
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_PROXY') }}:8082"]
-
-  - job_name: authentik
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_AUTHENTIK') }}:9300"]
-
-  - job_name: harbor
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_HARBOR') }}:9090"]
-
-  - job_name: step_ca
-    scheme: https
-    tls_config:
-      ca_file: /etc/ssl/certs/homelab-root.crt
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_STEP_CA') }}:9443"]
-
-  - job_name: netbox
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_NETBOX') }}:8080"]
-
-  - job_name: victoriametrics
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_MONITORING') }}:8428"]
-
-  - job_name: loki
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_MONITORING') }}:3100"]
-
-  - job_name: grafana
-    static_configs:
-      - targets: ["{{ lookup('env', 'LAB_IP_MONITORING') }}:3000"]
-```
-
-All `LAB_IP_*` env vars are already present in `.env` except `LAB_IP_PROXMOX_HOST` (see Variables section).
-
-**Note**: The scrape config must be written as an Ansible Jinja2 template file (`.j2`) so that `lookup('env', ...)` expressions are resolved at playbook runtime. Save it as `victoria-metrics/scrape.yml.j2` in the playbook's template search path and use `ansible.builtin.template` (not `copy`) to deploy it.
-
-**Pre-requisites before Phase 3 scrape config will work:**
-- Phase 1 (node_exporter) must be deployed on all targets
-- Phase 2 (cAdvisor) must be deployed before cadvisor job targets will resolve
-- Authentik port 9300 must be published (see Phase 2a)
-- Harbor metrics must be enabled (see Phase 2a)
-- NetBox `METRICS_ENABLED: true` must be set (see Phase 2a)
-
-**Compose changes needed** (deploy-monitoring-stack.yml):
-- Add `--promscrape.config=/etc/vm/scrape.yml` to VictoriaMetrics `command`
-- Add volume mount: `./victoria-metrics/scrape.yml:/etc/vm/scrape.yml:ro`
-- Add volume mount: `/usr/local/share/ca-certificates/homelab-root.crt:/etc/ssl/certs/homelab-root.crt:ro`
-- Add directory creation task for `{{ monitoring_compose_dir }}/victoria-metrics`
-
-### Phase 4 — Promtail on all stacks ✅
-
-**Goal**: Every LXC ships its logs to Loki.
-
-**Docker stacks** (harbor, authentik, netbox, proxy, portainer):
-- Add a `promtail` service to each stack's Docker Compose definition
-- Config: push to `http://{{ lookup('env', 'LAB_IP_MONITORING') }}:3100/loki/api/v1/push` (via Ansible template)
-- Collect `/var/log/**/*.log` with labels `job`, `host`, `stack`
-- Also collect Docker container stdout/stderr via Docker log discovery using Promtail's `docker_sd_configs`
-- Docker discovery requires `/var/run/docker.sock:/var/run/docker.sock:ro` volume mount
-- Image: `grafana/promtail:3.0.0` (same version already used by monitoring-stack) — pulled from Harbor
-
-**Non-Docker stacks** (dns-stack, step-ca-stack, apt-cacher-stack, ci-runner-01):
-- Install Promtail binary as a systemd service via a new `promtail` Ansible role
-- Config written to `/etc/promtail/config.yml`
-- Same labels and Loki endpoint as above
-- **dns-stack / apt-cacher-stack / ci-runner-01**: collect from `/var/log/**/*.log` + `journald` scrape config
-- **step-ca-stack**: step-ca logs go to journal; no `/var/log` files. Use `journal` scrape source only
-- Service: `promtail.service` enabled and started
-
-**monitoring-stack** (self):
-- Promtail already deployed and collecting from `/var/log/**/*.log`
-- Extend config to add Docker discovery for the compose stack containers
-- Requires adding `/var/run/docker.sock:/var/run/docker.sock:ro` volume to the `promtail` service in the monitoring compose definition
-
-### Phase 5 — Grafana dashboards ✅
-
-**Goal**: Pre-provisioned dashboards in Grafana so the data is immediately useful after a fresh deploy.
-
-Dashboards to provision via `grafana/provisioning/dashboards/`:
-
-| Dashboard | Data source | Key panels |
-|-----------|-------------|------------|
-| Lab Overview | VictoriaMetrics | Per-host CPU %, memory %, disk % — all stacks in one view |
-| Node Detail | VictoriaMetrics | Full node_exporter breakdown for a selected host |
-| Docker Containers | VictoriaMetrics | cAdvisor: per-container CPU/mem/net/disk |
-| Traefik Ingress | VictoriaMetrics | Request rate, p50/p99 latency, error rate per service |
-| CoreDNS | VictoriaMetrics | Query rate, NXDOMAIN rate, cache hit %, latency |
-| Authentik | VictoriaMetrics | Active sessions, auth event rate, provider health |
-| Harbor | VictoriaMetrics | Pull/push rate, replication job status |
-| Lab Logs | Loki | Full-stack log explorer, filterable by host/stack/severity |
-| Auth Logs | Loki | SSH logins, sudo, auth.log across all hosts |
-
-Dashboards will be stored as JSON files in `terraform/lxc/stacks/monitoring-stack/dashboards/` and deployed by the monitoring playbook.
-
-**Compose/playbook changes needed** (deploy-monitoring-stack.yml):
-- Add directory creation tasks for `{{ monitoring_compose_dir }}/grafana/provisioning/dashboards` and `{{ monitoring_compose_dir }}/grafana/dashboards`
-- Add a Grafana dashboard provider config to `{{ monitoring_compose_dir }}/grafana/provisioning/dashboards/providers.yml`:
-  ```yaml
-  apiVersion: 1
-  providers:
-    - name: homelab
-      type: file
-      options:
-        path: /etc/grafana/dashboards
-  ```
-- Copy JSON dashboard files from `stacks/monitoring-stack/dashboards/*.json` into `{{ monitoring_compose_dir }}/grafana/dashboards/`
-- Add volume mount to Grafana container: `./grafana/dashboards:/etc/grafana/dashboards:ro`
+| CoreDNS | `:9153/metrics` | ✓ | |
+| Traefik | `:8082/metrics` | ✓ | |
+| Authentik | `:9300/metrics` | ✓ | |
+| Harbor | `:9090/metrics` | ✓ | |
+| NetBox | `:8080/metrics` | ✓ | |
+| step-ca | `:9443/metrics` | ✗ | HTTPS — needs homelab CA in VictoriaMetrics container |
+| VictoriaMetrics | `:8428/metrics` | ✓ | |
+| Loki | `:3100/metrics` | ✓ | |
+| Grafana | `:3000/metrics` | ✓ | |
 
 ---
 
 ## Variables and Secrets
 
-New env vars needed (add to `.env` and `.env.template`):
-
 ```
 LAB_IP_PROXMOX_HOST=192.168.1.2    # Proxmox bare-metal host — for node_exporter scrape
 ```
 
-All other `LAB_IP_*` variables required by the scrape config are **already present** in `.env`.
-
-No new secrets required. Loki and VictoriaMetrics have no auth (`auth_enabled: false` in Loki; VictoriaMetrics has no auth by default). This is acceptable since both are mgmt_seg-internal.
+All other `LAB_IP_*` variables are in `.env`. No secrets required for Loki or VictoriaMetrics (both are mgmt_seg-internal, no auth).
 
 ---
 
-## Loki Retention
+## Remaining Work
 
-The current Loki config has no retention period set. Add a `compactor` block and `retention_period` to the Loki config in `deploy-monitoring-stack.yml`:
+| Item | Notes |
+|------|-------|
+| Proxmox host node_exporter | Manual bootstrap — install node_exporter directly on 192.168.1.2 |
+| step-ca scrape job | Mount homelab CA into VictoriaMetrics container; add `scheme: https` + `tls_config.ca_file` to scrape config |
+| Loki retention | Add `compactor` block and `retention_period: 30d` to Loki config in `deploy-monitoring-stack.yml` (see below) |
+| Authentik dashboard | Metrics scraped but no Grafana dashboard built |
+| Harbor alerting | CVE/operations dashboards live; alert rules not defined |
+| Teardown health gate | Update monitoring-stack health check in `teardown-deploy-test.sh` to assert `> 0` active targets via `/api/v1/targets` |
+| VictoriaLogs | Replace Loki with VictoriaLogs for full-text log search and LLM analysis pipeline (see Phase 6) |
+
+---
+
+## Loki Retention (pending)
+
+Add a `compactor` block and `retention_period` to the Loki config in `deploy-monitoring-stack.yml`:
 
 ```yaml
 compactor:
@@ -433,69 +209,116 @@ compactor:
 limits_config:
   allow_structured_metadata: false
   volume_enabled: true
-  retention_period: 30d    # adjust as needed; 30d is a reasonable lab default
+  retention_period: 30d
 ```
 
-Note: Loki filesystem compactor with retention requires Loki >= 2.9. The current deployment uses `3.0.0` so this is supported.
+Note: if VictoriaLogs replaces Loki (Phase 6), this is not worth implementing.
 
 ---
 
-## Health Gate Updates
+## Teardown Health Gate
 
-After implementation, the teardown-deploy-test cycle health check for monitoring-stack should be extended:
+After Phase 6 lands, the monitoring-stack health check in `teardown-deploy-test.sh` should be extended to assert at least one VictoriaMetrics scrape target is up:
 
 ```bash
-# current
-curl -fsS 'http://${ip}:3000/login' && curl -fsS 'http://${ip}:8428/-/ready'
-
-# target (post Phase 3)
-curl -fsS 'http://${ip}:3000/login' \
-  && curl -fsS 'http://${ip}:8428/-/ready' \
-  && curl -fsS 'http://${ip}:3100/ready' \
-  && curl -fsS "http://${ip}:8428/api/v1/targets" | python3 -c "import sys,json; t=json.load(sys.stdin); up=[x for x in t['data']['activeTargets'] if x['health']=='up']; print(len(up),'targets up'); sys.exit(0 if len(up)>0 else 1)"
+curl -fsS "http://${ip}:8428/api/v1/targets" \
+  | python3 -c "import sys,json; t=json.load(sys.stdin); up=[x for x in t['data']['activeTargets'] if x['health']=='up']; print(len(up),'targets up'); sys.exit(0 if len(up)>0 else 1)"
 ```
 
-The final check verifies at least one scrape target is healthy — confirming the scrape config is loaded and working, not just that VictoriaMetrics started.
-
 ---
 
-## Remaining Work
+## Phase 6 — VictoriaLogs
 
-| Item | Notes |
-|------|-------|
-| Proxmox host node_exporter | node_exporter needs to be installed directly on 192.168.1.2 (manual bootstrap — not managed by LXC provisioning pipeline) |
-| step-ca scrape job | Needs homelab CA mounted into VictoriaMetrics container at `/etc/ssl/certs/homelab-root.crt:ro`; scrape job uses `scheme: https` + `tls_config.ca_file` |
-| Loki retention | Add `compactor` block and `retention_period: 30d` to Loki config in `deploy-monitoring-stack.yml` (see Loki Retention section below) |
-| Authentik dashboard | Not built; Authentik metrics are being scraped but no dashboard exists |
-| Harbor alerting and dashboard refinement | Harbor dashboards and findings exporter are live, including the `Harbor CVE Inventory` dashboard backed by the live `/findings.json` feed; alert rules are still missing, and the CVE dashboard still needs optional filtering/polish |
-| Teardown health gate | Update monitoring-stack health check in `teardown-deploy-test.sh` to assert `> 0` active targets via `/api/v1/targets` |
-| `APPROVED_PLATFORM_ORDER` in `provision.sh` | `test-storage` and `test-storage-extra` stacks exist in `terraform/lxc/stacks/` with `deployment_tier: platform` but are absent from the approved order list — `--tier platform` currently fails |
+### Goal
 
----
+Replace Loki with VictoriaLogs for full-text log search and a per-source LLM analysis pipeline.
 
-## Task Breakdown
+**Why replace Loki**: Loki indexes only labels, not log content. Full-text search requires a scan query that degrades with volume. VictoriaLogs indexes content and supports fast substring and field-extraction queries via LogsQL. It is from the VictoriaMetrics team (same operational patterns, already in the stack), runs as a single container, and stores data as a Docker volume on the existing 52 GB `/var/lib/docker` mount — no second LXC mount required.
 
-| # | Task | Phase | Scope |
-|---|------|-------|-------|
-| 1 | New `node_exporter` Ansible role; apply from `lxc_base` | 1 | Role creation |
-| 2 | Re-provision all platform stacks to deploy node_exporter | 1 | Ansible |
-| 3 | Install node_exporter on Proxmox host directly (one-time, manual) | 1 | Bootstrap |
-| 4 | Add `LAB_IP_PROXMOX_HOST` to `.env` and `.env.template` | 1 | Config |
-| 5 | Mirror `cadvisor/cadvisor:v0.49.1` into Harbor | 2 | Harbor |
-| 6 | Add cAdvisor service to Docker Compose in each Docker stack playbook | 2 | 6 playbooks |
-| 7 | Use port `8081:8080` for cAdvisor on netbox-stack (port conflict) | 2 | netbox playbook |
-| 7a | Publish Authentik port 9300 + set `AUTHENTIK_LISTEN__METRICS` env var | 2a | authentik compose |
-| 7b | Add `metric.enabled: true, port: 9090` to Harbor `harbor.yml.j2` template | 2a | harbor role |
-| 7c | Add `METRICS_ENABLED: True` to NetBox compose environment | 2a | netbox compose |
-| 8 | Write VictoriaMetrics scrape config template; update monitoring compose | 3 | Ansible |
-| 9 | Add homelab CA volume mount to VictoriaMetrics container (for step-ca TLS) | 3 | Ansible |
-| 10 | Add `--promscrape.config` flag to VictoriaMetrics command in compose | 3 | Ansible |
-| 11 | Validate VictoriaMetrics scrape targets via `/api/v1/targets` | 3 | Manual + health gate |
-| 12 | Add Loki retention config (compactor + `retention_period: 30d`) to monitoring deploy | 3 | Ansible |
-| 13 | New `promtail` Ansible role for systemd-based stacks (with journald support) | 4 | Role creation |
-| 14 | Add Promtail Docker service to each Docker stack playbook (with docker.sock mount) | 4 | 5 playbooks |
-| 15 | Extend monitoring-stack Promtail config with Docker discovery + docker.sock mount | 4 | Ansible |
-| 16 | Validate Loki is receiving streams (`/loki/api/v1/labels`) | 4 | Manual |
-| 17 | Create dashboard JSON files in `stacks/monitoring-stack/dashboards/` | 5 | Grafana |
-| 18 | Add dashboard provider config and volume mount to monitoring compose | 5 | Ansible |
-| 19 | Update teardown health gate to check Loki `/ready` and VM target count | — | `teardown-deploy-test.sh` |
+### Design
+
+```
+                         monitoring-stack (192.168.20.12)
+                         ┌──────────────────────────────────────────┐
+                         │  VictoriaMetrics  VictoriaLogs  Grafana  │
+ Promtail (per stack) ───►  (metrics)        :9428         :3000    │
+                         │                       ▲                  │
+                         │              LLM analysis pipeline        │
+                         │              (query API → Claude API)     │
+                         └──────────────────────────────────────────┘
+```
+
+VictoriaLogs exposes a Loki-compatible ingest endpoint at `/insert/loki/api/v1/push`, so all existing Promtail agents redirect with a single URL change. LogsQL queries are issued against `/select/logsql/query`.
+
+### VictoriaLogs container
+
+```yaml
+victorialogs:
+  image: docker.io/victoriametrics/victoria-logs:v1-victorialogs
+  ports:
+    - "9428:9428"
+  volumes:
+    - victorialogs-data:/vlogs
+  command:
+    - -storageDataPath=/vlogs
+    - -retentionPeriod=30d
+  restart: unless-stopped
+```
+
+Data stored in a named Docker volume — lives on the existing `/var/lib/docker` mount. No additional LXC mount point needed.
+
+### Migration path
+
+1. Add VictoriaLogs container to monitoring-stack compose (alongside Loki initially)
+2. Add VictoriaLogs Grafana datasource plugin (`victoriametrics-logs-datasource`)
+3. Update all Promtail configs to push to VictoriaLogs: change `url` from `http://192.168.20.12:3100/loki/api/v1/push` to `http://192.168.20.12:9428/insert/loki/api/v1/push`
+4. Rebuild Lab Logs and Auth Logs dashboards using VictoriaLogs datasource + LogsQL
+5. Verify log ingestion and dashboard queries
+6. Remove Loki container and volumes
+
+### LLM analysis pipeline
+
+A lightweight script (or small service) that fetches recent logs for a named source and sends them to the Claude API for analysis. Query pattern:
+
+```bash
+# Fetch last N lines from a stream and pipe to LLM
+curl -G "http://192.168.20.12:9428/select/logsql/query" \
+  --data-urlencode 'query=_stream:{stack="harbor-stack"} | limit 200' \
+  | <send to Claude API>
+```
+
+LogsQL stream selectors map directly to the `stack` and `job` labels already set by Promtail, so per-source retrieval is precise and fast.
+
+Implementation: a small Python script invoked ad-hoc (or triggered via Grafana panel button). Kept outside the monitoring-stack compose definition — it's a tooling concern, not an infrastructure service.
+
+### Tasks
+
+| # | Task | Notes |
+|---|------|-------|
+| 1 | Pin a VictoriaLogs release version | Check https://github.com/VictoriaMetrics/VictoriaMetrics/releases for latest stable `-victorialogs` tag |
+| 2 | Mirror VictoriaLogs image to Harbor | `harbor.lab.gibbsgreatly.xyz/dockerhub/victoriametrics/victoria-logs:<tag>` |
+| 3 | Add `victorialogs-logs-datasource` Grafana plugin | Set `GF_INSTALL_PLUGINS` in Grafana container env |
+| 4 | Add VictoriaLogs service to monitoring compose in `deploy-monitoring-stack.yml` | Single container, named volume, port 9428 |
+| 5 | Add VictoriaLogs datasource to Grafana provisioning | Point at `http://victorialogs:9428` |
+| 6 | Update Promtail push URL across all stacks | Change `3100/loki/api/v1/push` → `9428/insert/loki/api/v1/push` in all Promtail configs |
+| 7 | Rebuild Lab Logs and Auth Logs dashboards with LogsQL | Replace Loki datasource and PromQL-style log queries |
+| 8 | Verify ingestion (`/select/logsql/query?query=*`) | Confirm streams from all stacks are arriving |
+| 9 | Remove Loki service and volumes | After dashboards confirmed working |
+| 10 | Write LLM analysis script | Python: accept `stack=<name>`, fetch N lines from VictoriaLogs API, POST to Claude API |
+| 11 | Update teardown health gate | Replace Loki `:3100/ready` check with VictoriaLogs `:9428/health` |
+| 12 | Provision + smoke test on pve-test | Full deploy cycle confirming VictoriaLogs survives teardown |
+
+### Pre-conditions
+
+- [ ] VictoriaLogs stable release confirmed and pinned
+- [ ] Harbor mirror of VictoriaLogs image available
+- [ ] Branch cut from `baseline/teardown-validated`
+
+### Branch
+
+```bash
+git checkout baseline/teardown-validated && git pull
+git checkout -b task/monitoring-victorialogs
+```
+
+Promotion gate: full teardown + redeploy cycle confirms log ingestion resumes and all dashboards show data after rebuild.

--- a/docs/portainer-stack/00-overview.md
+++ b/docs/portainer-stack/00-overview.md
@@ -63,9 +63,15 @@ not break netbox-populate discovery.
 
 On full teardown + rebuild:
 - Admin password, Harbor registry, Authentik OAuth — auto-reprovisioned by Ansible
-- Application stack definitions — restored from NAS backup (see sprint 01)
-- Application endpoints — portainer-agents keep running and reconnect automatically
-  once Portainer is back at the same URL
+- Application stack definitions — restored from NAS backup via `scripts/portainer-restore.sh`
+- Application endpoints — portainer-agents keep running on their hosts; however, after a
+  Portainer rebuild the agents are paired with the old (destroyed) instance. The restore script
+  restores the DB including endpoint registrations. Agents reconnect automatically once Portainer
+  is back at the same URL and the restored DB contains their endpoint record.
+
+The full restore sequence is automated: `./with-secrets-prod scripts/portainer-restore.sh`
+runs Phase 1 (deploy Portainer CE without init), restores the DB, then Phase 2 (init skip +
+OAuth + backup timer). See [sprint 01 restore runbook](01-backup-restore.md#restore-runbook).
 
 ---
 
@@ -133,7 +139,8 @@ showing the complete stack (including the new backup timer) survives a rebuild.
 
 | Sprint | Goal | Status |
 |---|---|---|
-| [01](01-backup-restore.md) | Backup and restore from NAS — prove before migration | planned |
-| [02](02-migration.md) | Migrate application stacks from existing Portainer | planned |
+| [01](01-backup-restore.md) | Backup and restore from NAS — prove before migration | **complete** — validated 2026-06-19 |
+| [02](02-migration.md) | Migrate application stacks from existing Portainer | **IaC ready** — test harness validated 2026-06-19; real migration pending |
 
-Sprint 01 must complete and be validated before sprint 02 begins.
+Sprint 01 is complete. Sprint 02 IaC is in place (`migrate-portainer-stack.yml`); the real migration
+runs when the legacy Portainer admin password is retrieved and the production approval workflow is followed.

--- a/docs/portainer-stack/01-backup-restore.md
+++ b/docs/portainer-stack/01-backup-restore.md
@@ -205,7 +205,20 @@ After restore: verify stacks, endpoints, and env vars match pre-destroy state.
 
 Fill in the Restore Runbook section below with exact commands confirmed in step 7.
 
-### 9. Commit, merge, and promote
+### 9. Tidyup — add single-stack redeploy harness
+
+During this sprint it became clear there is no top-level command to apply Terraform + Ansible
+for a single named stack without running the full teardown cycle. The pattern is embedded inside
+`teardown-deploy-test.sh`'s `stack_apply()` but not exposed externally.
+
+Tracked in **issue #381**. After the restore gate is passed, cut a `task/single-stack-harness`
+branch and add a `--stack NAME` flag (or a new `scripts/deploy-stack.sh`) that runs:
+1. `terragrunt apply -auto-approve` from the stack directory
+2. `provision.sh --stack NAME`
+
+This is a separate task; do not block sprint 01 promotion on it.
+
+### 10. Commit, merge, and promote
 
 ```bash
 git add -p

--- a/docs/portainer-stack/01-backup-restore.md
+++ b/docs/portainer-stack/01-backup-restore.md
@@ -78,7 +78,44 @@ with write permissions for root (privileged LXC) or the mapped UID (unprivileged
 
 ### 3. Configure NFS bind mount into Portainer LXC
 
-Add to the Portainer LXC Terraform resource or apply directly to test:
+The `lxc-docker-host` Terraform module (`terraform/lxc/modules/lxc-docker-host/main.tf`)
+supports `mount_point` blocks for LVM volumes but does not yet have a host bind mount
+input. Add one before this sprint begins — it unlocks a clean teardown-cycle-safe path.
+
+**Extend the module** — add a `host_bind_mounts` variable and dynamic block:
+
+```hcl
+# In terraform/lxc/modules/lxc-docker-host/variables.tf
+variable "host_bind_mounts" {
+  type    = list(object({ host_path = string, lxc_path = string }))
+  default = []
+}
+
+# In terraform/lxc/modules/lxc-docker-host/main.tf  (inside the container resource)
+dynamic "mount_point" {
+  for_each = var.host_bind_mounts
+  content {
+    volume = mount_point.value.host_path
+    path   = mount_point.value.lxc_path
+  }
+}
+```
+
+**Declare the bind mount in `stack.yaml`:**
+
+```yaml
+host_bind_mounts:
+  - host_path: /mnt/nas-backup/portainer-backup
+    lxc_path: /var/backups/portainer
+```
+
+Wire the new variable through `terraform/lxc/main.tf` (pass
+`local.stack.host_bind_mounts` to the module call).
+
+This bind mount will be re-applied on every `terraform apply`, surviving teardown
+cycles automatically.
+
+**Test manually first** before wiring into Terraform (verify NFS permissions work):
 
 ```bash
 export TASK_APPROVAL="portainer-backup-restore"
@@ -88,14 +125,11 @@ export TASK_APPROVAL="portainer-backup-restore"
 The pve NFS mount at `/mnt/nas-backup` is already in fstab with `_netdev` and
 `x-systemd.requires=network-online.target` — it mounts before LXCs start.
 
-Also add the bind mount to the Portainer LXC's Terraform config so it survives
-a full teardown cycle.
-
 ### 4. Write backup systemd service and timer
 
 Service: authenticates via `POST /api/auth`, then calls `POST /api/backup`,
 writes binary to `/var/backups/portainer/portainer-YYYYMMDD.tar.gz`.
-Retains last 7 backups.
+Retains last 7 backups (rotation: `ls -t | tail -n +8 | xargs -r rm`).
 
 Timer: daily, `Persistent=true`, `RandomizedDelaySec=1800`.
 
@@ -105,8 +139,18 @@ Model on `netbox-populate.timer` (same credential env file pattern):
 
 ### 5. Provision via Ansible
 
-Add tasks to `deploy-portainer-stack.yml` (run after the Ansible validation
-tier — syntax-check first, then provision to apply):
+Create a `portainer_backup` Ansible role at
+`terraform/lxc/ansible/roles/portainer_backup/` — follow the role-per-concern
+pattern used by `portainer_api` and `portainer_agent`. Include the role in
+`deploy-portainer-stack.yml` after the Portainer init play.
+
+Role tasks:
+- Write `/etc/portainer-backup/env` (mode 0600, templated from `PORTAINER_ADMIN_PASSWORD`)
+- Write `/opt/portainer-backup/backup.sh`
+- Write systemd service and timer units to `/etc/systemd/system/`
+- `systemctl daemon-reload && systemctl enable --now portainer-backup.timer`
+
+After writing the role, run the Ansible validation tier:
 
 ```bash
 # Syntax check first (always, even for comment-only changes)
@@ -116,12 +160,6 @@ ansible-playbook --syntax-check terraform/lxc/ansible/playbooks/deploy-portainer
 export TASK_APPROVAL="portainer-backup-restore"
 ./with-secrets-prod scripts/provision.sh --stack portainer-stack
 ```
-
-Tasks to add:
-- Write `/etc/portainer-backup/env` (mode 0600, templated from `PORTAINER_ADMIN_PASSWORD`)
-- Write `/opt/portainer-backup/backup.sh`
-- Write systemd service and timer units to `/etc/systemd/system/`
-- `systemctl daemon-reload && systemctl enable --now portainer-backup.timer`
 
 ### 6. Test backup
 
@@ -179,35 +217,43 @@ Then open a PR: `task/portainer-backup-restore` → `baseline/teardown-validated
 
 ## Restore Runbook
 
-_To be completed and verified during task 7. Commands below are a template — fill in
-actual Portainer LXC IP and confirm the exact steps work before treating this as
-authoritative._
+_To be completed and verified during task 7. Commands below are a template — confirm
+the exact steps work during the test restore before treating this as authoritative._
 
 ```bash
-# 1. Provision fresh Portainer LXC
+# 0. Verify NAS backup directory is accessible from pve host
+ls /mnt/nas-backup/portainer-backup/
+
+# 1. Provision fresh Portainer LXC (Ansible sets admin credentials, OAuth, Harbor)
 export TASK_APPROVAL="portainer-restore"
 ./with-secrets-prod scripts/provision.sh --stack portainer-stack
 
-# 2. Get admin JWT (from inside the LXC or from a host that can reach mgmt_seg)
-#    Admin password is in terraform/secrets.pve.enc.yaml — use ./with-secrets-prod
-#    to resolve it rather than typing it in plaintext
+# 2. Get admin JWT — PORTAINER_ADMIN_PASSWORD resolved from SOPS by with-secrets-prod
 PORTAINER_IP=192.168.20.20
-TOKEN=$(./with-secrets-prod bash -c '
-  curl -s -X POST http://'"$PORTAINER_IP"':9000/api/auth \
+TOKEN=$(./with-secrets-prod env | grep PORTAINER_ADMIN_PASSWORD | cut -d= -f2- | \
+  xargs -I{} curl -s -X POST http://$PORTAINER_IP:9000/api/auth \
     -H "Content-Type: application/json" \
-    -d "{\"Username\":\"admin\",\"Password\":\"${PORTAINER_ADMIN_PASSWORD}\"}" \
-  | jq -r .jwt
-')
+    -d "{\"Username\":\"admin\",\"Password\":\"{}\"}" | jq -r .jwt)
 
 # 3. Restore from latest NAS backup
+#    The backup file is a tar.gz of Portainer's BoltDB — verify with: tar tzf <file> | head
 BACKUP=$(ls -t /mnt/nas-backup/portainer-backup/portainer-*.tar.gz | head -1)
+echo "Restoring from: $BACKUP"
 curl -X POST http://$PORTAINER_IP:9000/api/restore \
   -H "Authorization: Bearer $TOKEN" \
-  -F "file=@$BACKUP"
+  -F "file=@$BACKUP" \
+  -w "\nHTTP %{http_code}\n"
 
 # 4. Restart Portainer to apply restored state
 ./with-secrets-prod pct exec 20020 -- docker restart portainer
+
+# 5. Verify stacks, endpoints, and env vars match pre-destroy state
+curl -s -H "Authorization: Bearer $TOKEN" http://$PORTAINER_IP:9000/api/stacks | jq '[.[].Name]'
 ```
+
+After restore, Ansible can run again safely — the provisioner is idempotent and will
+only update settings that differ from desired state (admin password and OAuth settings
+will match SOPS, so no changes should apply).
 
 ---
 

--- a/docs/portainer-stack/01-backup-restore.md
+++ b/docs/portainer-stack/01-backup-restore.md
@@ -238,38 +238,79 @@ Then open a PR: `task/portainer-backup-restore` → `baseline/teardown-validated
 
 ## Restore Runbook
 
-_To be completed and verified during task 7. Commands below are a template — confirm
-the exact steps work during the test restore before treating this as authoritative._
+**Verified 2026-06-19.** Commands below are confirmed working.
+
+### Critical constraint: restore must happen before `provision.sh`
+
+`POST /api/restore` only works on an **uninitialized** Portainer instance. Once
+`provision.sh` runs the init play (`POST /api/users/admin/init`), the instance is
+initialized and the restore API returns 400. The correct order is:
+
+1. `terragrunt apply` → LXC created, Portainer starts uninitialized
+2. Restore from backup (no auth required on uninitialized instance)
+3. `provision.sh` → init play gets 409 (already initialized from backup, skips);
+   OAuth, timer, bind mount all apply idempotently
 
 ```bash
-# 0. Verify NAS backup directory is accessible from pve host
+# 0. Verify NAS backup directory is accessible and has a backup file
 ls /mnt/nas-backup/portainer-backup/
 
-# 1. Provision fresh Portainer LXC (Ansible sets admin credentials, OAuth, Harbor)
+# 1. Deploy fresh LXC (Terraform only — do NOT run provision.sh yet)
 export TASK_APPROVAL="portainer-restore"
+NETWORK_SDN_ALLOW_DESTROY_OVERRIDE=true \
+  ./with-secrets-prod terragrunt apply \
+  --working-dir terraform/lxc/stacks/portainer-stack -auto-approve
+
+# 2. Wait for Portainer API to come up (uninitialized — no auth needed yet)
+until curl -sf http://192.168.20.20:9000/api/system/status > /dev/null; do sleep 3; done
+echo "Portainer API ready — InstanceID before restore:"
+curl -s http://192.168.20.20:9000/api/system/status | jq .InstanceID
+
+# 3. Restore from NAS backup (no Bearer token — instance is not yet initialized)
+#    The backup file is accessible inside the LXC at /var/backups/portainer/
+#    (NAS bind mount is applied at container creation time)
+ssh root@pve.gibbsgreatly.xyz "pct exec 20020 -- bash -c '
+  BACKUP=\$(ls -t /var/backups/portainer/portainer-*.tar.gz | head -1)
+  echo \"Restoring from: \${BACKUP}\"
+  tar tzf \"\${BACKUP}\" | head -5
+  curl -sf -X POST http://localhost:9000/api/restore \
+    -F \"file=@\${BACKUP}\" \
+    -w \"\nHTTP %{http_code}\n\"
+'"
+
+# 4. Restart Portainer to load restored state
+ssh root@pve.gibbsgreatly.xyz "pct exec 20020 -- docker restart portainer-portainer-1"
+sleep 10
+
+# 5. Verify InstanceID matches the backed-up instance
+curl -s http://192.168.20.20:9000/api/system/status | jq .InstanceID
+
+# 6. Run provision.sh — init gets 409 (skipped), everything else applies
 ./with-secrets-prod scripts/provision.sh --stack portainer-stack
 
-# 2. Get admin JWT — PORTAINER_ADMIN_PASSWORD resolved from SOPS by with-secrets-prod
-PORTAINER_IP=192.168.20.20
-TOKEN=$(./with-secrets-prod env | grep PORTAINER_ADMIN_PASSWORD | cut -d= -f2- | \
-  xargs -I{} curl -s -X POST http://$PORTAINER_IP:9000/api/auth \
-    -H "Content-Type: application/json" \
-    -d "{\"Username\":\"admin\",\"Password\":\"{}\"}" | jq -r .jwt)
+# 7. Verify Portainer is healthy and auth works
+curl -s http://192.168.20.20:9000/api/system/status | jq .
+```
 
-# 3. Restore from latest NAS backup
-#    The backup file is a tar.gz of Portainer's BoltDB — verify with: tar tzf <file> | head
-BACKUP=$(ls -t /mnt/nas-backup/portainer-backup/portainer-*.tar.gz | head -1)
-echo "Restoring from: $BACKUP"
-curl -X POST http://$PORTAINER_IP:9000/api/restore \
-  -H "Authorization: Bearer $TOKEN" \
-  -F "file=@$BACKUP" \
-  -w "\nHTTP %{http_code}\n"
+### Bind mount note
 
-# 4. Restart Portainer to apply restored state
-./with-secrets-prod pct exec 20020 -- docker restart portainer
+`mp1` (`/mnt/nas-backup/portainer-backup → /var/backups/portainer`) is applied by the
+`portainer_backup` Ansible role via `pct set` on the pve host. Because step 6 runs
+`provision.sh` after the restore, the bind mount is guaranteed to be in place.
 
-# 5. Verify stacks, endpoints, and env vars match pre-destroy state
-curl -s -H "Authorization: Bearer $TOKEN" http://$PORTAINER_IP:9000/api/stacks | jq '[.[].Name]'
+The backup file at `/var/backups/portainer/` is accessible from the LXC **as soon as
+`provision.sh` has run at least once** (or if restored from a backup that included the
+bind mount in the container config). On a brand-new LXC before provision, the NAS path
+is not yet mounted — use the NAS path directly on pve for the initial restore instead:
+
+```bash
+# Alternative step 3 (if bind mount not yet applied — before first provision.sh):
+ssh root@pve.gibbsgreatly.xyz "bash -c '
+  BACKUP=\$(ls -t /mnt/nas-backup/portainer-backup/portainer-*.tar.gz | head -1)
+  curl -sf -X POST http://192.168.20.20:9000/api/restore \
+    -F \"file=@\${BACKUP}\" \
+    -w \"\nHTTP %{http_code}\n\"
+'"
 ```
 
 After restore, Ansible can run again safely — the provisioner is idempotent and will

--- a/docs/portainer-stack/01-backup-restore.md
+++ b/docs/portainer-stack/01-backup-restore.md
@@ -238,89 +238,60 @@ Then open a PR: `task/portainer-backup-restore` → `baseline/teardown-validated
 
 ## Restore Runbook
 
-**Verified 2026-06-19.** Commands below are confirmed working.
+**Verified 2026-06-19** — full destroy → apply → restore → provision cycle confirmed.
 
-### Critical constraint: restore must happen before `provision.sh`
+### Automated path (use this)
 
-`POST /api/restore` only works on an **uninitialized** Portainer instance. Once
-`provision.sh` runs the init play (`POST /api/users/admin/init`), the instance is
-initialized and the restore API returns 400. The correct order is:
-
-1. `terragrunt apply` → LXC created, Portainer starts uninitialized
-2. Restore from backup (no auth required on uninitialized instance)
-3. `provision.sh` → init play gets 409 (already initialized from backup, skips);
-   OAuth, timer, bind mount all apply idempotently
+`scripts/portainer-restore.sh` automates the full sequence. It handles the ordering
+constraint (Portainer CE must start before restore, init must not run before restore),
+wipes stale DB state from the fresh LXC, and runs both provision phases.
 
 ```bash
-# 0. Verify NAS backup directory is accessible and has a backup file
-ls /mnt/nas-backup/portainer-backup/
-
-# 1. Deploy fresh LXC (Terraform only — do NOT run provision.sh yet)
+# 1. Destroy the LXC
 export TASK_APPROVAL="portainer-restore"
+NETWORK_SDN_ALLOW_DESTROY_OVERRIDE=true \
+  ./with-secrets-prod terragrunt destroy \
+  --working-dir terraform/lxc/stacks/portainer-stack -auto-approve
+
+# 2. Recreate the LXC from template
 NETWORK_SDN_ALLOW_DESTROY_OVERRIDE=true \
   ./with-secrets-prod terragrunt apply \
   --working-dir terraform/lxc/stacks/portainer-stack -auto-approve
 
-# 2. Wait for Portainer API to come up (uninitialized — no auth needed yet)
-until curl -sf http://192.168.20.20:9000/api/system/status > /dev/null; do sleep 3; done
-echo "Portainer API ready — InstanceID before restore:"
-curl -s http://192.168.20.20:9000/api/system/status | jq .InstanceID
-
-# 3. Restore from NAS backup (no Bearer token — instance is not yet initialized)
-#    The backup file is accessible inside the LXC at /var/backups/portainer/
-#    (NAS bind mount is applied at container creation time)
-ssh root@pve.gibbsgreatly.xyz "pct exec 20020 -- bash -c '
-  BACKUP=\$(ls -t /var/backups/portainer/portainer-*.tar.gz | head -1)
-  echo \"Restoring from: \${BACKUP}\"
-  tar tzf \"\${BACKUP}\" | head -5
-  curl -sf -X POST http://localhost:9000/api/restore \
-    -F \"file=@\${BACKUP}\" \
-    -w \"\nHTTP %{http_code}\n\"
-'"
-
-# 4. Restart Portainer to load restored state
-ssh root@pve.gibbsgreatly.xyz "pct exec 20020 -- docker restart portainer-portainer-1"
-sleep 10
-
-# 5. Verify InstanceID matches the backed-up instance
-curl -s http://192.168.20.20:9000/api/system/status | jq .InstanceID
-
-# 6. Run provision.sh — init gets 409 (skipped), everything else applies
-./with-secrets-prod scripts/provision.sh --stack portainer-stack
-
-# 7. Verify Portainer is healthy and auth works
-curl -s http://192.168.20.20:9000/api/system/status | jq .
+# 3. Run the restore script — handles everything from here
+./with-secrets-prod scripts/portainer-restore.sh
 ```
 
-### Bind mount note
+The script sequence:
+1. Wipes `/var/lib/portainer` (stale DB can survive template recreation)
+2. Runs `provision.sh --stack portainer-stack --tags pre_restore` (Docker base + Portainer CE, no init)
+3. Waits for uninitialized Portainer API
+4. POSTs the latest NAS backup to `/api/restore` from pve via SSH
+5. Restarts Portainer container to load restored DB
+6. Verifies InstanceID changed (confirms restore applied)
+7. Runs `provision.sh --stack portainer-stack` (full — init gets 409 and skips; OAuth, bind mount, timer apply idempotently)
 
-`mp1` (`/mnt/nas-backup/portainer-backup → /var/backups/portainer`) is applied by the
-`portainer_backup` Ansible role via `pct set` on the pve host. Because step 6 runs
-`provision.sh` after the restore, the bind mount is guaranteed to be in place.
+### Critical constraint: restore must happen before init
 
-The backup file at `/var/backups/portainer/` is accessible from the LXC **as soon as
-`provision.sh` has run at least once** (or if restored from a backup that included the
-bind mount in the container config). On a brand-new LXC before provision, the NAS path
-is not yet mounted — use the NAS path directly on pve for the initial restore instead:
+`POST /api/restore` only works on an **uninitialized** Portainer instance — before
+`POST /api/users/admin/init` has been called. The `pre_restore` tag in
+`deploy-portainer-stack.yml` splits the playbook so only plays 1+2 (Docker base,
+Portainer CE start) run before restore. Plays 3+4 (init, backup timer) run after.
 
-```bash
-# Alternative step 3 (if bind mount not yet applied — before first provision.sh):
-ssh root@pve.gibbsgreatly.xyz "bash -c '
-  BACKUP=\$(ls -t /mnt/nas-backup/portainer-backup/portainer-*.tar.gz | head -1)
-  curl -sf -X POST http://192.168.20.20:9000/api/restore \
-    -F \"file=@\${BACKUP}\" \
-    -w \"\nHTTP %{http_code}\n\"
-'"
-```
+### Backup file location
 
-After restore, Ansible can run again safely — the provisioner is idempotent and will
-only update settings that differ from desired state (admin password and OAuth settings
-will match SOPS, so no changes should apply).
+The NAS backup bind mount (`/mnt/nas-backup/portainer-backup → /var/backups/portainer`
+inside the LXC) is applied by the `portainer_backup` Ansible role via `pct set` on pve.
+The restore script accesses the backup directly from pve via SSH rather than relying on
+the bind mount being present, so it works even before `provision.sh` has run.
+
+Backups: `/mnt/nas-backup/portainer-backup/portainer-YYYYMMDD.tar.gz` on pve.
+The script picks the latest file with `ls -t | head -1`.
 
 ---
 
 ## Pre-conditions
 
-- [ ] Infrastructure Portainer deployed and stable on pve
-- [ ] NAS reachable from pve (`/mnt/nas-backup` mounted and healthy)
-- [ ] No application stacks migrated yet (nothing to lose during test restore)
+- [x] Infrastructure Portainer deployed and stable on pve
+- [x] NAS reachable from pve (`/mnt/nas-backup` mounted and healthy)
+- [x] Restore cycle validated with no application stacks (2026-06-19)

--- a/docs/portainer-stack/01-backup-restore.md
+++ b/docs/portainer-stack/01-backup-restore.md
@@ -62,19 +62,27 @@ accessible from pve at `/mnt/nas-backup/portainer-backup/`.
 
 ### 1. Confirm Portainer LXC privilege level
 
-```bash
-./with-secrets-prod pct config 20020 | grep unprivileged
-```
+**Confirmed:** LXC 20020 runs `unprivileged: 1` with `features: nesting=1`.
+subuid mapping is `root:100000:65536`, so:
+- UID 0 (root) inside LXC = UID **100000** on pve host
+- Proxmox presents a directory owned by host UID 100000 as root-owned inside the LXC
 
-The Portainer LXC runs Docker, which typically requires a privileged LXC.
-A privileged LXC (no `unprivileged: 1` line) means UID 0 inside = UID 0 on
-host, which simplifies NFS permissions. If unprivileged, a bindfs re-mount
-will be needed (same pattern as CT105/PBS in the existing pve fstab).
+No bindfs re-mount is needed — correct ownership on the NAS directory is sufficient.
 
 ### 2. Create NAS directory
 
-On the NAS (ADM GUI or SSH): create `/volume1/ProxmoxBackup/portainer-backup/`
-with write permissions for root (privileged LXC) or the mapped UID (unprivileged).
+On pve, via the NFS mount (NFS export uses no_root_squash — verified by `dump/`
+being root-owned under the same mount):
+
+```bash
+mkdir /mnt/nas-backup/portainer-backup
+chown 100000:100000 /mnt/nas-backup/portainer-backup
+chmod 700 /mnt/nas-backup/portainer-backup
+```
+
+Inside the LXC, Proxmox's UID remapping presents this directory as root-owned 700.
+The backup script running as root inside the LXC can read/write it, and no other
+user or process can.
 
 ### 3. Configure NFS bind mount into Portainer LXC
 

--- a/docs/portainer-stack/02-migration.md
+++ b/docs/portainer-stack/02-migration.md
@@ -26,18 +26,77 @@ All pve commands run through `./with-secrets-prod`. Mutating commands require
 
 ---
 
+## Existing Portainer
+
+**Server:** `management-stack` LXC — `192.168.1.70`, VMID 101, on the LAN bridge.
+**Portainer CE:** port 9000 (HTTP), port 9443 (HTTPS).
+**Credentials:** not in SOPS — retrieve the admin password from the management LXC
+before this sprint begins (check its stack env file or Docker compose env).
+
+The management-stack also runs NPM, a central Docker registry, and Trivy. This sprint
+covers the Portainer migration only. Full management-stack decommission (including NPM,
+registry, and DNS cutover) is a later step — see
+[application-migration/05-management-decommission.md](../application-migration/05-management-decommission.md).
+
+**Application hosts currently managed (on LAN bridge):**
+- `torrent-stack` — `192.168.1.5`, endpoint `tcp://192.168.1.5:9001`
+- `media-stack` — `192.168.1.6`, endpoint `tcp://192.168.1.6:9001`
+- `gaming-stack` — `192.168.1.7`, endpoint `tcp://192.168.1.7:9001`
+
+After this sprint, infra Portainer owns these endpoints at their **current LAN IPs**.
+Endpoint URLs will be updated to VLAN IPs as each application-migration sprint runs.
+
+---
+
+## Relationship to Application-Migration Sprints
+
+This sprint (portainer-stack/02) migrates ownership of the Portainer server — all
+endpoints re-registered from the management-stack Portainer to infra Portainer.
+
+The [application-migration sprints](../application-migration/00-overview.md) migrate
+the application LXCs themselves into VLAN zones (dl_seg, media_seg, game_seg). Those
+sprints run after this one, and each updates the portainer endpoint URL from the old
+LAN IP to the new VLAN IP via the `portainer_api` role.
+
+Sequencing:
+```
+portainer-stack/01  →  portainer-stack/02  →  app-migration/01  →  app-migration/02
+(backup validated)     (ownership migrated)   (torrent → dl_seg) (media → media_seg)
+                                                ↓ each sprint updates endpoint URL in infra Portainer
+```
+
+---
+
 ## Goal
 
 After this sprint:
-- All application stacks (torrent, media, gaming, any others) are owned and
-  managed by infrastructure Portainer
+- All application stacks (torrent, media, gaming) are owned and managed by
+  infrastructure Portainer
 - Application host portainer-agents are registered as endpoints in infrastructure Portainer
-- Existing Portainer server is shut down and decommissioned
+  (initially at their LAN bridge IPs — updated to VLAN IPs by later app-migration sprints)
+- Existing management-stack Portainer is stopped (management-stack LXC remains up;
+  full decommission is sprint 05 of application-migration)
 - First backup of the migrated state has run and landed on NAS
 
 ---
 
 ## Tasks
+
+### 0. Check existing Portainer version
+
+Before doing anything else, check the existing Portainer version to determine whether
+Option A (backup/restore) will work cleanly.
+
+In the existing Portainer UI: **Settings → About** — note the version number.
+Or via API:
+
+```bash
+curl -s http://192.168.1.70:9000/api/system/status | jq .Version
+```
+
+Infrastructure Portainer runs **2.27.3**. If the existing version differs significantly,
+prefer Option B (re-create stacks manually) in task 5 to avoid compatibility issues.
+Minor version differences within 2.x are generally safe for backup/restore.
 
 ### 1. Identify agent type on existing Portainer
 
@@ -45,11 +104,12 @@ In the existing Portainer UI: **Settings → Environments** — check the Type c
 - "Agent" → regular agent (port 9001, Portainer dials in)
 - "Edge Agent" → edge agent (agent dials out, has join token)
 
-This determines steps 4 and 5 below.
+This determines steps 4 and 5 below. The existing agent type is expected to be
+"Agent" (regular) based on the application-migration sprint docs.
 
 ### 2. Inventory existing stacks
 
-In the existing Portainer: list all stacks, note:
+In the existing Portainer at `http://192.168.1.70:9000`: list all stacks, note:
 - Stack names
 - Which endpoint each stack runs on
 - Any non-obvious environment variables (secrets stored in Portainer)
@@ -60,12 +120,11 @@ in SOPS.
 
 ### 3. Export backup from existing Portainer
 
-The existing Portainer credentials are not in `secrets.pve.enc.yaml`. Retrieve
-the admin password from the existing Portainer host (check its stack env file
-or the management LXC where it's deployed) and run:
+Retrieve the admin password from the existing Portainer host (check its stack env
+file or the management LXC where it's deployed) and run:
 
 ```bash
-EXISTING_PORTAINER_IP=<ip-of-existing-portainer>
+EXISTING_PORTAINER_IP=192.168.1.70
 TOKEN=$(curl -s -X POST http://$EXISTING_PORTAINER_IP:9000/api/auth \
   -H "Content-Type: application/json" \
   -d '{"Username":"admin","Password":"<existing-password>"}' | jq -r .jwt)
@@ -84,12 +143,17 @@ Regular agents just listen — no reconfiguration needed on the app hosts.
 Add each application host as an endpoint in infrastructure Portainer via the UI
 or portainer_api role:
 
-- Endpoint name: matches existing (e.g., `torrent-stack`, `media-stack`)
-- URL: `tcp://<app-lxc-ip>:9001`
-- Verify endpoint goes green (agent is reachable)
+| Endpoint name   | URL                             |
+|---|---|
+| `torrent-stack` | `tcp://192.168.1.5:9001`        |
+| `media-stack`   | `tcp://192.168.1.6:9001`        |
+| `gaming-stack`  | `tcp://192.168.1.7:9001`        |
 
-MikroTik pre-condition: `mgmt_seg → <zone>:9001` rule must exist.
-See application-migration/00-overview.md pre-conditions.
+Verify each endpoint goes green (agent reachable). The MikroTik
+`mgmt_seg → 192.168.1.0/24:9001` rule (pre-condition) must be in place.
+
+These LAN bridge IPs are temporary — endpoint URLs will be updated to VLAN
+addresses by the `portainer_api` role as each application-migration sprint runs.
 
 ### 4b. If edge agents — update join tokens on app hosts
 
@@ -106,22 +170,26 @@ Two options depending on Portainer version compatibility:
 
 ```bash
 # Infrastructure Portainer is at 192.168.20.20
-# Use ./with-secrets-prod to resolve PORTAINER_ADMIN_PASSWORD from SOPS
-TOKEN=$(./with-secrets-prod bash -c '
-  curl -s -X POST http://192.168.20.20:9000/api/auth \
+# PORTAINER_ADMIN_PASSWORD resolved from SOPS by with-secrets-prod
+TOKEN=$(./with-secrets-prod env | grep PORTAINER_ADMIN_PASSWORD | cut -d= -f2- | \
+  xargs -I{} curl -s -X POST http://192.168.20.20:9000/api/auth \
     -H "Content-Type: application/json" \
-    -d "{\"Username\":\"admin\",\"Password\":\"${PORTAINER_ADMIN_PASSWORD}\"}" \
-  | jq -r .jwt
-')
+    -d "{\"Username\":\"admin\",\"Password\":\"{}\"}" | jq -r .jwt)
 
-BACKUP=/mnt/nas-backup/portainer-backup/portainer-migration-<date>.tar.gz
+BACKUP=/mnt/nas-backup/portainer-backup/portainer-migration-$(date +%Y%m%d).tar.gz
 curl -X POST http://192.168.20.20:9000/api/restore \
   -H "Authorization: Bearer $TOKEN" \
-  -F "file=@$BACKUP"
+  -F "file=@$BACKUP" \
+  -w "\nHTTP %{http_code}\n"
+
+# Restart Portainer to apply restored database
+./with-secrets-prod pct exec 20020 -- docker restart portainer
 ```
 
 After restore: verify stacks are present and endpoints are assigned correctly.
-Stack env vars should be intact.
+Stack env vars should be intact. Note that endpoint URLs in the restored backup
+will reflect the old Portainer's registrations — update them if needed (or they
+will be updated automatically when each app-migration sprint provisions its LXC).
 
 **Option B — re-create stacks manually (if versions differ or restore fails)**
 
@@ -144,13 +212,16 @@ Run `systemctl start portainer-backup.service` on the Portainer LXC to take
 an immediate backup of the migrated state. Verify it lands on the NAS.
 This is the recovery point from this moment forward.
 
-### 8. Decommission existing Portainer
+### 8. Stop existing Portainer
 
 Once all stacks are verified in infrastructure Portainer:
-- Stop the existing Portainer server (or its container)
-- Confirm app stacks continue running (they're now managed by infrastructure Portainer)
-- Decommission the old LXC/VM if it was dedicated to Portainer
-- Remove the old portainer DNS record if applicable
+- Stop the Portainer container on management-stack: `docker stop portainer` (inside VMID 101)
+- Confirm app stacks continue running (they're now managed by infrastructure Portainer,
+  not by the management-stack Portainer)
+- Leave the management-stack LXC (VMID 101) up — it still runs NPM and the central
+  Docker registry, which are decommissioned in application-migration sprint 05
+- Remove the old portainer DNS record if it points at 192.168.1.70 and there is
+  no other service using that hostname
 
 ### 9. Commit, merge, and promote
 
@@ -174,7 +245,9 @@ infrastructure still deploys cleanly with the migrated Portainer state.
 ## Pre-conditions
 
 - [ ] Sprint 01 complete: backup and restore validated
-- [ ] Access to existing Portainer (credentials)
-- [ ] Application host IPs known for endpoint registration
-- [ ] MikroTik `mgmt_seg → <zone>:9001` rules in place for each app zone
+- [ ] Existing Portainer admin password retrieved (not in SOPS — get from management-stack)
+- [ ] MikroTik rule: `mgmt_seg → 192.168.1.0/24:9001` in place
+  — infra Portainer (192.168.20.x) must reach app hosts on the LAN bridge during
+  the transition phase (before they move to VLAN zones in application-migration sprints)
 - [ ] Inventory of stacks and any Portainer-only secrets (step 2) complete before proceeding
+- [ ] Version compatibility confirmed (step 0) before choosing Option A vs B

--- a/docs/portainer-stack/02-migration.md
+++ b/docs/portainer-stack/02-migration.md
@@ -141,59 +141,60 @@ curl -o /mnt/nas-backup/portainer-backup/portainer-migration-$(date +%Y%m%d).tar
 Writing directly to `/mnt/nas-backup/portainer-backup/` keeps the backup off
 local disk and immediately on the NAS.
 
-### 4a. If regular agents — un-pair from legacy and register in infrastructure Portainer
+### 4a. If regular agents — migrate via Ansible playbook
 
 **Agent pairing constraint (validated 2026-06-19):** A portainer-agent can only be paired
-with ONE Portainer server at a time. Pairing state is stored in the agent container's
-writable layer. `docker restart` does NOT clear it — the old state remains in the
-container filesystem. Additionally, legacy Portainer's polling reconnects within seconds
-of an agent restart, winning any race to re-pair.
+with ONE Portainer server at a time. Pairing state lives in the container's writable layer.
+`docker restart` does NOT clear it. Legacy Portainer polls continuously and reconnects
+within seconds of an agent restart, winning any naive race.
 
-**Required procedure per host:**
+The migration playbook (`migrate-portainer-stack.yml`) handles this automatically:
+it blocks legacy Portainer's IP while resetting the agent and registering with infra
+Portainer, then unblocks.
 
-```bash
-APP_HOST_IP=192.168.1.5   # change per host
-APP_HOST_VMID=...          # Proxmox LXC VMID
+**Per-host stack.yaml** must declare `portainer_stacks` (compose files to deploy) and
+optionally `portainer_migration_legacy_ip` (default: `192.168.1.4`):
 
-# 1. Block legacy Portainer from reconnecting during the transition
-ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- \
-  iptables -I INPUT -s 192.168.1.4 -p tcp --dport 9001 -j DROP"
-
-# 2. Destroy and recreate the agent container (docker rm clears writable layer)
-ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- bash -c \
-  'cd /opt/portainer && docker compose down && docker compose up -d portainer-agent'"
-
-# 3. Immediately register with infra Portainer (while legacy is still blocked)
-JWT=$(curl -sf http://192.168.20.20:9000/api/auth \
-  -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"<PORTAINER_ADMIN_PASSWORD>"}' | jq -r '.jwt')
-
-curl -s http://192.168.20.20:9000/api/endpoints \
-  -H "Authorization: Bearer ${JWT}" \
-  -F "Name=<endpoint-name>" \
-  -F "EndpointCreationType=2" \
-  -F "URL=tcp://${APP_HOST_IP}:9001" \
-  -F "TLS=true" -F "TLSSkipVerify=true" -F "TLSSkipClientVerify=true"
-
-# 4. Remove iptables block
-ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- \
-  iptables -D INPUT -s 192.168.1.4 -p tcp --dport 9001 -j DROP"
+```yaml
+# terraform/lxc/stacks/<name>/stack.yaml
+ansible_playbook: "deploy-portainer-agent"
+portainer_agent: true
+portainer_stacks:
+  - name: <stack-name>
+    compose_file: docker-compose.yml   # relative to the stack directory
 ```
 
-Note: if legacy Portainer admin access is available, remove the endpoint from legacy first
-(`DELETE /api/endpoints/<id>` via API). This is cleaner than the iptables block approach,
-but the block works when legacy API access is unavailable.
+**Run migration:**
 
-After registering, verify each endpoint goes green. The `mgmt_seg → 192.168.1.0/24:9001`
-routing was confirmed in place during testing — no MikroTik changes required.
+```bash
+export TASK_APPROVAL="portainer-migration"
+./with-secrets-prod scripts/provision.sh --stack <name> \
+  --playbook terraform/lxc/ansible/playbooks/migrate-portainer-stack.yml
+```
+
+Or directly with ansible-playbook:
+
+```bash
+source .env
+ansible-playbook \
+  -i terraform/lxc/stacks/<name>/inventory.yml \
+  terraform/lxc/ansible/playbooks/migrate-portainer-stack.yml \
+  -e "@/tmp/<name>.ansible-extra-vars.yml"
+```
+
+If legacy Portainer admin access is available, remove the endpoint from legacy first
+(`DELETE /api/endpoints/<id>`) — this stops legacy polling and makes the iptables block
+unnecessary. The playbook works either way.
+
+`mgmt_seg → 192.168.1.0/24:9001` routing confirmed in place — no MikroTik changes required.
 
 Application hosts and LAN IPs:
 
-| Endpoint name   | URL                      | VMID |
-|---|---|---|
-| `torrent-stack` | `tcp://192.168.1.5:9001` | TBD  |
-| `media-stack`   | `tcp://192.168.1.6:9001` | TBD  |
-| `gaming-stack`  | `tcp://192.168.1.7:9001` | TBD  |
+| Stack yaml  | Endpoint name   | Agent URL                | VMID |
+|---|---|---|---|
+| `torrent-stack` | `torrent-stack` | `tcp://192.168.1.5:9001` | TBD  |
+| `media-stack`   | `media-stack`   | `tcp://192.168.1.6:9001` | TBD  |
+| `gaming-stack`  | `gaming-stack`  | `tcp://192.168.1.7:9001` | TBD  |
 
 These LAN bridge IPs are temporary — endpoint URLs will be updated to VLAN
 addresses by the `portainer_api` role as each application-migration sprint runs.
@@ -210,13 +211,20 @@ infrastructure Portainer.
 Option A (backup/restore) is not available — legacy is 2.33.6, infra is 2.27.3.
 Restoring a newer-version backup into an older Portainer is incompatible.
 
-**Option B — re-create stacks via API or UI**
+**Option B — re-create stacks via IaC (automated)**
 
-For each stack:
-1. In infrastructure Portainer: Stacks → Add Stack
-2. Paste compose file content
-3. Add environment variables (from SOPS where available, from notes in step 2 for others)
-4. Deploy on the correct endpoint
+The `portainer_stack` Ansible role deploys stacks idempotently via the Portainer API
+as part of the migration playbook (task 4a). Compose files must be committed to the
+repo under each stack's directory before running the playbook.
+
+For each application host before running the migration:
+1. Commit the compose file to `terraform/lxc/stacks/<name>/docker-compose.yml`
+2. Declare it in `stack.yaml` under `portainer_stacks`
+3. Add any environment variables under `portainer_stacks[].env` (from SOPS where
+   available, from manual notes in step 2 for Portainer-only secrets)
+
+The playbook then deploys stacks automatically during endpoint registration. Stacks
+already present on the endpoint are skipped (idempotent).
 
 ### 6. Verify stacks are running
 

--- a/docs/portainer-stack/02-migration.md
+++ b/docs/portainer-stack/02-migration.md
@@ -96,7 +96,7 @@ In the existing Portainer UI: **Settings → About** — note the version number
 Or via API:
 
 ```bash
-curl -s http://192.168.1.70:9000/api/system/status | jq .Version
+curl -s http://192.168.1.4:9000/api/system/status | jq .Version
 ```
 
 Infrastructure Portainer runs **2.27.3**. Legacy is **2.33.6** — newer than infra.
@@ -113,7 +113,7 @@ This determines steps 4 and 5 below. The existing agent type is expected to be
 
 ### 2. Inventory existing stacks
 
-In the existing Portainer at `http://192.168.1.70:9000`: list all stacks, note:
+In the existing Portainer at `http://192.168.1.4:9000`: list all stacks, note:
 - Stack names
 - Which endpoint each stack runs on
 - Any non-obvious environment variables (secrets stored in Portainer)
@@ -128,7 +128,7 @@ Retrieve the admin password from the existing Portainer host (check its stack en
 file or the management LXC where it's deployed) and run:
 
 ```bash
-EXISTING_PORTAINER_IP=192.168.1.70
+EXISTING_PORTAINER_IP=192.168.1.4
 TOKEN=$(curl -s -X POST http://$EXISTING_PORTAINER_IP:9000/api/auth \
   -H "Content-Type: application/json" \
   -d '{"Username":"admin","Password":"<existing-password>"}' | jq -r .jwt)
@@ -141,20 +141,59 @@ curl -o /mnt/nas-backup/portainer-backup/portainer-migration-$(date +%Y%m%d).tar
 Writing directly to `/mnt/nas-backup/portainer-backup/` keeps the backup off
 local disk and immediately on the NAS.
 
-### 4a. If regular agents — register endpoints in infrastructure Portainer
+### 4a. If regular agents — un-pair from legacy and register in infrastructure Portainer
 
-Regular agents just listen — no reconfiguration needed on the app hosts.
-Add each application host as an endpoint in infrastructure Portainer via the UI
-or portainer_api role:
+**Agent pairing constraint (validated 2026-06-19):** A portainer-agent can only be paired
+with ONE Portainer server at a time. Pairing state is stored in the agent container's
+writable layer. `docker restart` does NOT clear it — the old state remains in the
+container filesystem. Additionally, legacy Portainer's polling reconnects within seconds
+of an agent restart, winning any race to re-pair.
 
-| Endpoint name   | URL                             |
-|---|---|
-| `torrent-stack` | `tcp://192.168.1.5:9001`        |
-| `media-stack`   | `tcp://192.168.1.6:9001`        |
-| `gaming-stack`  | `tcp://192.168.1.7:9001`        |
+**Required procedure per host:**
 
-Verify each endpoint goes green (agent reachable). The MikroTik
-`mgmt_seg → 192.168.1.0/24:9001` rule (pre-condition) must be in place.
+```bash
+APP_HOST_IP=192.168.1.5   # change per host
+APP_HOST_VMID=...          # Proxmox LXC VMID
+
+# 1. Block legacy Portainer from reconnecting during the transition
+ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- \
+  iptables -I INPUT -s 192.168.1.4 -p tcp --dport 9001 -j DROP"
+
+# 2. Destroy and recreate the agent container (docker rm clears writable layer)
+ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- bash -c \
+  'cd /opt/portainer && docker compose down && docker compose up -d portainer-agent'"
+
+# 3. Immediately register with infra Portainer (while legacy is still blocked)
+JWT=$(curl -sf http://192.168.20.20:9000/api/auth \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"<PORTAINER_ADMIN_PASSWORD>"}' | jq -r '.jwt')
+
+curl -s http://192.168.20.20:9000/api/endpoints \
+  -H "Authorization: Bearer ${JWT}" \
+  -F "Name=<endpoint-name>" \
+  -F "EndpointCreationType=2" \
+  -F "URL=tcp://${APP_HOST_IP}:9001" \
+  -F "TLS=true" -F "TLSSkipVerify=true" -F "TLSSkipClientVerify=true"
+
+# 4. Remove iptables block
+ssh root@pve.gibbsgreatly.xyz "pct exec ${APP_HOST_VMID} -- \
+  iptables -D INPUT -s 192.168.1.4 -p tcp --dport 9001 -j DROP"
+```
+
+Note: if legacy Portainer admin access is available, remove the endpoint from legacy first
+(`DELETE /api/endpoints/<id>` via API). This is cleaner than the iptables block approach,
+but the block works when legacy API access is unavailable.
+
+After registering, verify each endpoint goes green. The `mgmt_seg → 192.168.1.0/24:9001`
+routing was confirmed in place during testing — no MikroTik changes required.
+
+Application hosts and LAN IPs:
+
+| Endpoint name   | URL                      | VMID |
+|---|---|---|
+| `torrent-stack` | `tcp://192.168.1.5:9001` | TBD  |
+| `media-stack`   | `tcp://192.168.1.6:9001` | TBD  |
+| `gaming-stack`  | `tcp://192.168.1.7:9001` | TBD  |
 
 These LAN bridge IPs are temporary — endpoint URLs will be updated to VLAN
 addresses by the `portainer_api` role as each application-migration sprint runs.
@@ -224,10 +263,8 @@ infrastructure still deploys cleanly with the migrated Portainer state.
 
 ## Pre-conditions
 
-- [ ] Sprint 01 complete: backup and restore validated
+- [x] Sprint 01 complete: backup and restore validated (2026-06-19 — full destroy+apply+restore cycle confirmed)
 - [ ] Existing Portainer admin password retrieved (not in SOPS — get from management-stack)
-- [ ] MikroTik rule: `mgmt_seg → 192.168.1.0/24:9001` in place
-  — infra Portainer (192.168.20.x) must reach app hosts on the LAN bridge during
-  the transition phase (before they move to VLAN zones in application-migration sprints)
+- [x] MikroTik rule: `mgmt_seg → 192.168.1.0/24:9001` in place (confirmed 2026-06-19 — no changes needed)
 - [ ] Inventory of stacks and any Portainer-only secrets (step 2) complete before proceeding
-- [ ] Version compatibility confirmed (step 0) before choosing Option A vs B
+- [x] Version compatibility confirmed: legacy 2.33.6 > infra 2.27.3, Option B (re-create stacks) only

--- a/docs/portainer-stack/02-migration.md
+++ b/docs/portainer-stack/02-migration.md
@@ -28,14 +28,19 @@ All pve commands run through `./with-secrets-prod`. Mutating commands require
 
 ## Existing Portainer
 
-**Server:** `management-stack` LXC — `192.168.1.70`, VMID 101, on the LAN bridge.
-**Portainer CE:** port 9000 (HTTP), port 9443 (HTTPS).
-**Credentials:** not in SOPS — retrieve the admin password from the management LXC
-before this sprint begins (check its stack env file or Docker compose env).
+**Server:** `management-stack` LXC — `192.168.1.4`, on the LAN bridge.
+**Portainer CE:** `2.33.6`, port 9000 (HTTP).
+**Credentials:** not in SOPS — admin password must be retrieved from management-stack
+before this sprint begins.
 
-The management-stack also runs NPM, a central Docker registry, and Trivy. This sprint
-covers the Portainer migration only. Full management-stack decommission (including NPM,
-registry, and DNS cutover) is a later step — see
+**Version incompatibility:** legacy is `2.33.6`, infra Portainer is `2.27.3`. A backup
+from a newer version cannot restore into an older one. **Option A (backup/restore) is
+not available for this migration.** All stacks must be migrated via Option B
+(re-register agents, re-create stacks manually or via API).
+
+Also running on management-stack: NPM, central Docker registry, registry-ui, Trivy.
+This sprint covers the Portainer migration only. Full management-stack decommission
+is a later step — see
 [application-migration/05-management-decommission.md](../application-migration/05-management-decommission.md).
 
 **Application hosts currently managed (on LAN bridge):**
@@ -94,9 +99,8 @@ Or via API:
 curl -s http://192.168.1.70:9000/api/system/status | jq .Version
 ```
 
-Infrastructure Portainer runs **2.27.3**. If the existing version differs significantly,
-prefer Option B (re-create stacks manually) in task 5 to avoid compatibility issues.
-Minor version differences within 2.x are generally safe for backup/restore.
+Infrastructure Portainer runs **2.27.3**. Legacy is **2.33.6** — newer than infra.
+Backup/restore across versions is incompatible. **Use Option B only** (task 5).
 
 ### 1. Identify agent type on existing Portainer
 
@@ -162,36 +166,12 @@ On each application host update the portainer-agent config with the new
 join token and restart the service. The agent will re-register with
 infrastructure Portainer.
 
-### 5. Restore or re-create stacks in infrastructure Portainer
+### 5. Re-create stacks in infrastructure Portainer
 
-Two options depending on Portainer version compatibility:
+Option A (backup/restore) is not available — legacy is 2.33.6, infra is 2.27.3.
+Restoring a newer-version backup into an older Portainer is incompatible.
 
-**Option A — restore backup (preferred if versions are close)**
-
-```bash
-# Infrastructure Portainer is at 192.168.20.20
-# PORTAINER_ADMIN_PASSWORD resolved from SOPS by with-secrets-prod
-TOKEN=$(./with-secrets-prod env | grep PORTAINER_ADMIN_PASSWORD | cut -d= -f2- | \
-  xargs -I{} curl -s -X POST http://192.168.20.20:9000/api/auth \
-    -H "Content-Type: application/json" \
-    -d "{\"Username\":\"admin\",\"Password\":\"{}\"}" | jq -r .jwt)
-
-BACKUP=/mnt/nas-backup/portainer-backup/portainer-migration-$(date +%Y%m%d).tar.gz
-curl -X POST http://192.168.20.20:9000/api/restore \
-  -H "Authorization: Bearer $TOKEN" \
-  -F "file=@$BACKUP" \
-  -w "\nHTTP %{http_code}\n"
-
-# Restart Portainer to apply restored database
-./with-secrets-prod pct exec 20020 -- docker restart portainer
-```
-
-After restore: verify stacks are present and endpoints are assigned correctly.
-Stack env vars should be intact. Note that endpoint URLs in the restored backup
-will reflect the old Portainer's registrations — update them if needed (or they
-will be updated automatically when each app-migration sprint provisions its LXC).
-
-**Option B — re-create stacks manually (if versions differ or restore fails)**
+**Option B — re-create stacks via API or UI**
 
 For each stack:
 1. In infrastructure Portainer: Stacks → Add Stack

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -15,7 +15,7 @@
 #
 # Environment (resolved by with-secrets-prod):
 #   LAB_IP_PORTAINER         — Portainer LXC IP
-#   PORTAINER_ADMIN_PASSWORD — admin password (used by provision.sh after restore)
+#   TF_VAR_portainer_admin_password — admin password (resolved by provision.sh after restore)
 
 set -euo pipefail
 

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # Restore Portainer from the latest NAS backup after a fresh terragrunt apply.
-# Must run BEFORE provision.sh — POST /api/restore only works on an uninitialised instance.
+#
+# Sequence:
+#   1. Run provision.sh --tags pre_restore  (Docker base + Portainer CE start, no init)
+#   2. Wait for uninitialized Portainer API
+#   3. POST /api/restore from latest NAS backup
+#   4. Restart Portainer container to load restored DB
+#   5. Run provision.sh (full — init gets 409, skips; everything else idempotent)
 #
 # Usage:
 #   export TASK_APPROVAL="<task-name>"
 #   ./with-secrets-prod scripts/portainer-restore.sh
 #
 # Environment (resolved by with-secrets-prod):
-#   LAB_IP_PORTAINER       — Portainer LXC IP (e.g. 192.168.20.20)
+#   LAB_IP_PORTAINER         — Portainer LXC IP
 #   PORTAINER_ADMIN_PASSWORD — admin password (used by provision.sh after restore)
 
 set -euo pipefail
@@ -50,15 +56,20 @@ echo "Target:  http://${PORTAINER_IP}:${PORTAINER_PORT}"
 echo "PVE:     ${PVE_HOST}  (VMID ${PORTAINER_VMID})"
 echo ""
 
-# Step 1: wait for fresh instance
-wait_for_api "Waiting for Portainer API to be reachable"
+# Step 1: start Portainer CE without initialising
+echo "=== Phase 1: deploy Docker base + Portainer CE (no init) ==="
+ANSIBLE_TAGS="pre_restore" "${SCRIPT_DIR}/provision.sh" --stack portainer-stack
+echo ""
+
+# Step 2: wait for fresh uninitialized instance
+wait_for_api "Waiting for Portainer API (uninitialized)"
 
 INSTANCE_BEFORE=$(curl -sf --max-time 5 \
     "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status" | jq -r .InstanceID)
 echo "InstanceID (new instance): ${INSTANCE_BEFORE}"
 echo ""
 
-# Step 2: find latest backup on NAS via pve SSH
+# Step 3: find latest backup on NAS via pve SSH
 echo "Finding latest backup on NAS..."
 BACKUP=$(ssh root@"${PVE_HOST}" \
     "ls -t ${NAS_BACKUP_DIR}/portainer-*.tar.gz 2>/dev/null | head -1")
@@ -70,40 +81,38 @@ BACKUP_SIZE=$(ssh root@"${PVE_HOST}" "du -sh ${BACKUP} | cut -f1")
 echo "Restoring from: ${BACKUP} (${BACKUP_SIZE})"
 echo ""
 
-# Step 3: restore (no auth — instance is uninitialised)
+# Step 4: restore (no auth — instance is uninitialised)
 echo "POSTing restore..."
 HTTP=$(ssh root@"${PVE_HOST}" \
     "curl -sf --max-time 30 -X POST http://${PORTAINER_IP}:${PORTAINER_PORT}/api/restore \
      -F 'file=@${BACKUP}' -o /dev/null -w '%{http_code}'")
 echo "Restore response: HTTP ${HTTP}"
 if [[ "$HTTP" != "200" ]]; then
-    echo "ERROR: restore failed — check that the instance is still uninitialised"
-    echo "       (provision.sh must NOT have run before this script)"
+    echo "ERROR: restore failed (HTTP ${HTTP})"
     exit 1
 fi
 echo ""
 
-# Step 4: restart to load restored DB
-echo "Restarting Portainer container to apply restored database..."
+# Step 5: restart to load restored DB
+echo "Restarting Portainer container..."
 ssh root@"${PVE_HOST}" "pct exec ${PORTAINER_VMID} -- docker restart ${CONTAINER_NAME}"
 sleep 8
 
-# Step 5: wait for it to come back up
+# Step 6: wait for it to come back up
 wait_for_api "Waiting for Portainer API after restart"
 echo ""
 
-# Step 6: verify InstanceID changed
+# Step 7: verify InstanceID changed to match backup
 INSTANCE_AFTER=$(curl -sf --max-time 5 \
     "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status" | jq -r .InstanceID)
-echo "InstanceID (restored):     ${INSTANCE_AFTER}"
-
+echo "InstanceID (restored): ${INSTANCE_AFTER}"
 if [[ "$INSTANCE_BEFORE" == "$INSTANCE_AFTER" ]]; then
-    echo "WARN: InstanceID unchanged — this may indicate the restore did not apply"
+    echo "WARN: InstanceID unchanged — restore may not have applied"
 else
     echo "OK: InstanceID changed — database restored from backup"
 fi
 echo ""
 
-# Step 7: provision (init play gets 409 and skips; everything else is idempotent)
-echo "=== Running provision.sh --stack portainer-stack ==="
+# Step 8: full provision (init gets 409 and skips; OAuth, bind mount, timer all idempotent)
+echo "=== Phase 2: full provision (init + OAuth + backup timer) ==="
 "${SCRIPT_DIR}/provision.sh" --stack portainer-stack

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -2,11 +2,12 @@
 # Restore Portainer from the latest NAS backup after a fresh terragrunt apply.
 #
 # Sequence:
-#   1. Run provision.sh --tags pre_restore  (Docker base + Portainer CE start, no init)
-#   2. Wait for uninitialized Portainer API
-#   3. POST /api/restore from latest NAS backup
-#   4. Restart Portainer container to load restored DB
-#   5. Run provision.sh (full — init gets 409, skips; everything else idempotent)
+#   1. Wipe /var/lib/portainer so the instance is guaranteed uninitialized
+#   2. Run provision.sh --tags pre_restore  (Docker base + Portainer CE start, no init)
+#   3. Wait for uninitialized Portainer API
+#   4. POST /api/restore from latest NAS backup
+#   5. Restart Portainer container to load restored DB
+#   6. Run provision.sh (full — init gets 409, skips; everything else idempotent)
 #
 # Usage:
 #   export TASK_APPROVAL="<task-name>"
@@ -56,12 +57,25 @@ echo "Target:  http://${PORTAINER_IP}:${PORTAINER_PORT}"
 echo "PVE:     ${PVE_HOST}  (VMID ${PORTAINER_VMID})"
 echo ""
 
-# Step 1: start Portainer CE without initialising
+# Step 1: wipe Portainer database so the instance is guaranteed uninitialized.
+# /var/lib/portainer can survive a destroy/apply cycle if the storage profile
+# reuses an existing volume or the template has stale data.
+# Stop+remove the container first so the DB isn't live in memory during wipe.
+echo "Wiping /var/lib/portainer to guarantee a fresh uninitialized instance..."
+ssh root@"${PVE_HOST}" "pct exec ${PORTAINER_VMID} -- bash -c '
+    docker stop portainer-portainer-1 2>/dev/null || true
+    docker rm   portainer-portainer-1 2>/dev/null || true
+    rm -rf /var/lib/portainer
+'"
+echo "Wiped."
+echo ""
+
+# Step 2: start Portainer CE without initialising (plays 1+2 only)
 echo "=== Phase 1: deploy Docker base + Portainer CE (no init) ==="
 ANSIBLE_TAGS="pre_restore" "${SCRIPT_DIR}/provision.sh" --stack portainer-stack
 echo ""
 
-# Step 2: wait for fresh uninitialized instance
+# Step 3: wait for fresh uninitialized instance
 wait_for_api "Waiting for Portainer API (uninitialized)"
 
 INSTANCE_BEFORE=$(curl -sf --max-time 5 \
@@ -69,7 +83,7 @@ INSTANCE_BEFORE=$(curl -sf --max-time 5 \
 echo "InstanceID (new instance): ${INSTANCE_BEFORE}"
 echo ""
 
-# Step 3: find latest backup on NAS via pve SSH
+# Step 4: find latest backup on NAS via pve SSH
 echo "Finding latest backup on NAS..."
 BACKUP=$(ssh root@"${PVE_HOST}" \
     "ls -t ${NAS_BACKUP_DIR}/portainer-*.tar.gz 2>/dev/null | head -1")
@@ -81,28 +95,33 @@ BACKUP_SIZE=$(ssh root@"${PVE_HOST}" "du -sh ${BACKUP} | cut -f1")
 echo "Restoring from: ${BACKUP} (${BACKUP_SIZE})"
 echo ""
 
-# Step 4: restore (no auth — instance is uninitialised)
+# Step 5: restore (no auth — instance is uninitialised)
+# Note: -s suppresses progress but errors are still captured via -w; no -f so
+# we always get the HTTP code rather than a silent exit-22 on 4xx.
 echo "POSTing restore..."
-HTTP=$(ssh root@"${PVE_HOST}" \
-    "curl -sf --max-time 30 -X POST http://${PORTAINER_IP}:${PORTAINER_PORT}/api/restore \
-     -F 'file=@${BACKUP}' -o /dev/null -w '%{http_code}'")
-echo "Restore response: HTTP ${HTTP}"
+RESTORE_RESPONSE=$(ssh root@"${PVE_HOST}" \
+    "curl -s --max-time 30 -X POST http://${PORTAINER_IP}:${PORTAINER_PORT}/api/restore \
+     -F 'file=@${BACKUP}' -w '\nHTTP %{http_code}'")
+echo "${RESTORE_RESPONSE}"
+
+HTTP=$(echo "${RESTORE_RESPONSE}" | grep -oE 'HTTP [0-9]+' | awk '{print $2}')
 if [[ "$HTTP" != "200" ]]; then
     echo "ERROR: restore failed (HTTP ${HTTP})"
+    echo "       Ensure provision.sh has NOT run (init play must not have executed yet)"
     exit 1
 fi
 echo ""
 
-# Step 5: restart to load restored DB
+# Step 6: restart to load restored DB
 echo "Restarting Portainer container..."
 ssh root@"${PVE_HOST}" "pct exec ${PORTAINER_VMID} -- docker restart ${CONTAINER_NAME}"
 sleep 8
 
-# Step 6: wait for it to come back up
+# Step 7: wait for it to come back up
 wait_for_api "Waiting for Portainer API after restart"
 echo ""
 
-# Step 7: verify InstanceID changed to match backup
+# Step 8: verify InstanceID changed
 INSTANCE_AFTER=$(curl -sf --max-time 5 \
     "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status" | jq -r .InstanceID)
 echo "InstanceID (restored): ${INSTANCE_AFTER}"
@@ -113,6 +132,6 @@ else
 fi
 echo ""
 
-# Step 8: full provision (init gets 409 and skips; OAuth, bind mount, timer all idempotent)
+# Step 9: full provision (init gets 409 and skips; OAuth, bind mount, timer all idempotent)
 echo "=== Phase 2: full provision (init + OAuth + backup timer) ==="
 "${SCRIPT_DIR}/provision.sh" --stack portainer-stack

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Restore Portainer from the latest NAS backup after a fresh terragrunt apply.
+# Must run BEFORE provision.sh — POST /api/restore only works on an uninitialised instance.
+#
+# Usage:
+#   export TASK_APPROVAL="<task-name>"
+#   ./with-secrets-prod scripts/portainer-restore.sh
+#
+# Environment (resolved by with-secrets-prod):
+#   LAB_IP_PORTAINER       — Portainer LXC IP (e.g. 192.168.20.20)
+#   PORTAINER_ADMIN_PASSWORD — admin password (used by provision.sh after restore)
+
+set -euo pipefail
+
+PORTAINER_IP="${LAB_IP_PORTAINER:-192.168.20.20}"
+PORTAINER_PORT="9000"
+PORTAINER_VMID="20020"
+PVE_HOST="pve.gibbsgreatly.xyz"
+NAS_BACKUP_DIR="/mnt/nas-backup/portainer-backup"
+CONTAINER_NAME="portainer-portainer-1"
+WAIT_TIMEOUT=180
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+
+wait_for_api() {
+    local label="$1"
+    local url="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status"
+    local deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    echo -n "${label}"
+    while true; do
+        if curl -sf --max-time 5 "$url" > /dev/null 2>&1; then
+            echo " OK"
+            return 0
+        fi
+        if [[ $(date +%s) -ge $deadline ]]; then
+            echo " TIMEOUT after ${WAIT_TIMEOUT}s"
+            return 1
+        fi
+        echo -n "."
+        sleep 5
+    done
+}
+
+# ---------------------------------------------------------------------------
+
+echo "=== Portainer Restore ==="
+echo "Target:  http://${PORTAINER_IP}:${PORTAINER_PORT}"
+echo "PVE:     ${PVE_HOST}  (VMID ${PORTAINER_VMID})"
+echo ""
+
+# Step 1: wait for fresh instance
+wait_for_api "Waiting for Portainer API to be reachable"
+
+INSTANCE_BEFORE=$(curl -sf --max-time 5 \
+    "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status" | jq -r .InstanceID)
+echo "InstanceID (new instance): ${INSTANCE_BEFORE}"
+echo ""
+
+# Step 2: find latest backup on NAS via pve SSH
+echo "Finding latest backup on NAS..."
+BACKUP=$(ssh root@"${PVE_HOST}" \
+    "ls -t ${NAS_BACKUP_DIR}/portainer-*.tar.gz 2>/dev/null | head -1")
+if [[ -z "$BACKUP" ]]; then
+    echo "ERROR: no backup found in ${NAS_BACKUP_DIR} on ${PVE_HOST}"
+    exit 1
+fi
+BACKUP_SIZE=$(ssh root@"${PVE_HOST}" "du -sh ${BACKUP} | cut -f1")
+echo "Restoring from: ${BACKUP} (${BACKUP_SIZE})"
+echo ""
+
+# Step 3: restore (no auth — instance is uninitialised)
+echo "POSTing restore..."
+HTTP=$(ssh root@"${PVE_HOST}" \
+    "curl -sf --max-time 30 -X POST http://${PORTAINER_IP}:${PORTAINER_PORT}/api/restore \
+     -F 'file=@${BACKUP}' -o /dev/null -w '%{http_code}'")
+echo "Restore response: HTTP ${HTTP}"
+if [[ "$HTTP" != "200" ]]; then
+    echo "ERROR: restore failed — check that the instance is still uninitialised"
+    echo "       (provision.sh must NOT have run before this script)"
+    exit 1
+fi
+echo ""
+
+# Step 4: restart to load restored DB
+echo "Restarting Portainer container to apply restored database..."
+ssh root@"${PVE_HOST}" "pct exec ${PORTAINER_VMID} -- docker restart ${CONTAINER_NAME}"
+sleep 8
+
+# Step 5: wait for it to come back up
+wait_for_api "Waiting for Portainer API after restart"
+echo ""
+
+# Step 6: verify InstanceID changed
+INSTANCE_AFTER=$(curl -sf --max-time 5 \
+    "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/system/status" | jq -r .InstanceID)
+echo "InstanceID (restored):     ${INSTANCE_AFTER}"
+
+if [[ "$INSTANCE_BEFORE" == "$INSTANCE_AFTER" ]]; then
+    echo "WARN: InstanceID unchanged — this may indicate the restore did not apply"
+else
+    echo "OK: InstanceID changed — database restored from backup"
+fi
+echo ""
+
+# Step 7: provision (init play gets 409 and skips; everything else is idempotent)
+echo "=== Running provision.sh --stack portainer-stack ==="
+"${SCRIPT_DIR}/provision.sh" --stack portainer-stack

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -150,6 +150,11 @@ SOCKET_PROXY_KEYS = (
     "docker_socket_proxy_targets",
 )
 
+PORTAINER_MIGRATION_KEYS = (
+    "portainer_stacks",
+    "portainer_migration_legacy_ip",
+)
+
 
 def resolve_placeholders(value):
     if isinstance(value, str):
@@ -186,6 +191,10 @@ with open(stack_file, "r", encoding="utf-8") as handle:
     stack = yaml.safe_load(handle) or {}
 
 extra_vars = {}
+
+# Always inject the stack directory so playbooks can reference compose files
+extra_vars["stack_dir"] = os.path.dirname(os.path.abspath(stack_file))
+
 for key in SOCKET_PROXY_KEYS:
     if key in stack and stack[key] is not None:
         extra_vars[key] = resolve_placeholders(stack[key])
@@ -196,6 +205,10 @@ if extra_vars.get("enable_docker_socket_proxy") is True:
         die(f"{stack_file}: enabled docker socket proxy requires docker_socket_proxy_bind_addr")
     if "${" in bind_addr:
         die(f"{stack_file}: unresolved docker_socket_proxy_bind_addr placeholder: {bind_addr}")
+
+for key in PORTAINER_MIGRATION_KEYS:
+    if key in stack and stack[key] is not None:
+        extra_vars[key] = resolve_placeholders(stack[key])
 
 with open(output_file, "w", encoding="utf-8") as handle:
     yaml.safe_dump(extra_vars, handle, sort_keys=False)

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -481,6 +481,10 @@ for stack in "${ordered_stacks[@]}"; do
     cmd+=(--check)
   fi
 
+  if [[ -n "${ANSIBLE_TAGS:-}" ]]; then
+    cmd+=(--tags "$ANSIBLE_TAGS")
+  fi
+
   log "RUN ${stack}: ${cmd[*]}"
   "${cmd[@]}"
 done

--- a/scripts/teardown-deploy-test.sh
+++ b/scripts/teardown-deploy-test.sh
@@ -1550,6 +1550,13 @@ stack_destroy() {
   vmid="$(stack_vmid "${spec}")"
 
   ensure_workspace_dir "${stack}"
+
+  if [[ "${stack}" == "portainer-stack" ]]; then
+    run_logged "pre-destroy-backup-${stack}" \
+      ssh -F /dev/null "root@${TARGET_PVE_HOST}" \
+        "pct exec ${vmid} -- bash -c 'set -a; source /etc/portainer-backup/env; set +a; /opt/portainer-backup/backup.sh'"
+  fi
+
   guard_target
   if [[ "${stack}" == "portainer-stack" || "${stack}" == "netbox-stack" || "${stack}" == "monitoring-stack" || "${stack}" == "harbor-stack" || "${stack}" == "authentik-stack" || "${stack}" == "step-ca-stack" || "${stack}" == "proxy-stack" || "${stack}" == "dns-stack" || "${stack}" == "ci-runner-01" || "${stack}" == "apt-cacher-stack" ]]; then
     run_logged "destroy-${stack}" \

--- a/terraform/lxc/ansible/playbooks/deploy-portainer-agent.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-portainer-agent.yml
@@ -1,7 +1,8 @@
 ---
-# Provisions Docker base and Portainer Agent on an LXC host.
-# Does NOT register the endpoint with any Portainer server — registration
-# is done separately via the target Portainer's API.
+# Provisions Docker base and Portainer Agent on an LXC host,
+# then registers the endpoint with infra Portainer.
+# For migrating from legacy Portainer use migrate-portainer-stack.yml instead.
+
 - name: Configure Docker base and install Portainer Agent
   hosts: all
   become: true
@@ -38,3 +39,9 @@
       ansible.builtin.systemd:
         name: docker
         state: restarted
+
+- name: Register endpoint with infra Portainer
+  hosts: all
+  roles:
+    - portainer_api
+    - portainer_stack

--- a/terraform/lxc/ansible/playbooks/deploy-portainer-agent.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-portainer-agent.yml
@@ -1,0 +1,40 @@
+---
+# Provisions Docker base and Portainer Agent on an LXC host.
+# Does NOT register the endpoint with any Portainer server — registration
+# is done separately via the target Portainer's API.
+- name: Configure Docker base and install Portainer Agent
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    docker_registry_host: "{{ registry_host | default(lookup('env', 'LAB_IP_HARBOR'), true) | mandatory('registry_host var or LAB_IP_HARBOR env var is required') }}"
+  roles:
+    - lxc_base
+    - docker_base
+    - portainer_agent
+
+  tasks:
+    - name: Trust Harbor HTTP registry in Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "insecure-registries": ["{{ docker_registry_host }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "3"
+            },
+            "storage-driver": "overlay2"
+          }
+      notify: Restart Docker
+
+    - name: Flush handlers to apply Docker daemon config
+      ansible.builtin.meta: flush_handlers
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted

--- a/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
@@ -6,6 +6,7 @@
   hosts: all
   become: true
   gather_facts: true
+  tags: [pre_restore]
   vars:
     docker_registry_host: "{{ registry_host | default('') | trim }}"
     docker_dns_server: "{{ lookup('env', 'LAB_IP_DNS') | default(dns_server, true) | mandatory('LAB_IP_DNS env var or dns_server inventory var is required') }}"
@@ -73,6 +74,7 @@
   hosts: all
   become: true
   gather_facts: false
+  tags: [pre_restore]
 
   vars:
     portainer_compose_dir: /opt/portainer
@@ -182,6 +184,7 @@
   hosts: all
   become: false
   gather_facts: false
+  tags: [post_restore]
 
   vars:
     portainer_lab_domain: "{{ lookup('env', 'LAB_DOMAIN') | default('lab.gibbsgreatly.xyz', true) }}"
@@ -664,5 +667,6 @@
   hosts: all
   become: true
   gather_facts: false
+  tags: [post_restore]
   roles:
     - portainer_backup

--- a/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
@@ -659,3 +659,10 @@
              if (portainer_endpoint_group_policy_needs_update | bool)
              else 'Portainer local endpoint group policy already grants OAuth default team access.' }}
       when: not ansible_check_mode
+
+- name: Install Portainer NAS backup timer
+  hosts: all
+  become: true
+  gather_facts: false
+  roles:
+    - portainer_backup

--- a/terraform/lxc/ansible/playbooks/migrate-portainer-stack.yml
+++ b/terraform/lxc/ansible/playbooks/migrate-portainer-stack.yml
@@ -1,0 +1,86 @@
+---
+# Migrates a portainer-agent host from legacy to infrastructure Portainer.
+#
+# The portainer-agent pairs with the first Portainer server that connects
+# after it starts. Pairing state lives in the container writable layer and
+# persists across `docker restart`. Legacy Portainer polls its endpoints
+# continuously and reconnects within seconds of an agent restart.
+#
+# This playbook handles that race by:
+#   1. Blocking legacy Portainer's IP at the agent host while the transition runs
+#   2. Doing a full docker compose down/up (not just restart) to clear pairing state
+#   3. Registering the fresh agent with infra Portainer before unblocking
+#
+# Usage (via provision.sh):
+#   ANSIBLE_TAGS=pre_migrate  provision.sh --stack <name>   # step 1+2 only (debug)
+#   provision.sh --stack <name>                              # full migration
+#
+# Usage (direct):
+#   source .env
+#   ansible-playbook -i terraform/lxc/stacks/<name>/inventory.yml \
+#     terraform/lxc/ansible/playbooks/migrate-portainer-stack.yml \
+#     -e "@/tmp/<name>.ansible-extra-vars.yml"
+#
+# Required extra vars (from stack.yaml via provision.sh render_stack_ansible_extra_vars):
+#   stack_dir                    — absolute path to the stack directory (auto-injected)
+#   portainer_stacks             — list of {name, compose_file} to deploy
+#   portainer_migration_legacy_ip (optional, default 192.168.1.4)
+
+- name: Block legacy Portainer and reset agent pairing state
+  hosts: all
+  become: true
+  tags: [pre_migrate]
+  vars:
+    _legacy_ip: "{{ portainer_migration_legacy_ip | default('192.168.1.4') }}"
+  tasks:
+    - name: Block legacy Portainer from reconnecting during migration
+      ansible.builtin.iptables:
+        chain: INPUT
+        source: "{{ _legacy_ip }}"
+        protocol: tcp
+        destination_port: "9001"
+        jump: DROP
+
+    - name: Bring compose project down (removes container and clears pairing state)
+      community.docker.docker_compose_v2:
+        project_src: "{{ portainer_agent_compose_dir | default('/opt/portainer') }}"
+        state: absent
+
+    - name: Bring portainer-agent back up (fresh, no pairing state)
+      community.docker.docker_compose_v2:
+        project_src: "{{ portainer_agent_compose_dir | default('/opt/portainer') }}"
+        state: present
+
+    - name: Wait for agent to be reachable
+      ansible.builtin.uri:
+        url: "https://{{ ansible_host }}:9001/ping"
+        method: GET
+        status_code: 204
+        validate_certs: false
+      retries: 15
+      delay: 2
+      register: _agent_ping
+      until: _agent_ping.status == 204
+
+- name: Register endpoint and deploy stacks in infra Portainer
+  hosts: all
+  tags: [pre_migrate, post_migrate]
+  roles:
+    - portainer_api
+    - portainer_stack
+
+- name: Unblock legacy Portainer
+  hosts: all
+  become: true
+  tags: [post_migrate]
+  vars:
+    _legacy_ip: "{{ portainer_migration_legacy_ip | default('192.168.1.4') }}"
+  tasks:
+    - name: Remove iptables block on legacy Portainer
+      ansible.builtin.iptables:
+        chain: INPUT
+        source: "{{ _legacy_ip }}"
+        protocol: tcp
+        destination_port: "9001"
+        jump: DROP
+        state: absent

--- a/terraform/lxc/ansible/roles/portainer_api/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_api/tasks/main.yml
@@ -1,13 +1,13 @@
 # portainer_api — idempotent agent endpoint registration via Portainer API
-# Registers agent if not already present; skips if endpoint name exists.
-# Wrapped in block/rescue so auth failures don't abort subsequent plays.
+# Registers endpoint if not present; updates URL if already registered.
+# Always sets portainer_endpoint_id for downstream roles (e.g. portainer_stack).
 
 ---
 - name: Register agent endpoint with Portainer
   block:
     - name: Get Portainer authentication token
       ansible.builtin.uri:
-        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/auth"
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/auth" # nosonar
         method: POST
         body_format: json
         body:
@@ -28,7 +28,7 @@
 
     - name: Get existing endpoints
       ansible.builtin.uri:
-        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints"
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints" # nosonar
         method: GET
         headers:
           Authorization: "Bearer {{ portainer_api_token }}"
@@ -36,16 +36,19 @@
       register: portainer_api_endpoints_response
       delegate_to: localhost
 
-    - name: Check if endpoint already exists
+    - name: Find existing endpoint by name
       ansible.builtin.set_fact:
-        portainer_api_existing_endpoint_id: "{{ item.Id }}"
-      loop: "{{ portainer_api_endpoints_response.json }}"
-      when: item.Name == portainer_api_endpoint_name
+        portainer_api_existing_endpoint: >-
+          {{
+            portainer_api_endpoints_response.json
+            | selectattr('Name', 'equalto', portainer_api_endpoint_name)
+            | list | first | default(none)
+          }}
       delegate_to: localhost
 
-    - name: Register agent with Portainer Server
+    - name: Register agent with Portainer (endpoint not yet present)
       ansible.builtin.uri:
-        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints"
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints" # nosonar
         method: POST
         headers:
           Authorization: "Bearer {{ portainer_api_token }}"
@@ -59,18 +62,24 @@
           TLSSkipClientVerify: "true"
         status_code: 200
       register: portainer_api_registration_result
-      when: portainer_api_existing_endpoint_id is not defined
+      when: portainer_api_existing_endpoint is none
       delegate_to: localhost
 
-    - name: Display registration result
+    - name: Set portainer_endpoint_id from new registration
+      ansible.builtin.set_fact:
+        portainer_endpoint_id: "{{ portainer_api_registration_result.json.Id }}"
+      when: portainer_api_existing_endpoint is none
+      delegate_to: localhost
+
+    - name: Report new endpoint registration
       ansible.builtin.debug:
-        msg: "Agent '{{ portainer_api_endpoint_name }}' registered with ID: {{ portainer_api_registration_result.json.Id }}"
-      when: portainer_api_existing_endpoint_id is not defined
+        msg: "Registered '{{ portainer_api_endpoint_name }}' as endpoint ID {{ portainer_endpoint_id }}"
+      when: portainer_api_existing_endpoint is none
       delegate_to: localhost
 
-    - name: Update existing endpoint URL to current agent IP
+    - name: Update existing endpoint URL
       ansible.builtin.uri:
-        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints/{{ portainer_api_existing_endpoint_id }}"
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints/{{ portainer_api_existing_endpoint.Id }}" # nosonar
         method: PUT
         headers:
           Authorization: "Bearer {{ portainer_api_token }}"
@@ -79,21 +88,28 @@
           Name: "{{ portainer_api_endpoint_name }}"
           URL: "tcp://{{ portainer_api_agent_ip }}:{{ portainer_api_agent_port }}"
         status_code: 200
-      when: portainer_api_existing_endpoint_id is defined
+      when: portainer_api_existing_endpoint is not none
       delegate_to: localhost
 
-    - name: Display existing endpoint
+    - name: Set portainer_endpoint_id from existing endpoint
+      ansible.builtin.set_fact:
+        portainer_endpoint_id: "{{ portainer_api_existing_endpoint.Id }}"
+      when: portainer_api_existing_endpoint is not none
+      delegate_to: localhost
+
+    - name: Report existing endpoint
       ansible.builtin.debug:
         msg: >-
-          Agent '{{ portainer_api_endpoint_name }}' already registered
-          (ID: {{ portainer_api_existing_endpoint_id }}) — URL updated to
+          Endpoint '{{ portainer_api_endpoint_name }}' already registered
+          (ID: {{ portainer_endpoint_id }}) — URL updated to
           tcp://{{ portainer_api_agent_ip }}:{{ portainer_api_agent_port }}
-      when: portainer_api_existing_endpoint_id is defined
+      when: portainer_api_existing_endpoint is not none
       delegate_to: localhost
 
   rescue:
     - name: Warn on Portainer registration failure
       ansible.builtin.debug:
         msg: >-
-          WARNING: Portainer endpoint registration failed for '{{ portainer_api_endpoint_name }}'.
-          Harbor install will continue. Register the endpoint manually in Portainer if needed.
+          WARNING: Portainer endpoint registration failed for
+          '{{ portainer_api_endpoint_name }}'. Register the endpoint manually
+          in Portainer if needed.

--- a/terraform/lxc/ansible/roles/portainer_backup/defaults/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+portainer_backup_portainer_ip: "{{ ansible_host }}"
+portainer_backup_portainer_port: "9000"
+portainer_backup_admin_password: >-
+  {{
+    lookup('env', 'PORTAINER_ADMIN_PASSWORD')
+    | default(lookup('env', 'TF_VAR_portainer_admin_password'), true)
+    | mandatory('PORTAINER_ADMIN_PASSWORD environment variable is required')
+  }}
+portainer_backup_dir: /var/backups/portainer
+portainer_backup_env_dir: /etc/portainer-backup
+portainer_backup_script_dir: /opt/portainer-backup
+portainer_backup_retain_days: 7

--- a/terraform/lxc/ansible/roles/portainer_backup/handlers/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
@@ -92,9 +92,8 @@
       #!/bin/bash
       set -euo pipefail
 
-      # nosonar: ansible:S5332 — Portainer API is HTTP-only on internal SDN; no TLS on port 9000
-      AUTH_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/auth"
-      BACKUP_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/backup"
+      AUTH_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/auth"  # nosonar: ansible:S5332 — HTTP-only internal SDN
+      BACKUP_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/backup"  # nosonar: ansible:S5332 — HTTP-only internal SDN
 
       TOKEN=$(curl -sf -X POST "${AUTH_URL}" \
         -H "Content-Type: application/json" \
@@ -103,8 +102,10 @@
 
       OUTFILE="${BACKUP_DIR}/portainer-$(date +%Y%m%d).tar.gz"
 
-      curl -sf -o "${OUTFILE}" \
+      curl -sf -X POST -o "${OUTFILE}" \
         -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{}' \
         "${BACKUP_URL}"
 
       # Rotate — remove backups older than RETAIN_DAYS

--- a/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
@@ -34,6 +34,7 @@
         ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
         ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
+  always:
     - name: Start portainer LXC
       ansible.builtin.command:
         cmd: pct start {{ vmid }}
@@ -42,6 +43,8 @@
         ansible_user: "{{ pve_ssh_user | default('root') }}"
         ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
         ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: pct_start
+      failed_when: pct_start.rc != 0 and "already running" not in pct_start.stderr
 
     - name: Wait for container to come back online
       ansible.builtin.wait_for_connection:
@@ -89,7 +92,11 @@
       #!/bin/bash
       set -euo pipefail
 
-      TOKEN=$(curl -sf -X POST "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/auth" \
+      # nosonar: ansible:S5332 — Portainer API is HTTP-only on internal SDN; no TLS on port 9000
+      AUTH_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/auth"
+      BACKUP_URL="http://${PORTAINER_IP}:${PORTAINER_PORT}/api/backup"
+
+      TOKEN=$(curl -sf -X POST "${AUTH_URL}" \
         -H "Content-Type: application/json" \
         -d "{\"Username\":\"admin\",\"Password\":\"${PORTAINER_ADMIN_PASSWORD}\"}" \
         | jq -r .jwt)
@@ -98,7 +105,7 @@
 
       curl -sf -o "${OUTFILE}" \
         -H "Authorization: Bearer ${TOKEN}" \
-        "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/backup"
+        "${BACKUP_URL}"
 
       # Rotate — remove backups older than RETAIN_DAYS
       find "${BACKUP_DIR}" -maxdepth 1 -name "portainer-*.tar.gz" \

--- a/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
@@ -1,0 +1,112 @@
+---
+- name: Create portainer-backup script directory
+  ansible.builtin.file:
+    path: "{{ portainer_backup_script_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Create portainer-backup credential directory
+  ansible.builtin.file:
+    path: "{{ portainer_backup_env_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+
+- name: Write portainer-backup credential env file
+  ansible.builtin.copy:
+    dest: "{{ portainer_backup_env_dir }}/env"
+    owner: root
+    group: root
+    mode: "0600"
+    content: |
+      # Portainer backup credentials — managed by Ansible, do not edit by hand
+      PORTAINER_IP={{ portainer_backup_portainer_ip }}
+      PORTAINER_PORT={{ portainer_backup_portainer_port }}
+      PORTAINER_ADMIN_PASSWORD={{ portainer_backup_admin_password }}
+      BACKUP_DIR={{ portainer_backup_dir }}
+      RETAIN_DAYS={{ portainer_backup_retain_days }}
+  no_log: true
+
+- name: Write portainer-backup script
+  ansible.builtin.copy:
+    dest: "{{ portainer_backup_script_dir }}/backup.sh"
+    owner: root
+    group: root
+    mode: "0750"
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      TOKEN=$(curl -sf -X POST "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/auth" \
+        -H "Content-Type: application/json" \
+        -d "{\"Username\":\"admin\",\"Password\":\"${PORTAINER_ADMIN_PASSWORD}\"}" \
+        | jq -r .jwt)
+
+      OUTFILE="${BACKUP_DIR}/portainer-$(date +%Y%m%d).tar.gz"
+
+      curl -sf -o "${OUTFILE}" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "http://${PORTAINER_IP}:${PORTAINER_PORT}/api/backup"
+
+      # Rotate — remove backups older than RETAIN_DAYS
+      find "${BACKUP_DIR}" -maxdepth 1 -name "portainer-*.tar.gz" \
+        -mtime "+${RETAIN_DAYS}" -delete
+
+      echo "portainer-backup: wrote ${OUTFILE}"
+
+- name: Write portainer-backup systemd service
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/portainer-backup.service
+    owner: root
+    group: root
+    mode: "0644"  # nosonar: ansible:S2612 — standard systemd unit file permissions; world-read is required
+    content: |
+      [Unit]
+      Description=Back up Portainer state to NAS
+      After=network-online.target docker.service
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      EnvironmentFile={{ portainer_backup_env_dir }}/env
+      ExecStart={{ portainer_backup_script_dir }}/backup.sh
+      StandardOutput=append:/var/log/portainer-backup.log
+      StandardError=append:/var/log/portainer-backup.log
+
+      [Install]
+      WantedBy=multi-user.target
+  notify: Reload systemd
+
+- name: Write portainer-backup systemd timer
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/portainer-backup.timer
+    owner: root
+    group: root
+    mode: "0644"  # nosonar: ansible:S2612 — standard systemd unit file permissions; world-read is required
+    content: |
+      [Unit]
+      Description=Run Portainer backup daily
+      Requires=portainer-backup.service
+
+      [Timer]
+      OnCalendar=daily
+      RandomizedDelaySec=1800
+      Persistent=true
+
+      [Install]
+      WantedBy=timers.target
+  notify: Reload systemd
+
+- name: Flush handlers before enabling timer
+  ansible.builtin.meta: flush_handlers
+
+- name: Enable and start portainer-backup timer
+  ansible.builtin.systemd:
+    name: portainer-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: false
+  when: not ansible_check_mode

--- a/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
@@ -25,13 +25,6 @@
       register: pct_stop
       failed_when: pct_stop.rc != 0 and "not running" not in pct_stop.stderr
 
-    - name: Wait for container to stop
-      ansible.builtin.wait_for:
-        host: "{{ ansible_host }}"
-        port: 22
-        state: stopped
-        timeout: 30
-
     - name: Configure NAS backup bind mount via pct set
       ansible.builtin.command:
         cmd: pct set {{ vmid }} -mp1 /mnt/nas-backup/portainer-backup,mp=/var/backups/portainer

--- a/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_backup/tasks/main.yml
@@ -1,4 +1,60 @@
 ---
+- name: Check if NAS backup bind mount is configured on pve host
+  ansible.builtin.command:
+    cmd: grep -q "mp1:.*portainer-backup" /etc/pve/lxc/{{ vmid }}.conf
+  delegate_to: "{{ pve_host }}"
+  vars:
+    ansible_user: "{{ pve_ssh_user | default('root') }}"
+    ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+  register: mp1_check
+  failed_when: false
+  changed_when: false
+
+- name: Apply NAS backup bind mount to LXC (requires brief stop/start)
+  when: mp1_check.rc != 0
+  block:
+    - name: Stop portainer LXC for bind mount configuration
+      ansible.builtin.command:
+        cmd: pct stop {{ vmid }}
+      delegate_to: "{{ pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      register: pct_stop
+      failed_when: pct_stop.rc != 0 and "not running" not in pct_stop.stderr
+
+    - name: Wait for container to stop
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        port: 22
+        state: stopped
+        timeout: 30
+
+    - name: Configure NAS backup bind mount via pct set
+      ansible.builtin.command:
+        cmd: pct set {{ vmid }} -mp1 /mnt/nas-backup/portainer-backup,mp=/var/backups/portainer
+      delegate_to: "{{ pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+
+    - name: Start portainer LXC
+      ansible.builtin.command:
+        cmd: pct start {{ vmid }}
+      delegate_to: "{{ pve_host }}"
+      vars:
+        ansible_user: "{{ pve_ssh_user | default('root') }}"
+        ansible_ssh_private_key_file: "{{ hostvars[inventory_hostname]['ansible_ssh_private_key_file'] }}"
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+
+    - name: Wait for container to come back online
+      ansible.builtin.wait_for_connection:
+        delay: 5
+        timeout: 120
+
 - name: Create portainer-backup script directory
   ansible.builtin.file:
     path: "{{ portainer_backup_script_dir }}"

--- a/terraform/lxc/ansible/roles/portainer_stack/defaults/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_stack/defaults/main.yml
@@ -1,4 +1,4 @@
-# terraform/ansible/shared-roles/portainer_api/defaults/main.yml
+# portainer_stack role defaults
 
 ---
 portainer_api_server_ip: >-
@@ -10,7 +10,6 @@ portainer_api_server_ip: >-
 portainer_api_server_port: "9000"
 
 portainer_api_admin_user: "admin"
-# TF_VAR_portainer_admin_password is the canonical name in SOPS/with-secrets
 portainer_api_admin_password: >-
   {{
     lookup('env', 'TF_VAR_portainer_admin_password')
@@ -18,6 +17,7 @@ portainer_api_admin_password: >-
     | mandatory('TF_VAR_portainer_admin_password environment variable is not set')
   }}
 
-portainer_api_endpoint_name: "{{ inventory_hostname }}"
-portainer_api_agent_ip: "{{ ansible_host }}"
-portainer_api_agent_port: "9001"
+# portainer_endpoint_id must be set by portainer_api role before this role runs.
+# portainer_stacks is a list of {name, compose_file} dicts from stack.yaml.
+# compose_file paths are relative to stack_dir (injected by provision.sh).
+portainer_stacks: []

--- a/terraform/lxc/ansible/roles/portainer_stack/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_stack/tasks/main.yml
@@ -1,0 +1,68 @@
+# portainer_stack — idempotent stack deployment via Portainer API.
+# Deploys each stack in portainer_stacks to the endpoint identified by
+# portainer_endpoint_id (set by the portainer_api role).
+# Skips stacks that already exist; does not update existing stacks.
+
+---
+- name: Deploy stacks to Portainer endpoint
+  when: portainer_stacks | length > 0
+  block:
+    - name: Authenticate to Portainer for stack operations
+      ansible.builtin.uri:
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/auth" # nosonar
+        method: POST
+        body_format: json
+        body:
+          Username: "{{ portainer_api_admin_user }}"
+          Password: "{{ portainer_api_admin_password }}"
+        status_code: 200
+      register: portainer_stack_auth
+      delegate_to: localhost
+      no_log: true
+
+    - name: Set stack auth token
+      ansible.builtin.set_fact:
+        portainer_stack_jwt: "{{ portainer_stack_auth.json.jwt }}"
+      delegate_to: localhost
+      no_log: true
+
+    - name: Get existing stacks
+      ansible.builtin.uri:
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/stacks" # nosonar
+        method: GET
+        headers:
+          Authorization: "Bearer {{ portainer_stack_jwt }}"
+        status_code: 200
+      register: portainer_stack_existing
+      delegate_to: localhost
+
+    - name: Deploy each stack not already present on this endpoint
+      ansible.builtin.uri:
+        url: >-
+          http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port
+          }}/api/stacks/create/standalone/string?endpointId={{ portainer_endpoint_id }} # nosonar
+        method: POST
+        headers:
+          Authorization: "Bearer {{ portainer_stack_jwt }}"
+          Content-Type: application/json
+        body_format: json
+        body:
+          Name: "{{ item.name }}"
+          StackFileContent: "{{ lookup('file', stack_dir + '/' + item.compose_file) }}"
+          Env: "{{ item.env | default([]) }}"
+        status_code: 200
+      loop: "{{ portainer_stacks }}"
+      when: >-
+        portainer_stack_existing.json
+        | selectattr('Name', 'equalto', item.name)
+        | selectattr('EndpointId', 'equalto', portainer_endpoint_id | int)
+        | list | length == 0
+      delegate_to: localhost
+      register: portainer_stack_deploy_result
+
+    - name: Report deployed stacks
+      ansible.builtin.debug:
+        msg: "Deployed stack '{{ item.item.name }}' (ID: {{ item.json.Id }})"
+      loop: "{{ portainer_stack_deploy_result.results }}"
+      when: not item.skipped | default(false)
+      delegate_to: localhost

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -629,6 +629,8 @@ module "lxc" {
   extra_mount_storage        = local.resolved_extra_mount_storage
   extra_mount_backup_enabled = local.resolved_extra_mount_backup_enabled
 
+  host_bind_mounts = try(local.stack.host_bind_mounts, [])
+
   depends_on = [null_resource.configure_network_sdn_attachment]
 }
 

--- a/terraform/lxc/modules/lxc-docker-host/main.tf
+++ b/terraform/lxc/modules/lxc-docker-host/main.tf
@@ -50,6 +50,14 @@ resource "proxmox_virtual_environment_container" "docker_host" {
     }
   }
 
+  dynamic "mount_point" {
+    for_each = var.host_bind_mounts
+    content {
+      volume = mount_point.value.host_path
+      path   = mount_point.value.lxc_path
+    }
+  }
+
   operating_system {
     template_file_id = var.ostemplate
     type             = var.ostype

--- a/terraform/lxc/modules/lxc-docker-host/main.tf
+++ b/terraform/lxc/modules/lxc-docker-host/main.tf
@@ -55,6 +55,7 @@ resource "proxmox_virtual_environment_container" "docker_host" {
     content {
       volume = mount_point.value.host_path
       path   = mount_point.value.lxc_path
+      backup = false
     }
   }
 

--- a/terraform/lxc/modules/lxc-docker-host/variables.tf
+++ b/terraform/lxc/modules/lxc-docker-host/variables.tf
@@ -164,3 +164,9 @@ variable "extra_mount_backup_enabled" {
   type        = bool
   default     = true
 }
+
+variable "host_bind_mounts" {
+  description = "Host filesystem paths to bind-mount into the container (no size — host path must exist on the Proxmox node)"
+  type        = list(object({ host_path = string, lxc_path = string }))
+  default     = []
+}

--- a/terraform/lxc/stacks/portainer-stack/stack.yaml
+++ b/terraform/lxc/stacks/portainer-stack/stack.yaml
@@ -49,10 +49,3 @@ docker_socket_proxy_bind_addr: "${lab_ip_portainer}"
 docker_socket_proxy_listen_port: 2375
 docker_socket_proxy_targets:
   - "${lab_ip_portainer}"
-
-# NAS backup bind mount — exposes pve's NFS-mounted backup path inside the LXC.
-# The NAS directory must exist at /volume1/ProxmoxBackup/portainer-backup/ before
-# provisioning. The portainer_backup role writes the systemd timer that uses this path.
-host_bind_mounts:
-  - host_path: /mnt/nas-backup/portainer-backup
-    lxc_path: /var/backups/portainer

--- a/terraform/lxc/stacks/portainer-stack/stack.yaml
+++ b/terraform/lxc/stacks/portainer-stack/stack.yaml
@@ -49,3 +49,10 @@ docker_socket_proxy_bind_addr: "${lab_ip_portainer}"
 docker_socket_proxy_listen_port: 2375
 docker_socket_proxy_targets:
   - "${lab_ip_portainer}"
+
+# NAS backup bind mount — exposes pve's NFS-mounted backup path inside the LXC.
+# The NAS directory must exist at /volume1/ProxmoxBackup/portainer-backup/ before
+# provisioning. The portainer_backup role writes the systemd timer that uses this path.
+host_bind_mounts:
+  - host_path: /mnt/nas-backup/portainer-backup
+    lxc_path: /var/backups/portainer

--- a/terraform/lxc/stacks/test-docker/docker-compose.yml
+++ b/terraform/lxc/stacks/test-docker/docker-compose.yml
@@ -1,28 +1,14 @@
 services:
-  nginx:
-    image: harbor.gibbsgreatly.xyz/dockerhub/library/nginx:alpine
-    container_name: test-docker-nginx
-    ports:
-      - "80:80"
-    restart: unless-stopped
-
-  redis:
-    image: harbor.gibbsgreatly.xyz/dockerhub/library/redis:alpine
-    container_name: test-docker-redis
-    ports:
-      - "6379:6379"
-    restart: unless-stopped
-
   whoami:
-    image: harbor.gibbsgreatly.xyz/dockerhub/traefik/whoami:latest
+    image: traefik/whoami:latest
     container_name: test-docker-whoami
     ports:
       - "8080:80"
     restart: unless-stopped
 
-  grafana:
-    image: harbor.gibbsgreatly.xyz/dockerhub/grafana/grafana:latest
-    container_name: test-docker-grafana
+  nginx:
+    image: nginx:alpine
+    container_name: test-docker-nginx
     ports:
-      - "3000:3000"
+      - "80:80"
     restart: unless-stopped

--- a/terraform/lxc/stacks/test-docker/stack.yaml
+++ b/terraform/lxc/stacks/test-docker/stack.yaml
@@ -1,6 +1,8 @@
-# test-docker — Nginx test stack deployed via Portainer API
+# test-docker — Docker host for migration test harness
+# Portainer agent only — endpoint registration done via legacy Portainer API
 hostname: test-docker
 ip_address: "192.168.1.52/24"
+gateway: "192.168.1.1"
 dns_server: "192.168.1.1"
 vmid: 131
 cores: 2
@@ -9,7 +11,5 @@ rootfs_size: 8
 storage_profile: platform-default
 template_name: "debian-13.1-2-docker-template.tar.gz"
 
-# Deployment
-ansible_playbook: "deploy-stack"
+ansible_playbook: "deploy-portainer-agent"
 portainer_agent: true
-app_stack_name: "test-docker"

--- a/terraform/lxc/stacks/test-docker/stack.yaml
+++ b/terraform/lxc/stacks/test-docker/stack.yaml
@@ -1,5 +1,4 @@
 # test-docker — Docker host for migration test harness
-# Portainer agent only — endpoint registration done via legacy Portainer API
 hostname: test-docker
 ip_address: "192.168.1.52/24"
 gateway: "192.168.1.1"
@@ -13,3 +12,7 @@ template_name: "debian-13.1-2-docker-template.tar.gz"
 
 ansible_playbook: "deploy-portainer-agent"
 portainer_agent: true
+
+portainer_stacks:
+  - name: test-docker
+    compose_file: docker-compose.yml


### PR DESCRIPTION
## Summary

- Automated daily NAS backup via `portainer-backup` Ansible role + systemd timer
- `scripts/portainer-restore.sh` — full unattended destroy→restore cycle (pre_restore provision, POST /api/restore, full provision)
- `portainer_api` role refactored to always export `portainer_endpoint_id`; fixed env var name bug
- `portainer_stack` role (new) — idempotently deploys stacks via Portainer API
- `migrate-portainer-stack.yml` playbook — handles agent re-pairing race via iptables block
- `deploy-portainer-agent.yml` updated to auto-register endpoints and deploy stacks on normal provision
- `teardown-deploy-test.sh` — pre-destroy backup step added for portainer-stack
- Documentation updated to reflect validated IaC state

## Validation

Full teardown + restore cycle run twice (2026-06-19 and 2026-06-20):
- InstanceID `3fbb1b8f` confirmed restored from NAS backup
- `local-test` and `test-docker` stacks restored (Status 1)
- `test-docker` endpoint (192.168.1.52:9001) reconnected automatically (Status 1)

Promotion gate satisfied — backup timer and restore path survive a full destroy + apply cycle.

## Test plan

- [x] Destroy portainer-stack LXC (`terragrunt destroy`)
- [x] Recreate from template (`terragrunt apply`)
- [x] Run `portainer-restore.sh` — InstanceID and stacks confirmed restored
- [x] Pre-destroy backup added to teardown script and validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)