### PR TITLE
fix(media-stack-lab): route immich/jellyfin images through Harbor

### DIFF
--- a/terraform/lxc/stacks/media-stack-lab/immich-docker-compose.yml
+++ b/terraform/lxc/stacks/media-stack-lab/immich-docker-compose.yml
@@ -16,7 +16,7 @@ name: media-stack-lab-immich
 
 services:
   immich-server:
-    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    image: ${REGISTRY_HOST}/ghcr/immich-app/immich-server:${IMMICH_VERSION:-release}
     container_name: media-stack-lab-immich-server
     user: "1000:1000"
     environment:
@@ -39,19 +39,19 @@ services:
     restart: unless-stopped
 
   immich-machine-learning:
-    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    image: ${REGISTRY_HOST}/ghcr/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
     container_name: media-stack-lab-immich-machine-learning
     volumes:
       - model-cache:/cache
     restart: unless-stopped
 
   redis:
-    image: docker.io/valkey/valkey:9@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
+    image: ${REGISTRY_HOST}/dockerhub/valkey/valkey:9@sha256:3acc0687f2a2e1091fae6450d7842dd658c941338cf0a873ddd9e14b9e4ea4dd
     container_name: media-stack-lab-redis
     restart: unless-stopped
 
   database:
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    image: ${REGISTRY_HOST}/ghcr/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
     container_name: media-stack-lab-database
     environment:
       - POSTGRES_PASSWORD=${MEDIA_STACK_LAB_DB_PASSWORD}

--- a/terraform/lxc/stacks/media-stack-lab/jellyfin-docker-compose.yml
+++ b/terraform/lxc/stacks/media-stack-lab/jellyfin-docker-compose.yml
@@ -14,7 +14,7 @@ name: media-stack-lab-jellyfin
 
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.11.11ubu2604-ls47
+    image: ${REGISTRY_HOST}/lscr/linuxserver/jellyfin:10.11.11ubu2604-ls47
     container_name: media-stack-lab-jellyfin
     environment:
       - PUID=1000


### PR DESCRIPTION
## Summary
Fixes CI's "Enforce Harbor-only image references" job, which started
failing on PR #389 once today's merges landed media-stack-lab on
`stable`. 5 image: lines in `immich-docker-compose.yml` and
`jellyfin-docker-compose.yml` pulled directly from ghcr.io/docker.io/
lscr.io instead of through Harbor's proxy-cache.

Fixed using the same `${REGISTRY_HOST}/<project>/...` convention this
file's own `cadvisor` entry already uses. Verified locally by running
the CI check's exact bash logic against this stack's directory — 0
violations remain in the deployed compose files.

## Not in scope (same CI job, pre-existing, not real violations)
- `stack-request.yaml`'s 5 flagged lines — that's a human-authored
  scratch input file, not a deployed artifact
- `harness-target-pve/docker-compose.yml`'s 3 flagged lines — same
  accepted-exception pattern as `harness-target/` (which the check
  already excludes), just missing from the exclude-dir list
- `deploy-mcp-utility-stack.yml`'s `mcp_harbor_fqdn` var — doesn't match
  the checker's `*registry_host*` naming convention, but does route
  through Harbor

## Deployment
Not deployed live as part of this PR — the image bytes are identical
either way (Harbor's proxy-cache is transparent), so this takes effect
naturally the next time media-stack-lab is redeployed for any reason,
rather than forcing an out-of-band redeploy just for this.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>