### PR TITLE
feat(portainer): migrate app agents to infra Portainer with teardown-validated restore

### DIFF
--- a/docs/monitoring-stack/design.md
+++ b/docs/monitoring-stack/design.md
@@ -170,13 +170,27 @@ Inter-VLAN routing via MikroTik. No firewall changes required — the forward ch
 
 ---
 
+## How to Provision
+
+```bash
+./with-secrets scripts/provision.sh --stack monitoring-stack
+```
+
+This is a pve-test-only operation during development. For production (`pve`), use `./with-secrets-prod` with `TASK_APPROVAL` set (see [Production Credentials Reference](../reference/production-credentials.md)).
+
+On pve-test, the full stack must already be up (harbor-stack, authentik-stack, proxy-stack, dns-stack) before monitoring-stack can be provisioned — it pulls images from Harbor and reconciles an Authentik OIDC client during provisioning.
+
+---
+
 ## Variables and Secrets
 
 ```
 LAB_IP_PROXMOX_HOST=192.168.1.2    # Proxmox bare-metal host — for node_exporter scrape
 ```
 
-All other `LAB_IP_*` variables are in `.env`. No secrets required for Loki or VictoriaMetrics (both are mgmt_seg-internal, no auth).
+All other `LAB_IP_*` variables are in `.env`. Secrets (Grafana admin password, OAuth client secret, Harbor admin password, Authentik API token) are in `secrets.enc.yaml` and loaded by `./with-secrets`. See [STACK_CONTRACT.md](../../terraform/lxc/stacks/monitoring-stack/STACK_CONTRACT.md) for the full inputs list.
+
+No secrets are required for Loki or VictoriaMetrics (both are mgmt_seg-internal, no auth).
 
 ---
 
