### PR TITLE
feat(provision): add opt-in RUNNER_FORCE_RECONFIGURE hook for ci-runner-01

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -666,6 +666,16 @@ provision_stack() {
     cmd=(env GRAYLOG_DEPLOY_RUNTIME=true "${cmd[@]}")
   fi
 
+  # Opt-in only: GitHub deletes a runner's registration after enough idle
+  # time (or certain server-side events), independent of whether the LXC
+  # itself is up. When that happens the runner service starts and exits
+  # immediately (see runsvc.sh's "registration has been deleted" error) --
+  # a plain restart never fixes it, it needs actual re-registration.
+  if [[ "$stack" == "ci-runner-01" && "${RUNNER_FORCE_RECONFIGURE:-false}" == "true" ]]; then
+    log "ci-runner-01: forcing runner de-registration + re-registration (RUNNER_FORCE_RECONFIGURE=true)"
+    cmd+=(-e "runner_force_reconfigure=true")
+  fi
+
   if [[ "$stack" == "technitium-stack" ]]; then
     local generated_records
     if [[ -n "${PVE_ENV:-}" ]]; then


### PR DESCRIPTION
GitHub can delete a self-hosted runner's registration after enough idle
time (or certain server-side events), independent of whether the LXC
itself is up. When that happens, `actions.runner.*.service` starts and
exits immediately with "the runner registration has been deleted from
the server, please re-configure" — a plain restart never fixes it.

`deploy-ci-runner.yml` already has the logic to handle this
(`runner_force_reconfigure`: generates a removal token, deregisters,
re-registers with a fresh token), but `provision.sh` had no way to flip
that var on for a single run, matching the existing per-stack special
cases for `graylog-stack`/`technitium-stack`.

**Usage**: `RUNNER_FORCE_RECONFIGURE=true ./with-secrets-prod scripts/provision.sh --stack ci-runner-01`

No behavior change to any other stack.

## Validation
- `bash -n scripts/provision.sh` — OK
- `shellcheck scripts/provision.sh` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)