### PR TITLE
fix(ansible-lint): clear all non-warn_list ansible-lint findings

### DIFF
--- a/ansible/00-initial-setup/framework-desktop-bootstrap.yml
+++ b/ansible/00-initial-setup/framework-desktop-bootstrap.yml
@@ -126,7 +126,7 @@
         mode: '0644'
       when: not (framework_apt_cacher_reachable.failed | default(true))
 
-    - name: Add {{ framework_gpu_group_user }} to video/render groups for GPU device access
+    - name: Add {{ framework_gpu_group_user }} to video/render groups for GPU device access # noqa: name[template]
       ansible.builtin.user:
         name: "{{ framework_gpu_group_user }}"
         groups: video,render

--- a/ansible/00-initial-setup/framework-desktop-comfyui.yml
+++ b/ansible/00-initial-setup/framework-desktop-comfyui.yml
@@ -71,7 +71,7 @@
         enabled: true
         state: started
 
-    - name: Add {{ framework_comfyui_user }} to the docker group
+    - name: Add {{ framework_comfyui_user }} to the docker group # noqa: name[template]
       ansible.builtin.user:
         name: "{{ framework_comfyui_user }}"
         groups: docker

--- a/ansible/00-initial-setup/framework-desktop-llamacpp.yml
+++ b/ansible/00-initial-setup/framework-desktop-llamacpp.yml
@@ -80,7 +80,7 @@
         enabled: true
         state: started
 
-    - name: Add {{ framework_llamacpp_user }} to the docker group
+    - name: Add {{ framework_llamacpp_user }} to the docker group # noqa: name[template]
       ansible.builtin.user:
         name: "{{ framework_llamacpp_user }}"
         groups: docker

--- a/ansible/00-initial-setup/framework-desktop-ollama.yml
+++ b/ansible/00-initial-setup/framework-desktop-ollama.yml
@@ -70,7 +70,7 @@
         enabled: true
         state: started
 
-    - name: Add {{ framework_ollama_user }} to the docker group
+    - name: Add {{ framework_ollama_user }} to the docker group # noqa: name[template]
       ansible.builtin.user:
         name: "{{ framework_ollama_user }}"
         groups: docker

--- a/ansible/00-initial-setup/mikrotik-game-seg.yml
+++ b/ansible/00-initial-setup/mikrotik-game-seg.yml
@@ -42,7 +42,7 @@
       # RouterOS rejects connection-state combined with src-address through its
       # REST endpoint. This intentionally mirrors the router's existing
       # established/related rule, but is ordered before game_seg's deny.
-      - { comment: "game_seg established and related", chain: forward, action: accept, connection-state: established,related }
+      - { comment: "game_seg established and related", chain: forward, action: accept, connection-state: established, related }
       - { comment: "game-stack LAN administration and Minecraft", chain: forward, action: accept, protocol: tcp, src-address: 192.168.1.0/24, dst-address: "{{ game_stack_ip }}", dst-port: "22,25565" }
       - { comment: "mgmt_seg Portainer to game-stack agent", chain: forward, action: accept, protocol: tcp, src-address: "{{ lookup('env', 'LAB_IP_PORTAINER') }}", dst-address: "{{ game_stack_ip }}", dst-port: "9001" }
       - { comment: "monitoring-stack scrapes game-stack metrics", chain: forward, action: accept, protocol: tcp, src-address: "{{ lookup('env', 'LAB_IP_MONITORING') }}", dst-address: "{{ game_stack_ip }}", dst-port: "9100,8080" }

--- a/ansible/00-initial-setup/tasks/proxmox-vlan-aware-bridge.yml
+++ b/ansible/00-initial-setup/tasks/proxmox-vlan-aware-bridge.yml
@@ -46,7 +46,7 @@
     - _vlan_aware_change.changed or _vlan_vids_change.changed
   changed_when: true
 
-- name: Verify {{ pmx_vlan_aware_bridge_name }} is VLAN-aware after reload
+- name: Verify {{ pmx_vlan_aware_bridge_name }} is VLAN-aware after reload # noqa: name[template]
   ansible.builtin.command: >-
     bridge -j vlan show dev {{ pmx_vlan_aware_bridge_name }}
   register: _vlan_aware_verify

--- a/terraform/lxc/ansible/playbooks/deploy-netbox-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-netbox-stack.yml
@@ -241,7 +241,8 @@
       register: netbox_docker_login
 
     - name: Pull and start NetBox compose stack
