### PR TITLE
feat(infra): per-environment Terragrunt layout for runtime isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,16 @@ override.tf.json
 **/stacks/*/network-*-vars.yml
 terraform/lxc/.generated/
 
+# Per-environment runtime outputs (environments/<env>/<stack>/)
+terraform/lxc/environments/**/terraform.tfstate
+terraform/lxc/environments/**/terraform.tfstate.*
+terraform/lxc/environments/**/terraform.tfstate.d/
+terraform/lxc/environments/**/inventory.yml
+terraform/lxc/environments/**/network-*-vars.yml
+terraform/lxc/environments/**/.generated/
+terraform/lxc/environments/**/certs/
+terraform/lxc/environments/**/.terragrunt-cache/
+
 # Ansible
 *.retry
 .vault_pass

--- a/docs/workflow/session-handoff-2026-06-24.md
+++ b/docs/workflow/session-handoff-2026-06-24.md
@@ -191,6 +191,7 @@ immediate fix (direct API call) is the workaround for this case.
 |--------|------|-------|
 | `main` | `5366b9b` | Current production state |
 | `stable` | `7998022` | Sprint merge point; `main` is ahead by 1 commit |
+| `task/terraform-env-runtime-isolation` | `037c328` | PR #386 open; env isolation code |
 | `work/sprint-env-isolation` | Retired | Complete |
 
 `stable` is one commit behind `main` (`5366b9b` was committed directly to
@@ -201,35 +202,47 @@ pve-test-vm validation dependency.
 
 ## Next: pve-test-vm work
 
-Before starting pve-test-vm work, verify the following pre-conditions:
+**Environment isolation is now structural** (commit `037c328`, PR #386). The
+old procedural mitigations (check certs, verify inventories, check edge routes)
+are replaced by the `environments/<env>/` layout. pve-test-vm runs write only
+to `environments/pve-test-vm/`; pve paths are untouched.
 
-**1. Check `certs/homelab-root.crt` fingerprint (Rule 6)**
+See `docs/workflow/terraform-env-layout.md` for the full design and step status.
 
-Any pve-test-vm rebuild overwrites this file with pve-test-vm's root CA. If the
-fingerprint doesn't match pve's step-ca, restore it before any pve provisioning:
+### What remains before full pve-test-vm work can start
+
+**1. Merge PR #386** (`task/terraform-env-runtime-isolation` → `main`)
+
+Review and merge before starting pve-test-vm applies.
+
+**2. Fresh `terragrunt apply` from env entrypoints**
+
+Run from `terraform/lxc/environments/pve-test-vm/<stack>/` for each stack.
+Generated outputs (inventory, network vars, edge files) will land under
+`environments/pve-test-vm/` and not touch `environments/pve/`.
 
 ```bash
-# Check current cert
-openssl x509 -noout -fingerprint -in certs/homelab-root.crt
-
-# Compare against pve step-ca (expected: C1:D1:77:26:...)
-curl -sk "https://192.168.20.11/roots.pem" | openssl x509 -noout -fingerprint
-
-# Restore if needed
-curl -sk "https://192.168.20.11/roots.pem" > certs/homelab-root.crt
+PVE_ENV=pve-test-vm ./with-secrets terragrunt apply \
+  --terragrunt-working-dir terraform/lxc/environments/pve-test-vm/<stack>
 ```
 
-**2. After any pve-test-vm Terraform apply, regenerate pve inventories**
+**3. Remaining deferred items** (do not block pve-test-vm work)
 
-Verify that `stacks/*/inventory.yml` files still have base-range IPs after any
-pve-test-vm Terraform run. If contaminated, run `terragrunt apply` per stack
-in the pve workspace to regenerate.
+- Root CA scoping: `certs/homelab-root.crt` → `environments/<env>/certs/`
+  (Step 6 in design doc). Until done, pve-test-vm step-ca rebuild still
+  overwrites the global cert. Manual restore from `https://192.168.20.11/roots.pem`
+  if pve provisioning is needed afterward.
+- Legacy script audit (Step 7): `teardown-deploy-test.sh`, phase deploy scripts,
+  and validate scripts may still reference shared paths. Review before running.
 
-**3. Check `.generated/traefik/*.yml` before any proxy-stack provision**
+### Residual contamination risk (until Step 6 and 7 complete)
 
-Confirm routes use `lab.gibbsgreatly.xyz` and base-range IPs. If they show
-`test.gibbsgreatly.xyz` or +100 IPs, run `reconcile-edge.py --apply` with
-prod env first.
+`certs/homelab-root.crt` is still a global file. If pve-test-vm step-ca is
+rebuilt, restore the pve root CA before any pve provision:
+
+```bash
+curl -sk "https://192.168.20.11/roots.pem" > certs/homelab-root.crt
+```
 
 ---
 

--- a/docs/workflow/terraform-env-layout.md
+++ b/docs/workflow/terraform-env-layout.md
@@ -1,7 +1,34 @@
 # Terraform Environment Runtime Isolation
 
-**Status:** Planned. This is the next structural prerequisite for safe parallel
-work on `pve` and `pve-test-vm`.
+**Status:** In progress — code committed (`037c328`), PR #386 open →
+`main`. Steps 1–5 and 8 complete. Step 9 (pve state migration) partially
+complete. Steps 6, 7, and 10 pending.
+
+| Step | Status |
+|------|--------|
+| 1. Environment path helpers in provision.sh | ✅ Done |
+| 2. Terragrunt entrypoints for pve + pve-test-vm | ✅ Done (24 stacks each) |
+| 3. `generated_dir` variable + `output_dir` local in main.tf | ✅ Done |
+| 4. provision.sh reads env inventories (with fallback) | ✅ Done |
+| 5. Edge generated output scoped to env (reconcile-edge.py) | ✅ Done |
+| 6. Root CA scoping (`certs/homelab-root.crt` → env dir) | ⬜ Deferred |
+| 7. Legacy script audit and updates | ⬜ Deferred |
+| 8. `.gitignore` environment runtime entries | ✅ Done |
+| 9. Migrate pve (inventories pre-populated; state migration deferred) | ⚠️ Partial |
+| 10. Enable pve-test-vm (fresh apply from env entrypoints) | ⬜ Pending |
+
+**Step 9 note:** `environments/pve/<stack>/inventory.yml` files pre-populated by
+direct copy from `stacks/*/inventory.yml` (all confirmed pve base-range IPs). Full
+Terraform state migration is deferred because `null_resource.configure_network_sdn_attachment`
+has `sdn_vars_file = local_file.network_sdn_vars[0].filename` as a trigger — changing
+`output_dir` from `stacks/` to `environments/pve/` would fire the trigger and run
+Ansible SDN playbooks on pve unexpectedly. Migration requires targeted `-target` or
+`terraform state mv` approach, or waiting until the SDN attachment null_resource is
+refactored. The fallback in provision.sh (`stacks/` if env inventory missing) covers
+this gap in the interim.
+
+This is the next structural prerequisite for safe parallel work on `pve` and
+`pve-test-vm`.
 
 **Problem:** `pve` and `pve-test-vm` still share runtime outputs in one working
 tree. A run against one environment can overwrite files later consumed by the

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STACKS_DIR="${REPO_ROOT}/terraform/lxc/stacks"
 ANSIBLE_DIR="${REPO_ROOT}/terraform/lxc/ansible"
+# Per-environment runtime root — non-empty when PVE_ENV is set.
+# Generated files (inventory, network vars, edge output) land here when the
+# env-scoped Terragrunt layout is in use; falls back to STACKS_DIR otherwise.
+ENV_ROOT="${REPO_ROOT}/terraform/lxc/environments/${PVE_ENV:-}"
 
 usage() {
   cat <<'EOF'
@@ -97,9 +101,21 @@ ensure_portainer_oauth_secret() {
 reconcile_all_edge() {
   local check_mode="$1"
   local stacks_dir="$STACKS_DIR"
-  local proxy_inventory="${stacks_dir}/proxy-stack/inventory.yml"
   local proxy_playbook="${ANSIBLE_DIR}/playbooks/deploy-proxy-stack.yml"
-  local generated_traefik_dir="${REPO_ROOT}/terraform/lxc/.generated/traefik"
+
+  local proxy_inventory
+  if [[ -f "${ENV_ROOT}/proxy-stack/inventory.yml" ]]; then
+    proxy_inventory="${ENV_ROOT}/proxy-stack/inventory.yml"
+  else
+    proxy_inventory="${stacks_dir}/proxy-stack/inventory.yml"
+  fi
+
+  local generated_traefik_dir
+  if [[ -n "${PVE_ENV:-}" ]]; then
+    generated_traefik_dir="${ENV_ROOT}/.generated/traefik"
+  else
+    generated_traefik_dir="${REPO_ROOT}/terraform/lxc/.generated/traefik"
+  fi
 
   [[ -f "$proxy_inventory" ]] || { log "SKIP edge reconcile: proxy-stack inventory not found"; return 0; }
 
@@ -154,7 +170,12 @@ sys.exit(0 if d.get('register_portainer_env') else 1)
   log "Portainer env registration: ${stacks[*]}"
 
   for stack in "${stacks[@]}"; do
-    local inventory="${stacks_dir}/${stack}/inventory.yml"
+    local inventory
+    if [[ -f "${ENV_ROOT}/${stack}/inventory.yml" ]]; then
+      inventory="${ENV_ROOT}/${stack}/inventory.yml"
+    else
+      inventory="${stacks_dir}/${stack}/inventory.yml"
+    fi
     if [[ ! -f "$inventory" ]]; then
       log "SKIP portainer env registration for ${stack}: inventory not found"
       continue
@@ -417,7 +438,12 @@ PY
 provision_stack() {
   local stack="$1"
   local check_mode="$2"
-  local inventory_file="${STACKS_DIR}/${stack}/inventory.yml"
+  local inventory_file
+  if [[ -f "${ENV_ROOT}/${stack}/inventory.yml" ]]; then
+    inventory_file="${ENV_ROOT}/${stack}/inventory.yml"
+  else
+    inventory_file="${STACKS_DIR}/${stack}/inventory.yml"
+  fi
 
   ensure_portainer_oauth_secret "$stack"
 
@@ -450,7 +476,12 @@ provision_stack() {
   # Always regenerate zone from EdgeManifests before deploying dns-stack so the
   # live zone is never stale with respect to declared routes.
   if [[ "$stack" == "dns-stack" ]]; then
-    local generated_zone="${REPO_ROOT}/terraform/lxc/.generated/coredns/coredns-lab.zone"
+    local generated_zone
+    if [[ -n "${PVE_ENV:-}" ]]; then
+      generated_zone="${ENV_ROOT}/.generated/coredns/coredns-lab.zone"
+    else
+      generated_zone="${REPO_ROOT}/terraform/lxc/.generated/coredns/coredns-lab.zone"
+    fi
     mkdir -p "$(dirname "$generated_zone")"
     log "Regenerating CoreDNS zone from EdgeManifests"
     python3 "${REPO_ROOT}/terraform/lxc/render-edge-coredns.py" \

--- a/terraform/lxc/environments/pve-test-vm/apt-cacher-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/apt-cacher-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/authentik-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/authentik-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/ci-runner-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/ci-runner-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/dns-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/dns-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/docker-socket-proxy-test/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/docker-socket-proxy-test/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/harbor-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/harbor-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/monitoring-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/monitoring-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-app-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-app-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-artifacts-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-artifacts-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-build-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-build-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-client-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-client-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-client-02/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-client-02/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-isolated-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-isolated-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-service-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-service-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-service-02/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-service-02/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/net-svc-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/net-svc-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/netbox-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/netbox-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/portainer-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/portainer-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/proxy-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/proxy-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/step-ca-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/step-ca-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/test-docker/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/test-docker/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/test-lxc/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/test-lxc/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/test-storage-extra/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/test-storage-extra/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve-test-vm/test-storage/terragrunt.hcl
+++ b/terraform/lxc/environments/pve-test-vm/test-storage/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/apt-cacher-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/apt-cacher-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/authentik-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/authentik-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/ci-runner-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/ci-runner-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/dns-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/dns-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/docker-socket-proxy-test/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/docker-socket-proxy-test/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/harbor-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/harbor-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/monitoring-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/monitoring-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-app-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-app-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-artifacts-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-artifacts-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-build-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-build-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-client-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-client-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-client-02/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-client-02/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-isolated-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-isolated-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-service-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-service-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-service-02/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-service-02/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/net-svc-01/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/net-svc-01/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/netbox-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/netbox-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/portainer-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/portainer-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/proxy-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/proxy-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/step-ca-stack/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/step-ca-stack/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/test-docker/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/test-docker/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/test-lxc/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/test-lxc/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/test-storage-extra/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/test-storage-extra/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/environments/pve/test-storage/terragrunt.hcl
+++ b/terraform/lxc/environments/pve/test-storage/terragrunt.hcl
@@ -1,0 +1,13 @@
+include "root" {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_repo_root()}/terraform/lxc//"
+}
+
+inputs = {
+  stack_name      = basename(get_terragrunt_dir())
+  stack_yaml_path = "${get_repo_root()}/terraform/lxc/stacks/${basename(get_terragrunt_dir())}/stack.yaml"
+  generated_dir   = get_terragrunt_dir()
+}

--- a/terraform/lxc/main.tf
+++ b/terraform/lxc/main.tf
@@ -51,6 +51,9 @@ locals {
   ansible_dir        = "${local.lxc_root}/ansible"
   ansible_cfg        = "${local.ansible_dir}/ansible.cfg"
   ansible_roles_path = "${local.ansible_dir}/roles"
+  # When generated_dir is provided (env-scoped Terragrunt entrypoint), write
+  # runtime files there. Falls back to stack_dir for legacy stack/ entrypoints.
+  output_dir = var.generated_dir != "" ? var.generated_dir : local.stack_dir
 
   # Optional declarative network intent. Existing stacks continue to use the
   # current bridge defaults unless they opt in with stack.network.zone.
@@ -508,7 +511,7 @@ check "template_name_allowed_by_profile" {
 resource "local_file" "network_sdn_vars" {
   count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" ? 1 : 0
 
-  filename = "${local.stack_dir}/network-sdn-vars.yml"
+  filename = "${local.output_dir}/network-sdn-vars.yml"
   content = yamlencode({
     network_sdn_enable            = true
     network_sdn_target            = local.effective_target_node
@@ -548,7 +551,7 @@ resource "null_resource" "configure_network_sdn_attachment" {
       ansible-playbook \
         -i localhost, \
         playbooks/configure-network-sdn-vnet.yml \
-        -e '@${local.stack_dir}/network-sdn-vars.yml'
+        -e '@${local.output_dir}/network-sdn-vars.yml'
     EOT
     working_dir = local.ansible_dir
 
@@ -640,7 +643,7 @@ module "lxc" {
 # Ansible inventory (always generated)
 # ---------------------------------------------------------------------------
 resource "local_file" "ansible_inventory" {
-  filename = "${local.stack_dir}/inventory.yml"
+  filename = "${local.output_dir}/inventory.yml"
   content = templatefile("${local.lxc_root}/templates/inventory.tpl", {
     stack_name                            = local.stack_name
     hostname                              = module.lxc.hostname
@@ -680,7 +683,7 @@ resource "null_resource" "configure_keyctl" {
   provisioner "local-exec" {
     command     = <<-EOT
       ansible-playbook \
-        -i '${local.stack_dir}/inventory.yml' \
+        -i '${local.output_dir}/inventory.yml' \
         playbooks/configure-keyctl.yml
     EOT
     working_dir = local.ansible_dir
@@ -703,7 +706,7 @@ resource "null_resource" "configure_keyctl" {
 resource "local_file" "network_firewall_vars" {
   count = local.stack_network_zone != null && local.resolved_attachment_type == "bridge" && local.effective_firewall == true ? 1 : 0
 
-  filename = "${local.stack_dir}/network-firewall-vars.yml"
+  filename = "${local.output_dir}/network-firewall-vars.yml"
   content = yamlencode({
     network_firewall_enable     = true
     network_firewall_policy_in  = "DROP"
@@ -733,9 +736,9 @@ resource "null_resource" "configure_network_firewall" {
   provisioner "local-exec" {
     command     = <<-EOT
       ansible-playbook \
-        -i '${local.stack_dir}/inventory.yml' \
+        -i '${local.output_dir}/inventory.yml' \
         playbooks/configure-network-firewall.yml \
-        -e '@${local.stack_dir}/network-firewall-vars.yml'
+        -e '@${local.output_dir}/network-firewall-vars.yml'
     EOT
     working_dir = local.ansible_dir
 
@@ -762,7 +765,7 @@ resource "null_resource" "configure_network_firewall" {
 resource "local_file" "network_vnet_firewall_vars" {
   count = local.stack_network_zone != null && local.resolved_attachment_type == "sdn_vnet" && local.effective_firewall == true ? 1 : 0
 
-  filename = "${local.stack_dir}/network-vnet-firewall-vars.yml"
+  filename = "${local.output_dir}/network-vnet-firewall-vars.yml"
   content = yamlencode({
     network_vnet_firewall_enable         = true
     network_vnet_firewall_policy_forward = "DROP"
@@ -790,7 +793,7 @@ resource "null_resource" "configure_network_vnet_firewall" {
       ansible-playbook \
         -i localhost, \
         playbooks/configure-network-vnet-firewall.yml \
-        -e '@${local.stack_dir}/network-vnet-firewall-vars.yml'
+        -e '@${local.output_dir}/network-vnet-firewall-vars.yml'
     EOT
     working_dir = local.ansible_dir
 

--- a/terraform/lxc/reconcile-edge.py
+++ b/terraform/lxc/reconcile-edge.py
@@ -39,6 +39,15 @@ RENDER_COREDNS = _load_module("render_edge_coredns", SCRIPT_DIR / "render-edge-c
 DISCOVER_AUTHENTIK = _load_module("discover_authentik_edge", SCRIPT_DIR / "discover-authentik-edge.py")
 RECONCILE_AUTHENTIK = _load_module("reconcile_authentik_edge", SCRIPT_DIR / "reconcile-authentik-edge.py")
 
+# When PVE_ENV is set, write generated output under the env-scoped directory
+# so pve and pve-test-vm outputs never share the same path.
+_pve_env = os.environ.get("PVE_ENV", "")
+_generated_base = (
+    SCRIPT_DIR / "environments" / _pve_env / ".generated"
+    if _pve_env
+    else SCRIPT_DIR / ".generated"
+)
+
 
 DEFAULT_TARGET_PREFLIGHT_EXPECTED = os.environ.get("EDGE_TARGET_PREFLIGHT_EXPECTED") or os.environ.get("PVE_ENV", "pve-test")
 DEFAULT_TRAEFIK_PROBE_HOST = os.environ["LAB_IP_PROXY"]
@@ -109,7 +118,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--traefik-output-dir",
         type=Path,
-        default=SCRIPT_DIR / ".generated" / "traefik",
+        default=_generated_base / "traefik",
         help="Output directory for rendered Traefik dynamic files.",
     )
     parser.add_argument(
@@ -121,7 +130,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--coredns-output-zone",
         type=Path,
-        default=SCRIPT_DIR / ".generated" / "coredns" / "coredns-lab.zone",
+        default=_generated_base / "coredns" / "coredns-lab.zone",
         help="Output file for rendered CoreDNS zone.",
     )
     parser.add_argument(

--- a/terraform/lxc/variables.tf
+++ b/terraform/lxc/variables.tf
@@ -11,6 +11,12 @@ variable "stack_yaml_path" {
   type        = string
 }
 
+variable "generated_dir" {
+  description = "Directory where generated runtime files (inventory.yml, network-*-vars.yml) are written. Empty string falls back to the stack source directory for legacy compatibility."
+  type        = string
+  default     = ""
+}
+
 variable "network_intent_path" {
   description = "Optional override path for the shared network intent YAML file"
   type        = string


### PR DESCRIPTION
## Summary

- Adds `terraform/lxc/environments/{pve,pve-test-vm}/<stack>/terragrunt.hcl` for all 24 Terraform-managed stacks. These entrypoints pass `generated_dir=get_terragrunt_dir()` so state and all generated runtime files (inventory.yml, network-*-vars.yml) land under `environments/<env>/<stack>/` instead of the shared `stacks/<stack>/` directory.
- Adds `generated_dir` variable to `variables.tf` and `output_dir` local to `main.tf`. Old `stacks/<stack>/terragrunt.hcl` entrypoints are unchanged (empty `generated_dir` falls back to `stack_dir`).
- Updates `scripts/provision.sh` to prefer `environments/<PVE_ENV>/<stack>/inventory.yml` over `stacks/<stack>/inventory.yml` when present, and to write edge generated output (Traefik, CoreDNS) under `environments/<PVE_ENV>/.generated/`.
- Updates `terraform/lxc/reconcile-edge.py` defaults to use the env-scoped generated path when `PVE_ENV` is set.
- Updates `.gitignore` to exclude runtime outputs under `environments/**/`.

## What this solves

pve and pve-test-vm were sharing `stacks/*/inventory.yml`, `terraform.tfstate`, and `.generated/traefik/`. A Terraform run against pve-test-vm overwrote production inventories, causing the 2026-06-24 incident. This change gives each environment its own runtime output directory so those paths cannot collide.

## Safety

- **pve is not affected today**: env inventories are gitignored runtime files. pve env inventories have been pre-populated by copying from `stacks/` (identical content, same containers). `provision.sh` falls back to `stacks/` paths until the env inventory exists.
- **Terraform state migration deferred**: Running `terragrunt apply` from env dirs would change `local_file` filenames, causing `null_resource.configure_network_sdn_attachment` triggers to fire (Ansible SDN re-config). This is deferred until a targeted migration approach is validated.
- **pve-test-vm work can start**: `environments/pve-test-vm/<stack>/terragrunt.hcl` files are ready. Fresh applies will write all outputs to the env dir with no pve overlap.

## Test plan

- [x] `terraform fmt -check` passes
- [x] Pre-commit hooks pass
- [x] `render-edge-traefik.py` confirmed to call `output_dir.mkdir(parents=True, exist_ok=True)` — no failure on first run with new path
- [x] pve env inventories verified: all base-range IPs, no +100 contamination
- [x] `terraform/lxc/environments/**/inventory.yml` confirmed gitignored; `terragrunt.hcl` files confirmed tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)