### PR TITLE
fix: clean up CI Validate findings (ansible key-order, ruff, shellcheck)

### DIFF
--- a/scripts/framework-comfyui-benchmark/comfyui_benchmark.py
+++ b/scripts/framework-comfyui-benchmark/comfyui_benchmark.py
@@ -18,7 +18,6 @@ import hashlib
 import json
 import os
 import re
-import shutil
 import statistics
 import struct
 import subprocess  # nosec B404 -- fixed local administrative commands only

--- a/scripts/pentagi-test-harness/run_sequence.py
+++ b/scripts/pentagi-test-harness/run_sequence.py
@@ -120,7 +120,6 @@ def update_models_preset(cfg, run):
     content = content.rstrip() + "\n\n" + adviser_section
 
     tmp_remote = "/tmp/models-preset.ini.new"
-    escaped = content.replace("'", "'\\''")
     ssh_framework(cfg, f"cat > {tmp_remote} << 'PRESET_EOF'\n{content}\nPRESET_EOF")
     ssh_framework(cfg, f"cp {tmp_remote} {preset_path}", use_sudo=True)
     log(f"models-preset.ini updated: qwen ctx={run['qwen_ctx_size']} rb={run['qwen_reasoning_budget']}, "

--- a/scripts/portainer-restore.sh
+++ b/scripts/portainer-restore.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2029
+# Every ssh "..." command below intentionally expands its local vars
+# (PVE_HOST, PORTAINER_VMID, CONTAINER_NAME, etc.) client-side before
+# sending the command over SSH -- that's this whole script's own
+# parameterization mechanism, not a remote-side value, so SC2029's info
+# note doesn't apply here. File-level directive since the pattern repeats
+# throughout.
 # Restore Portainer from the latest NAS backup.
 #
 # Automatically selects the correct restore path based on current Portainer state:

--- a/terraform/lxc/ansible/playbooks/deploy-greenbone-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-greenbone-stack.yml
@@ -857,6 +857,7 @@
       tags: [credential-program]
 
     - name: Run credential-program setup and remove temporary key files
+      tags: [credential-program]
       block:
         - name: Write credential-program setup script
           ansible.builtin.copy:
@@ -918,7 +919,6 @@
             path: "{{ greenbone_credential_program_tempdir.path }}"
             state: absent
           no_log: true
-      tags: [credential-program]
 
 - name: Deploy findings ingestion (GVM -> opensearch-stack)
   hosts: all

--- a/terraform/lxc/stacks/netbox-stack/integrations/flows.py
+++ b/terraform/lxc/stacks/netbox-stack/integrations/flows.py
@@ -18,11 +18,9 @@ Standalone usage:
 Called from populate.py to push the model to NetBox as a config context.
 """
 
-import glob
 import json
 import os
 import re
-import sys
 from pathlib import Path
 
 import yaml

--- a/terraform/lxc/test_reconcile_authentik_edge.py
+++ b/terraform/lxc/test_reconcile_authentik_edge.py
@@ -188,7 +188,11 @@ class FakeClient:
     def create_application(self, payload: dict):
         self.request_methods.append("POST")
         if self.fail_create_application_duplicate:
-            body = b'{"slug":["Application with this slug already exists."],"provider":["Application with this provider already exists."]}'
+            # Real Authentik 400 body on a duplicate slug/provider, kept for
+            # readability -- the reconciler only checks exc.code == 400 at
+            # this call site, never the body, so it's not wired into the
+            # HTTPError below (see reconcile-authentik-edge.py's duplicate-
+            # create handling).
             raise urllib.error.HTTPError(
                 "https://authentik.example.test/api/v3/core/applications/",
                 400,


### PR DESCRIPTION
## Summary
Fixes the real, actionable findings from PR #389's failing "Validate"
job: 1 ansible-lint key-order error, 5 ruff dead-code findings, and a
9-instance ShellCheck SC2029 cluster (all in one file, same intentional
pattern, one file-level directive).

Deliberately scoped — not a full sweep of that job's much larger
pre-existing debt. See commit message for exactly what was and wasn't
addressed, and why (the ansible-lint job specifically will still show
red — its exit code depends on ~129 total violations, mostly
yaml[line-length] warnings across dozens of files, not just the one
error this PR fixes).

## Verification
- `ansible-lint playbooks/`: the specific greenbone key-order finding
  is gone
- `ruff check`: clean across every tracked `*.py` file
- `shellcheck`: clean across every tracked `*.sh` file
- All 21 tests in `test_reconcile_authentik_edge.py` still pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>