-      ansible.builtin.shell:
+      ansible.builtin.shell: # noqa: command-instead-of-shell -- the leading `pull &&` clause is conditionally
+        # omitted via Jinja, which ansible.builtin.command can't do (it has no shell operators)
         cmd: >-
           {{ '' if netbox_docker_login.failed else 'docker compose -f ' ~ compose_file ~ ' pull &&' }}
           docker compose -f {{ compose_file }} up -d --remove-orphans

--- a/terraform/lxc/ansible/roles/docker_socket_proxy/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/docker_socket_proxy/tasks/main.yml
@@ -75,6 +75,7 @@
     - enable_docker_socket_proxy | default(false) | bool
     - not ansible_check_mode
     - docker_socket_proxy_image_check.rc | default(1) != 0
+  ignore_errors: true  # best-effort shortcut -- if this fails, the compose step below surfaces the real error as before
   block:
     - name: Pull docker_socket_proxy image from its upstream registry
       ansible.builtin.command:
@@ -83,7 +84,6 @@
     - name: Tag docker_socket_proxy image with Harbor proxy cache path
       ansible.builtin.command:
         cmd: "docker tag {{ docker_socket_proxy_upstream_image }} {{ docker_socket_proxy_image }}"
-  ignore_errors: true  # best-effort shortcut -- if this fails, the compose step below surfaces the real error as before
 
 - name: Deploy compose project (idempotent)
   community.docker.docker_compose_v2:

--- a/terraform/lxc/ansible/roles/node_exporter/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/node_exporter/tasks/main.yml
@@ -59,7 +59,7 @@
     - not ansible_check_mode
     - node_exporter_step_ca_reachable.failed | default(true)
 
-- name: node_exporter TLS cert setup
+- name: Set up node_exporter TLS certs
   when:
     - node_exporter_tls_enabled | default(true) | bool
     - not ansible_check_mode

--- a/terraform/lxc/ansible/roles/wazuh_agent/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/wazuh_agent/tasks/main.yml
@@ -155,16 +155,14 @@
           <packages>yes</packages>
           <ports all="no">yes</ports>
           <processes>yes</processes>
-        </wodle>
-        {%- if wazuh_agent_docker_monitoring_enabled | bool %}
+        </wodle>{%- if wazuh_agent_docker_monitoring_enabled | bool %}
 
         <wodle name="docker-listener">
           <disabled>no</disabled>
           <interval>1m</interval>
           <attempts>5</attempts>
           <run_on_start>yes</run_on_start>
-        </wodle>
-        {%- endif %}
+        </wodle>{%- endif %}
 
         <sca>
           <enabled>yes</enabled>


### PR DESCRIPTION
Fixes the "Ansible lint" CI job (`.github/workflows/validate.yml`), which
runs `ansible-lint` against both `terraform/lxc/ansible/playbooks/` and
`ansible/` (host-bootstrap). `yaml[line-length]` and
`var-naming[no-role-prefix]` are already downgraded to `warn_list` in
`.ansible-lint` and don't fail the job; this PR clears the findings that
actually do:

- `command-instead-of-shell` (deploy-netbox-stack.yml): suppressed with
  `# noqa` + rationale — the leading `pull &&` clause is conditionally
  omitted via Jinja, which `ansible.builtin.command` can't express.
- `key-order[task]` (docker_socket_proxy): moved `ignore_errors` before
  `block`, matching PR #396's identical greenbone fix.
- `jinja[spacing]` (wazuh_agent ossec.conf template): joined the
  `{%- if %}` / `{%- endif %}` tags onto the preceding closing element,
  matching how Jinja actually renders them (the `-` already strips the
  newline).
- `name[template]` × 5 (framework-desktop-*, proxmox-vlan-aware-bridge):
  suppressed with `# noqa`, matching the existing precedent in
  `mikrotik-dns-lab-zone-delegate.yml` for task names that need a
  variable interpolated to stay meaningful.
- `yaml[commas]` (mikrotik-game-seg): added the missing space after the
  comma in `established,related`.
- `name[casing]` (node_exporter): renamed to start with an uppercase
  letter.

No behavior change to any deployed stack or host-bootstrap playbook —
lint-only cleanup.

## Validation
- `ansible-lint playbooks/` from `terraform/lxc/ansible/` — exit 0
- `ansible-lint 00-initial-setup/*.yml 01-base-system/*.yml` from `ansible/` — exit 0
- `ansible-playbook --syntax-check` on the touched playbook

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)