@@ -300,7 +314,7 @@ Implementation: a small Python script invoked ad-hoc (or triggered via Grafana p
 | 3 | Add `victorialogs-logs-datasource` Grafana plugin | Set `GF_INSTALL_PLUGINS` in Grafana container env |
 | 4 | Add VictoriaLogs service to monitoring compose in `deploy-monitoring-stack.yml` | Single container, named volume, port 9428 |
 | 5 | Add VictoriaLogs datasource to Grafana provisioning | Point at `http://victorialogs:9428` |
-| 6 | Update Promtail push URL across all stacks | Change `3100/loki/api/v1/push` → `9428/insert/loki/api/v1/push` in all Promtail configs |
+| 6 | Update Promtail push URL across all stacks | Two patterns — see note below |
 | 7 | Rebuild Lab Logs and Auth Logs dashboards with LogsQL | Replace Loki datasource and PromQL-style log queries |
 | 8 | Verify ingestion (`/select/logsql/query?query=*`) | Confirm streams from all stacks are arriving |
 | 9 | Remove Loki service and volumes | After dashboards confirmed working |
@@ -308,11 +322,40 @@ Implementation: a small Python script invoked ad-hoc (or triggered via Grafana p
 | 11 | Update teardown health gate | Replace Loki `:3100/ready` check with VictoriaLogs `:9428/health` |
 | 12 | Provision + smoke test on pve-test | Full deploy cycle confirming VictoriaLogs survives teardown |
 
+### Promtail URL changes (task 6 detail)
+
+Promtail configs live in two patterns across the codebase:
+
+**Pattern A — promtail role** (systemd, non-Docker stacks: step-ca, apt-cacher, ci-runner, dns-stack, harbor-stack):
+
+The role template at `terraform/lxc/ansible/roles/promtail/templates/config.yml.j2` builds the push URL as:
+```
+http://{{ promtail_loki_url }}/loki/api/v1/push
+```
+
+Two changes needed:
+1. Change the template path suffix from `/loki/api/v1/push` → `/insert/loki/api/v1/push`
+2. Change `promtail_loki_url` in each playbook from `LAB_IP_MONITORING:3100` → `LAB_IP_MONITORING:9428`
+
+**Pattern B — inline Docker Promtail config** (Docker stacks: netbox, portainer, authentik, proxy):
+
+Each playbook writes a Promtail config block inline with a hardcoded URL like:
+```
+url: http://{{ lab_ip_monitoring }}:3100/loki/api/v1/push
+```
+Change to:
+```
+url: http://{{ lab_ip_monitoring }}:9428/insert/loki/api/v1/push
+```
+
+**monitoring-stack self-Promtail** (`deploy-monitoring-stack.yml`): uses Docker-internal hostname `loki:3100/loki/api/v1/push` — change to `victorialogs:9428/insert/loki/api/v1/push`. Also update the Grafana datasource from `http://loki:3100` → `http://victorialogs:9428`.
+
 ### Pre-conditions
 
 - [ ] VictoriaLogs stable release confirmed and pinned
 - [ ] Harbor mirror of VictoriaLogs image available
-- [ ] Branch cut from `baseline/teardown-validated`
+- [ ] Portainer migration branch (`task/portainer-migration-test`) merged into `baseline/teardown-validated`
+- [ ] Branch cut from updated `baseline/teardown-validated`
 
 ### Branch
 

--- a/docs/portainer-stack/02-migration.md
+++ b/docs/portainer-stack/02-migration.md
@@ -190,11 +190,13 @@ unnecessary. The playbook works either way.
 
 Application hosts and LAN IPs:
 
-| Stack yaml  | Endpoint name   | Agent URL                | VMID |
-|---|---|---|---|
-| `torrent-stack` | `torrent-stack` | `tcp://192.168.1.5:9001` | TBD  |
-| `media-stack`   | `media-stack`   | `tcp://192.168.1.6:9001` | TBD  |
-| `gaming-stack`  | `gaming-stack`  | `tcp://192.168.1.7:9001` | TBD  |
+| Stack yaml  | Endpoint name   | Agent URL                | VMID | Stacks |
+|---|---|---|---|---|
+| `torrent-stack` | `torrent-stack` | `tcp://192.168.1.5:9001` | 100 | torrent-stack (gluetun + qbittorrent + arr suite) |
+| `media-stack`   | `media-stack`   | `tcp://192.168.1.6:9001` | 102 | jellyfin |
+| `gaming-stack`  | `gaming-stack`  | `tcp://192.168.1.7:9001` | 103 | foreverworld, testworld, dayz, newworld |
+| `analysis-stack` | `analysis-stack` | `tcp://192.168.1.16:9001` | 110 | (no stacks — agent only) |
+| `security-stack` | `security-stack` | `tcp://192.168.1.11:9001` | 109 | (no stacks — agent only) |
 
 These LAN bridge IPs are temporary — endpoint URLs will be updated to VLAN
 addresses by the `portainer_api` role as each application-migration sprint runs.
@@ -228,10 +230,119 @@ already present on the endpoint are skipped (idempotent).
 
 ### 6. Verify stacks are running
 
-For each migrated stack:
-- Check stack status in Portainer (running)
-- Spot-check the actual service (UI accessible, expected behaviour)
-- Confirm Traefik has picked up the stack's labels (if applicable)
+Do one host at a time. Verify each host fully before migrating the next —
+this limits any split state to a single host if something goes wrong.
+
+**Per-host verification checklist:**
+
+```bash
+# 1. Confirm endpoint is online in infra Portainer
+JWT=$(curl -sf http://192.168.20.20:9000/api/auth \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"Calm4-Scrap-Seventy"}' | jq -r .jwt)
+
+curl -sf http://192.168.20.20:9000/api/endpoints \
+  -H "Authorization: Bearer $JWT" \
+  | jq '[.[] | {Name, Status, URL}]'
+# Status 1 = online
+
+# 2. Confirm stack is running on the endpoint
+curl -sf http://192.168.20.20:9000/api/stacks \
+  -H "Authorization: Bearer $JWT" \
+  | jq '[.[] | select(.Name=="<stack-name>") | {Name, Status, EndpointId}]'
+# Status 1 = running
+
+# 3. Confirm containers are up on the host itself
+ssh root@pve.gibbsgreatly.xyz "pct exec <vmid> -- docker ps --format 'table {{.Names}}\t{{.Status}}'"
+
+# 4. Check recent container logs for errors
+ssh root@pve.gibbsgreatly.xyz "pct exec <vmid> -- docker compose -f /opt/<stack>/docker-compose.yml logs --tail=50"
+```
+
+**Per-stack spot-checks:**
+
+| Stack | Check |
+|---|---|
+| torrent-stack | qBittorrent WebUI at `http://192.168.1.5:8080` — confirm gluetun VPN is up (check gluetun logs for `healthy`) |
+| media-stack (jellyfin) | Jellyfin UI at `http://192.168.1.6:8096` — confirm library is intact |
+| gaming-stack | Check each game server port is listening: `nc -zv 192.168.1.7 25566` (Minecraft), `25567` (testworld), `2302` (DayZ UDP) |
+| analysis-stack | Confirm relevant containers are running via `docker ps` |
+| security-stack | Confirm relevant containers are running via `docker ps` |
+
+**Log check via Loki (if Promtail is running on the host):**
+
+```bash
+# Query recent logs for a host — look for errors or restarts
+curl -G "http://192.168.20.12:3100/loki/api/v1/query_range" \
+  --data-urlencode 'query={host="<hostname>"} |= "error"' \
+  --data-urlencode "start=$(date -d '5 minutes ago' +%s)000000000" \
+  --data-urlencode "end=$(date +%s)000000000" \
+  | jq '.data.result[].values[][1]'
+```
+
+**Confirm legacy Portainer no longer manages the endpoint:**
+
+After successful migration, the endpoint should show as offline or absent in
+legacy Portainer (`http://192.168.1.4:9000`). Verify with the API token:
+
+```bash
+./with-secrets bash -c '
+curl -sf -H "X-API-Key: $PORTAINER_TOKEN" http://192.168.1.4:9000/api/endpoints \
+  | jq "[.[] | select(.Name==\"<stack-name>\") | {Name, Status}]"'
+# Status 2 = offline (agent no longer paired with legacy)
+```
+
+---
+
+## Back-out Procedure
+
+Application services are never stopped during migration — only the portainer-agent
+container is reset. Back-out is therefore safe to run at any point without
+disrupting running services.
+
+### Per-host back-out
+
+If a migration fails or a stack cannot be verified, back out the affected host:
+
+```bash
+# On the application host (via pct exec or SSH)
+ssh root@pve.gibbsgreatly.xyz "pct exec <vmid> -- bash -c '
+  # Remove iptables block if the playbook left it in place
+  iptables -D INPUT -s 192.168.1.4 -p tcp --dport 9001 -j DROP 2>/dev/null || true
+
+  # Reset agent — legacy Portainer reconnects within ~3 seconds
+  cd /opt/portainer-agent && docker compose down && docker compose up -d
+'"
+```
+
+Legacy Portainer polls continuously. Once the agent container is fresh,
+legacy Portainer reclaims it automatically.
+
+### After back-out
+
+- Confirm the endpoint shows Status 1 in legacy Portainer
+- Confirm the endpoint shows Status 2 (offline) in infra Portainer, then
+  delete the stale endpoint from infra Portainer via the UI or:
+
+```bash
+curl -sf -X DELETE http://192.168.20.20:9000/api/endpoints/<endpoint-id> \
+  -H "Authorization: Bearer $JWT"
+```
+
+- Diagnose the failure before retrying (missing env vars, compose issue,
+  network reachability) — do not retry blind
+
+### Failure modes and responses
+
+| Failure | Response |
+|---|---|
+| Agent won't start after `docker compose up` | Check compose file and image availability on the host; back-out not needed since legacy will reconnect once agent is up |
+| Infra Portainer can't reach agent (endpoint stays Status 2) | Check `mgmt_seg → 192.168.1.x:9001` routing; verify agent is listening on port 9001 |
+| Stack fails to deploy (compose error) | Containers are still running; fix compose in infra Portainer and redeploy; no back-out needed |
+| Stack deploys but service is unhealthy | Check container logs; app data is on host volumes and untouched; fix config and restart stack |
+| Multiple hosts in bad state | Run per-host back-out on each; legacy Portainer resumes control |
+
+---
 
 ### 7. Trigger backup
 
@@ -271,8 +382,11 @@ infrastructure still deploys cleanly with the migrated Portainer state.
 
 ## Pre-conditions
 
-- [x] Sprint 01 complete: backup and restore validated (2026-06-19 — full destroy+apply+restore cycle confirmed)
-- [ ] Existing Portainer admin password retrieved (not in SOPS — get from management-stack)
+- [x] Sprint 01 complete: backup and restore validated (2026-06-19 — full destroy+apply+restore cycle confirmed, re-validated 2026-06-20 with stacks and endpoints in backup)
+- [x] Legacy Portainer API access confirmed: `PORTAINER_TOKEN` in SOPS is valid (verified 2026-06-20)
 - [x] MikroTik rule: `mgmt_seg → 192.168.1.0/24:9001` in place (confirmed 2026-06-19 — no changes needed)
-- [ ] Inventory of stacks and any Portainer-only secrets (step 2) complete before proceeding
+- [x] Stack inventory complete (2026-06-20): compose files retrieved, no Portainer-stored secrets on migration targets
 - [x] Version compatibility confirmed: legacy 2.33.6 > infra 2.27.3, Option B (re-create stacks) only
+- [ ] DayZ Steam credentials (`USERNAME`, `PASSWRD`) moved to SOPS before committing `gaming-stack/docker-compose.yml`
+- [ ] Compose files committed to repo for each migration target
+- [ ] VMIDs confirmed: torrent-stack=100, media-stack=102, gaming-stack=103, analysis-stack=110, security-stack=109

--- a/docs/troubleshooting/enp9s0-vmbr1-recovery.md
+++ b/docs/troubleshooting/enp9s0-vmbr1-recovery.md
@@ -1,0 +1,83 @@
+# enp9s0 / vmbr1 Recovery — Physical NIC Passthrough Zombie State
+
+## Symptom
+
+`vmbr1` shows `NO-CARRIER` and `enp9s0` is missing from `ip link show` on the pve host,
+even though `lspci` confirms the Realtek RTL8168h (`0000:09:00.0`) is present and
+`/sys/bus/pci/drivers/r8169/` lists `0000:09:00.0` as bound.
+
+`pvesh set /cluster/sdn` triggers `ifreload -a`, which logs `srvreload:networking FAIL`
+because `vmbr1` references `enp9s0` as its bridge port but the interface doesn't exist.
+
+## Root Cause
+
+`security-stack` (LXC 109) uses physical NIC passthrough:
+
+```
+lxc.net.1.type: phys
+lxc.net.1.link: enp9s0
+```
+
+When the LXC is running, `enp9s0` lives inside the container namespace as `monitor0`.
+When the LXC stops, the kernel should return the interface to the host — but it leaves
+the r8169 driver bound to `0000:09:00.0` without recreating the netdev. The interface
+is invisible on the host despite the driver binding being present.
+
+The LXC rename sequence visible in the kernel journal when LXC 109 starts:
+
+```
+vmbr1: port 1(enp9s0) entered disabled state
+r8169 0000:09:00.0 enp9s0: left promiscuous mode
+r8169 0000:09:00.0 phys5tIK2t: renamed from enp9s0   ← intermediate name during namespace move
+r8169 0000:09:00.0 monitor0: renamed from phys5tIK2t  ← final name inside the LXC
+```
+
+### Why the `srvreload:networking FAIL` is non-fatal
+
+`pvesh set /cluster/sdn` calls `reloadnetworkall`, which returns `OK` regardless of
+whether `ifreload -a` fails internally. The teardown cycle continues normally. These
+`FAIL` entries in the Proxmox task log are expected whenever security-stack is running
+and are harmless.
+
+## Fix
+
+Unbind and rebind the r8169 driver to force the kernel to recreate the netdev:
+
+```bash
+echo '0000:09:00.0' > /sys/bus/pci/drivers/r8169/unbind
+sleep 1
+echo '0000:09:00.0' > /sys/bus/pci/drivers/r8169/bind
+sleep 1
+ifreload -a
+```
+
+`ip link show enp9s0` should now show the interface as `master vmbr1`.
+
+## Correct Steady State
+
+- **LXC 109 (security-stack)** is legacy. It should be **stopped** (`onboot: 0`).
+  It was temporarily started during portainer migration work.
+- **VM 106 (Security Onion)** is the intended monitoring VM. It uses
+  `usb0: host=0bda:8153` (Realtek RTL8153 USB NIC, `enxa0cec811c0e2` on the host)
+  for its capture interface via USB passthrough.
+- **`enp9s0`** (PCIe Realtek RTL8168h, `0000:09:00.0`) is the `vmbr1` bridge port.
+  `vmbr1` carries mirrored switch traffic to Security Onion.
+- `vmbr1` will show `NO-CARRIER` if the switch mirror cable is unplugged or the mirror
+  port is inactive — that is expected and harmless.
+
+## USB NIC (r8152) Not Loading on Boot
+
+The `r8152` module is not loaded automatically. If VM 106 is stopped and the USB NIC
+(`0bda:8153`) is visible via `lsusb` but no interface appears on the host:
+
+```bash
+modprobe r8152
+```
+
+To make this permanent, add `r8152` to `/etc/modules` on pve.
+
+## Related
+
+- `lxc.net.1.type: phys` — LXC physical NIC passthrough docs: `man lxc.container.conf`
+- `/etc/network/interfaces` on pve: `vmbr1` bridge definition
+- `docs/teardown-test/lessons-learned.md` — non-fatal networking errors during SDN teardown

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 PORTAINER_IP="${LAB_IP_PORTAINER:-192.168.20.20}"
 PORTAINER_PORT="9000"
 PORTAINER_VMID="20020"
-PVE_HOST="pve.gibbsgreatly.xyz"
+PVE_HOST="${PORTAINER_RESTORE_PVE_HOST:-pve.gibbsgreatly.xyz}"
 NAS_BACKUP_DIR="/mnt/nas-backup/portainer-backup"
 CONTAINER_NAME="portainer-portainer-1"
 WAIT_TIMEOUT=180

--- a/scripts/teardown-deploy-test.sh
+++ b/scripts/teardown-deploy-test.sh
@@ -1538,8 +1538,14 @@ stack_apply() {
   run_logged "deploy-${stack}" \
     bash -lc "cd '${REPO_ROOT}/terraform/lxc/stacks/${stack}' && '${WITH_SECRETS}' env TF_WORKSPACE='${TERRAGRUNT_WORKSPACE}' terragrunt apply -auto-approve"
   guard_target
-  run_logged "provision-${stack}" \
-    "${WITH_SECRETS}" "${REPO_ROOT}/scripts/provision.sh" --stack "${stack}"
+  if [[ "${stack}" == "portainer-stack" ]]; then
+    run_logged "restore-${stack}" \
+      env PORTAINER_RESTORE_PVE_HOST="${TARGET_PVE_HOST}" \
+      "${WITH_SECRETS}" "${REPO_ROOT}/scripts/portainer-restore.sh"
+  else
+    run_logged "provision-${stack}" \
+      "${WITH_SECRETS}" "${REPO_ROOT}/scripts/provision.sh" --stack "${stack}"
+  fi
   validate_stack_smoke "${spec}"
 }
 

--- a/terraform/lxc/ansible/roles/portainer_api/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_api/tasks/main.yml
@@ -77,23 +77,24 @@
       when: portainer_api_existing_endpoint is none
       delegate_to: localhost
 
+    - name: Set portainer_endpoint_id from existing endpoint
+      ansible.builtin.set_fact:
+        portainer_endpoint_id: "{{ portainer_api_existing_endpoint.Id }}"
+      when: portainer_api_existing_endpoint is not none
+      delegate_to: localhost
+
     - name: Update existing endpoint URL
       ansible.builtin.uri:
         url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/endpoints/{{ portainer_api_existing_endpoint.Id }}" # nosonar
         method: PUT
         headers:
           Authorization: "Bearer {{ portainer_api_token }}"
-        body_format: form-urlencoded
+          Content-Type: application/json
+        body_format: json
         body:
           Name: "{{ portainer_api_endpoint_name }}"
           URL: "tcp://{{ portainer_api_agent_ip }}:{{ portainer_api_agent_port }}"
         status_code: 200
-      when: portainer_api_existing_endpoint is not none
-      delegate_to: localhost
-
-    - name: Set portainer_endpoint_id from existing endpoint
-      ansible.builtin.set_fact:
-        portainer_endpoint_id: "{{ portainer_api_existing_endpoint.Id }}"
       when: portainer_api_existing_endpoint is not none
       delegate_to: localhost
 

--- a/terraform/lxc/ansible/roles/portainer_stack/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/portainer_stack/tasks/main.yml
@@ -26,6 +26,11 @@
       delegate_to: localhost
       no_log: true
 
+    - name: Resolve portainer_endpoint_id from delegation context
+      ansible.builtin.set_fact:
+        portainer_endpoint_id: "{{ hostvars['localhost']['portainer_endpoint_id'] }}"
+      when: portainer_endpoint_id is not defined
+
     - name: Get existing stacks
       ansible.builtin.uri:
         url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/stacks" # nosonar
@@ -38,9 +43,7 @@
 
     - name: Deploy each stack not already present on this endpoint
       ansible.builtin.uri:
-        url: >-
-          http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port
-          }}/api/stacks/create/standalone/string?endpointId={{ portainer_endpoint_id }} # nosonar
+        url: "http://{{ portainer_api_server_ip }}:{{ portainer_api_server_port }}/api/stacks/create/standalone/string?endpointId={{ portainer_endpoint_id }}" # nosonar
         method: POST
         headers:
           Authorization: "Bearer {{ portainer_stack_jwt }}"

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -40,6 +40,8 @@ locals {
     lab_subnet_infra_cidr = var.lab_subnet_infra_cidr
     lab_subnet_build_cidr = var.lab_subnet_build_cidr
     proxmox_host          = var.proxmox_host
+    dayz_steam_username   = var.dayz_steam_username
+    dayz_steam_password   = var.dayz_steam_password
   }
   stack = yamldecode(templatefile(var.stack_yaml_path, local.stack_template_vars))
 

--- a/terraform/lxc/stacks/analysis-stack/stack.yaml
+++ b/terraform/lxc/stacks/analysis-stack/stack.yaml
@@ -1,0 +1,5 @@
+hostname: analysis-stack
+ip_address: "192.168.1.16"
+vmid: 110
+portainer_agent: true
+# No portainer_stacks — agent registration only

--- a/terraform/lxc/stacks/elastic-stack/stack.yaml
+++ b/terraform/lxc/stacks/elastic-stack/stack.yaml
@@ -1,0 +1,5 @@
+hostname: elastic-stack
+ip_address: "192.168.1.24"
+vmid: 112
+portainer_agent: true
+# No portainer_stacks — agent registration only, no compose stacks to deploy

--- a/terraform/lxc/stacks/gaming-stack/dayz-docker-compose.yml
+++ b/terraform/lxc/stacks/gaming-stack/dayz-docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  dayz:
+    image: ich777/steamcmd:dayz
+    container_name: dayz
+    restart: unless-stopped
+    environment:
+      - GAME_ID=223350
+      - GAME_PORT=2302
+      - GAME_PARAMS=-config=/serverdata/serverfiles/serverDZ.cfg -port=2302 -profiles=/serverdata/serverfiles/profiles -dologs -adminlog -netlog -freezecheck -mod=@1559212036;@1564026768;@1582756848;@1623711988;@2017605880;@3382463948;@1870524790
+      - USERNAME=${DAYZ_STEAM_USERNAME}
+      - PASSWRD=${DAYZ_STEAM_PASSWORD}
+      - UID=1000
+      - GID=1000
+      - VALIDATE=
+    volumes:
+      - /azerothcore/dayz/steam:/serverdata/Steam
+      - /azerothcore/dayz/steamcmd:/serverdata/steamcmd
+      - /azerothcore/dayz/server:/serverdata/serverfiles
+      - /azerothcore/dayz/mods:/serverdata/workshop
+    ports:
+      - "2302:2302/udp"
+      - "27016:27016/udp"

--- a/terraform/lxc/stacks/gaming-stack/foreverworld-docker-compose.yml
+++ b/terraform/lxc/stacks/gaming-stack/foreverworld-docker-compose.yml
@@ -1,0 +1,81 @@
+services:
+  mc:
+    image: itzg/minecraft-server:stable-java21
+    container_name: foreverworld-minecraft
+    tmpfs:
+      - /tmp:rw,exec,size=2g
+    tty: true
+    stdin_open: true
+    ports:
+      - "25566:25566"
+      - "25575:25575"
+    environment:
+      SERVER_PORT: "25566"
+      EULA: "TRUE"
+      TYPE: "FORGE"
+      VERSION: "1.20.1"
+      FORGE_VERSION: "47.4.0"
+      OVERRIDE_SERVER_PROPERTIES: "true"
+      MAX_PLAYERS: "2"
+      DIFFICULTY: "3"
+      ENABLE_COMMAND_BLOCK: "true"
+      GENERATE_STRUCTURES: "true"
+      SNOOPER_ENABLED: "false"
+      SPAWN_ANIMALS: "true"
+      SPAWN_MONSTERS: "true"
+      SPAWN_NPCS: "true"
+      SPAWN_PROTECTION: 0
+      MODE: "0"
+      PVP: "false"
+      WHITELIST: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a,3e9e78a4-6b43-4dd2-88c8-a854850da8f7"
+      OPS: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a"
+      VIEW_DISTANCE: "32"
+      SIMULATION_DISTANCE: "12"
+      NETWORK_COMPRESSION_THRESHOLD: "64"
+      PLAYER_IDLE_TIMEOUT: "0"
+      ENTITY_ACTIVATION_RANGE_ANIMALS: "16"
+      ENTITY_ACTIVATION_RANGE_MONSTERS: "24"
+      ENTITY_ACTIVATION_RANGE_RAIDERS: "16"
+      ENTITY_ACTIVATION_RANGE_MISC: "8"
+      ENTITY_ACTIVATION_RANGE_WATER: "8"
+      MEMORY: "16G"
+      USE_AIKAR_FLAGS: "false"
+      JVM_OPTS: >
+        -Xms16G -Xmx16G
+        -XX:+UseG1GC
+        -XX:+AlwaysPreTouch
+        -XX:+ParallelRefProcEnabled
+        -XX:+UseStringDeduplication
+        -XX:+DisableExplicitGC
+        -XX:G1HeapRegionSize=16M
+        -XX:G1HeapWastePercent=5
+        -XX:G1MixedGCCountTarget=4
+        -XX:InitiatingHeapOccupancyPercent=20
+        -XX:MaxTenuringThreshold=1
+        -XX:MaxGCPauseMillis=150
+        -XX:ParallelGCThreads=8
+        -XX:ConcGCThreads=2
+        -XX:ReservedCodeCacheSize=768m
+        -XX:InitialCodeCacheSize=384m
+        -XX:+PerfDisableSharedMem
+        -Djava.io.tmpdir=/tmp
+        -Djava.awt.headless=true
+      SERVER_NAME: "foreverworld"
+      SEED: "-8233912588774771127"
+      MAX_TICK_TIME: "600000"
+      ENABLE_RCON: "true"
+      RCON_PASSWORD: "minecraft" # gitleaks:allow
+      RCON_PORT: "25575"
+      RCON_CMDS_STARTUP: |-
+        gamerule doFireTick false
+        gamerule doDaylightCycle false
+        gamerule doWeatherCycle false
+        gamerule keepInventory true
+        time set 600
+    volumes:
+      - "/minecraft/foreverworld:/data"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    restart: unless-stopped

--- a/terraform/lxc/stacks/gaming-stack/newworld-docker-compose.yml
+++ b/terraform/lxc/stacks/gaming-stack/newworld-docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  mc:
+    image: itzg/minecraft-server:stable-java21
+    container_name: newworld-minecraft
+    tmpfs:
+      - /tmp:rw,exec,size=2g
+    tty: true
+    stdin_open: true
+    ports:
+      - "25568:25566"
+      - "25578:25575"
+    environment:
+      SERVER_PORT: "25566"
+      EULA: "TRUE"
+      TYPE: "NEOFORGE"
+      VERSION: "1.21.1"
+      NEOFORGE_VERSION: "21.1.219"
+      OVERRIDE_SERVER_PROPERTIES: "true"
+      MAX_PLAYERS: "2"
+      DIFFICULTY: "3"
+      ENABLE_COMMAND_BLOCK: "true"
+      GENERATE_STRUCTURES: "true"
+      SNOOPER_ENABLED: "false"
+      SPAWN_ANIMALS: "true"
+      SPAWN_MONSTERS: "true"
+      SPAWN_NPCS: "true"
+      SPAWN_PROTECTION: 0
+      MODE: "0"
+      PVP: "false"
+      WHITELIST: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a,3e9e78a4-6b43-4dd2-88c8-a854850da8f7"
+      OPS: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a"
+      NETWORK_COMPRESSION_THRESHOLD: "64"
+      PLAYER_IDLE_TIMEOUT: "0"
+      ENTITY_ACTIVATION_RANGE_ANIMALS: "16"
+      ENTITY_ACTIVATION_RANGE_MONSTERS: "24"
+      ENTITY_ACTIVATION_RANGE_RAIDERS: "16"
+      ENTITY_ACTIVATION_RANGE_MISC: "8"
+      ENTITY_ACTIVATION_RANGE_WATER: "8"
+      MEMORY: "16G"
+      USE_AIKAR_FLAGS: "false"
+      JVM_OPTS: >
+        -Xms16G -Xmx16G
+        -XX:+UseG1GC
+        -XX:+AlwaysPreTouch
+        -XX:+ParallelRefProcEnabled
+        -XX:+UseStringDeduplication
+        -XX:+DisableExplicitGC
+        -XX:G1HeapRegionSize=16M
+        -XX:G1HeapWastePercent=5
+        -XX:G1MixedGCCountTarget=4
+        -XX:InitiatingHeapOccupancyPercent=20
+        -XX:MaxTenuringThreshold=1
+        -XX:MaxGCPauseMillis=150
+        -XX:ParallelGCThreads=8
+        -XX:ConcGCThreads=2
+        -XX:ReservedCodeCacheSize=768m
+        -XX:InitialCodeCacheSize=384m
+        -XX:+PerfDisableSharedMem
+        -Djava.io.tmpdir=/tmp
+        -Djava.awt.headless=true
+      SERVER_NAME: "newworld"
+      SEED: "-8233912588774771127"
+      MAX_TICK_TIME: "600000"
+      ENABLE_RCON: "true"
+      RCON_PASSWORD: "minecraft" # gitleaks:allow
+      RCON_PORT: "25575"
+      RCON_CMDS_STARTUP: |-
+        gamerule doFireTick false
+        gamerule doDaylightCycle false
+        gamerule doWeatherCycle false
+        gamerule keepInventory true
+        time set 600
+    volumes:
+      - "/minecraft/newworld:/data"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    restart: unless-stopped

--- a/terraform/lxc/stacks/gaming-stack/stack.yaml
+++ b/terraform/lxc/stacks/gaming-stack/stack.yaml
@@ -1,0 +1,19 @@
+hostname: gaming-stack
+ip_address: "192.168.1.7"
+vmid: 103
+portainer_agent: true
+
+portainer_stacks:
+  - name: foreverworld
+    compose_file: foreverworld-docker-compose.yml
+  - name: testworld
+    compose_file: testworld-docker-compose.yml
+  - name: dayz
+    compose_file: dayz-docker-compose.yml
+    env:
+      - name: DAYZ_STEAM_USERNAME
+        value: "${dayz_steam_username}"
+      - name: DAYZ_STEAM_PASSWORD
+        value: "${dayz_steam_password}"
+  - name: newworld
+    compose_file: newworld-docker-compose.yml

--- a/terraform/lxc/stacks/gaming-stack/testworld-docker-compose.yml
+++ b/terraform/lxc/stacks/gaming-stack/testworld-docker-compose.yml
@@ -1,0 +1,60 @@
+services:
+  testworld:
+    image: itzg/minecraft-server:stable-java21
+    container_name: testworld-minecraft
+    tty: true
+    stdin_open: true
+    tmpfs:
+      - /tmp:size=2g
+    ports:
+      - "25567:25566"
+      - "25576:25575"
+    environment:
+      EULA: "TRUE"
+      TYPE: "FORGE"
+      VERSION: "1.20.1"
+      FORGE_VERSION: "47.4.0"
+      SERVER_NAME: "testworld"
+      SERVER_PORT: "25566"
+      MEMORY: "16G"
+      USE_AIKAR_FLAGS: "true"
+      JVM_OPTS: >
+        -Xms4G -Xmx16G
+        -XX:+UseG1GC
+        -XX:+ParallelRefProcEnabled
+        -XX:+UseStringDeduplication
+        -Djava.io.tmpdir=/tmp
+        -Xshare:on
+        -Xlog:cds=info
+      ENABLE_RCON: "true"
+      RCON_PASSWORD: "minecraft" # gitleaks:allow
+      RCON_PORT: "25575"
+      LEVEL_TYPE: "flat"
+      DIFFICULTY: "0"
+      MODE: "creative"
+      ALLOW_FLIGHT: "true"
+      SPAWN_MONSTERS: "false"
+      SPAWN_NPCS: "false"
+      PVP: "false"
+      VIEW_DISTANCE: "6"
+      SIMULATION_DISTANCE: "6"
+      MAX_PLAYERS: "2"
+      SNOOPER_ENABLED: "false"
+      GENERATE_STRUCTURES: "false"
+      OVERRIDE_SERVER_PROPERTIES: "true"
+      SYNC_CHUNK_WRITES: "false"
+      MAX_TICK_TIME: "600000"
+      RCON_CMDS_STARTUP: |
+        gamerule doMobSpawning false
+        gamerule doWeatherCycle false
+        gamerule doDaylightCycle true
+      OPS: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a"
+      WHITELIST: "8fa12314-eba1-43cf-a232-d8ceb3bc8d1a,3e9e78a4-6b43-4dd2-88c8-a854850da8f7"
+      TZ: "Pacific/Auckland"
+    volumes:
+      - "/minecraft/testworld:/data"
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    restart: unless-stopped

--- a/terraform/lxc/stacks/media-stack/jellyfin-docker-compose.yml
+++ b/terraform/lxc/stacks/media-stack/jellyfin-docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  jellyfin:
+    image: lscr.io/linuxserver/jellyfin:latest
+    container_name: jellyfin
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+      - JELLYFIN_PublishedServerUrl=https://jellyfin.gibbsgreatly.xyz
+    volumes:
+      - /config/jellyfin:/config
+      - /nas-media/video/movies:/movies
+      - /nas-media/video/tv:/tv
+      - /nas-media/music:/music
+    ports:
+      - 8096:8096
+      - 8920:8920
+      - 7359:7359/udp
+      - 1900:1900/udp
+    group_add:
+      - "44"
+      - "104"
+    restart: unless-stopped
+    privileged: false
+    security_opt:
+      - seccomp:unconfined

--- a/terraform/lxc/stacks/media-stack/stack.yaml
+++ b/terraform/lxc/stacks/media-stack/stack.yaml
@@ -1,0 +1,8 @@
+hostname: media-stack
+ip_address: "192.168.1.6"
+vmid: 102
+portainer_agent: true
+
+portainer_stacks:
+  - name: jellyfin
+    compose_file: jellyfin-docker-compose.yml

--- a/terraform/lxc/stacks/security-stack/stack.yaml
+++ b/terraform/lxc/stacks/security-stack/stack.yaml
@@ -1,0 +1,5 @@
+hostname: security-stack
+ip_address: "192.168.1.11"
+vmid: 109
+portainer_agent: true
+# No portainer_stacks — agent registration only

--- a/terraform/lxc/stacks/torrent-stack/stack.yaml
+++ b/terraform/lxc/stacks/torrent-stack/stack.yaml
@@ -1,0 +1,8 @@
+hostname: torrent-stack
+ip_address: "192.168.1.5"
+vmid: 100
+portainer_agent: true
+
+portainer_stacks:
+  - name: torrent-stack
+    compose_file: torrent-stack-docker-compose.yml

--- a/terraform/lxc/stacks/torrent-stack/torrent-stack-docker-compose.yml
+++ b/terraform/lxc/stacks/torrent-stack/torrent-stack-docker-compose.yml
@@ -1,0 +1,107 @@
+services:
+  gluetun:
+    image: qmcgaw/gluetun
+    container_name: gluetun
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - VPN_TYPE=wireguard
+      - VPN_SERVICE_PROVIDER=custom
+      - TZ=Pacific/Auckland
+      - HEALTH_TARGET_ADDRESSES=google.com:443
+      - FIREWALL_INPUT_PORTS=8888
+      - VPN_PORT_FORWARDING=on
+      - VPN_PORT_FORWARDING_PROVIDER=protonvpn
+      - DNS_ADDRESS=1.1.1.1
+      - DNS_SERVER=on
+    volumes:
+      - /config/torrents/gluetun:/gluetun
+      - /config/torrents/gluetun/wireguard:/gluetun/wireguard
+    ports:
+      - 8080:8888
+      - 6881:6881/tcp
+      - 6881:6881/udp
+    restart: unless-stopped
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent
+    container_name: qbittorrent
+    network_mode: "service:gluetun"
+    depends_on:
+      - gluetun
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+      - WEBUI_PORT=8888
+    volumes:
+      - /config/torrents/qbittorrent:/config
+      - /incoming:/downloads
+    restart: unless-stopped
+  flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: flaresolverr
+    environment:
+      - LOG_LEVEL=info
+      - TZ=Pacific/Auckland
+    ports:
+      - 8191:8191
+    restart: unless-stopped
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:latest
+    container_name: prowlarr
+    ports:
+      - 9696:9696
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+    volumes:
+      - /config/torrents/prowlarr:/config
+    restart: unless-stopped
+  radarr:
+    image: lscr.io/linuxserver/radarr:latest
+    container_name: radarr
+    ports:
+      - 7878:7878
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+    volumes:
+      - /config/torrents/radarr:/config
+      - /nas/video/movies:/movies
+      - /nas/video/movies:/media/movies
+      - /incoming:/downloads
+    restart: unless-stopped
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:latest
+    container_name: sonarr
+    ports:
+      - 8989:8989
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+    volumes:
+      - /config/torrents/sonarr:/config
+      - /nas/video/tv:/tv
+      - /nas/video/tv:/media/tv
+      - /incoming:/downloads
+    restart: unless-stopped
+  lidarr:
+    image: blampe/lidarr:latest
+    container_name: lidarr
+    ports:
+      - 8686:8686
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Pacific/Auckland
+    volumes:
+      - /config/torrents/lidarr:/config
+      - /nas/music:/music
+      - /nas/music:/media/music
+      - /incoming:/downloads
+    restart: unless-stopped

--- a/terraform/lxc/variables.tf
+++ b/terraform/lxc/variables.tf
@@ -247,3 +247,15 @@ variable "lab_subnet_build_cidr" {
   type        = string
   default     = ""
 }
+
+variable "dayz_steam_username" {
+  description = "Steam username for DayZ server authentication"
+  type        = string
+  default     = ""
+}
+
+variable "dayz_steam_password" {
+  description = "Steam password for DayZ server authentication"
+  type        = string
+  default     = ""
+}

--- a/terraform/secrets.pve.enc.yaml
+++ b/terraform/secrets.pve.enc.yaml
@@ -51,6 +51,8 @@ HARBOR_OIDC_PRIMARY_AUTH_MODE: ENC[AES256_GCM,data:beDf4Q==,iv:MHsmkPuFvAEfDy63S
 HARBOR_ROBOT_PASSWORD: ENC[AES256_GCM,data:uywB0uGHe0+dh35vGDi3Dl0zVFA1236iNi+5X9jU8Hs=,iv:05yNZUuJtcsFhByMzi6PHeydNWO7EpuHOlAn0EKwijw=,tag:ikOcTt+olFbnNwUXDBuN9A==,type:str]
 HARBOR_ROBOT_USER: ENC[AES256_GCM,data:jqP2hn2opl8cCNV4L5t9,iv:3q8eR4EoyHgttbPwA12++jjQOZhlIVcQamgnU6cfWIY=,tag:Wfc5q/QlJYSozxS2qv75kQ==,type:str]
 NPM_DB_PASSWORD: ENC[AES256_GCM,data:4vWHD+t0+NXiRFwzU85vNXrANVkTyzo+,iv:1d8f7MOKOFD5izbTIqBtZKkJqSfoR/TW69kInPAT7Wo=,tag:VFGI99WT50C2j85ZGx0S2Q==,type:str]
+TF_VAR_dayz_steam_username: ENC[AES256_GCM,data:9bH7cJlOTtqtBw==,iv:ta02tn9oydOw4ywduybaNT6Bd5pwCb2wj5bTH7xG6X0=,tag:1zML04PFbP6/nH8ZzVULEg==,type:str]
+TF_VAR_dayz_steam_password: ENC[AES256_GCM,data:7SP+Y/ZDbKBCEVJt,iv:/8Nv98x6jAMf7yGJVXaoTZ1z7Vp+7qXK1elmgoNPwMo=,tag:t9L7Xz2Sq2H/J3z3dK9U7A==,type:str]
 sops:
     age:
         - enc: |
@@ -62,7 +64,7 @@ sops:
             wjXHINScFnUEUcaqIB5C9IZj874w+r/4cBfun21JQx93PxGa/vf1ig==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fzhfgtun0jczh6z2ksswmf4mw90p7mg5nhmhpasny6ypesxucf5sctxqpe
-    lastmodified: "2026-06-18T22:00:16Z"
-    mac: ENC[AES256_GCM,data:rxTqy6i+wAwlpWhaV1l9W4XIizuAga0BgVslJF3YFRQIKgg6Uk+H5b675quVVXKLU6JC48h3mK+sNSl0TML6YmBbtuUEFYvjg1tiMLvQ4cU9OXc8ayLSvMFMyGmXfcitlbX741A9mP5oUmGhL1lhgHNCun+ZnvPB1E/hbIpsvB0=,iv:2JJmqfFm3bVHEcXSxPvelUKNoSerZp/sRW4qiB475pk=,tag:24iPmPRLDGw20oPKKjmUxg==,type:str]
+    lastmodified: "2026-06-19T21:10:25Z"
+    mac: ENC[AES256_GCM,data:e1wEJqr4S3uGSWNvPsM2EHXFuvIUvAjHEZOpoh9fBXWCe6NwMrdio07fu7NRrfgDWzGt4hE8Hmo2KVncztg1WtqK84qt6UligC9dsnopTJmls47khozMmeOSNzrPTkZG5b7qZY1ep3qcQJ98gMBXIkuKjNWIKj++Bt3Ig6kIAD4=,iv:j/+DSBi4ucVR5AaNf5pvZRA/hXWZldEEgfycBpRXKaY=,tag:gYMlasXdBPUAC55Ew7lGkw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
## Summary

- Migrates all app stack Portainer agents (torrent, media, gaming, elastic, analysis, security) from legacy management-stack Portainer (2.33.6) to infra Portainer (2.27.3) via `migrate-portainer-stack.yml`
- Wires `portainer-restore.sh` into the teardown cycle so infra Portainer is rebuilt from NAS backup on every redeploy, preserving all 7 endpoints and 6 stacks
- Adds DayZ Steam credentials to prod SOPS and stack template vars
- Adds `analysis-stack` and `security-stack` directories with migration inventory
- Fixes portainer_stack role: URL nosonar, endpoint_id scoping, PUT body format
- Documents enp9s0/vmbr1 zombie netdev recovery (lxc.net.1.type: phys passthrough side-effect)
- Documents Phase 6 (VictoriaLogs) Promtail URL detail

## Teardown gate

Full teardown + redeploy cycle completed on `pve` from this branch at 2026-06-20T03:22–04:08 UTC.
Evidence: `docs/teardown-test/artifacts/evidence/20260620-032251/`
`restore-portainer-stack` step PASSED — first validated restore-in-teardown run.
Zero failures across all 10 stacks.

## Test plan

- [ ] Verify infra Portainer at https://portainer.lab.gibbsgreatly.xyz shows 7 endpoints
- [ ] Verify torrent-stack, media-stack, gaming-stack (4 stacks), elastic-stack online
- [ ] Verify analysis-stack and security-stack endpoints present (offline — LXCs stopped)
- [ ] Confirm NAS backup captured at 137K post-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)