### PR TITLE
fix(ci-runner): force-clear stale local runner config before reconfiguring

### DIFF
--- a/terraform/lxc/ansible/playbooks/deploy-ci-runner.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-ci-runner.yml
@@ -207,6 +207,31 @@
       failed_when: false
       no_log: true
 
+    # `config.sh remove` above is best-effort: if GitHub already considers
+    # the runner's registration gone (the exact incident this force-reconfigure
+    # path exists for), remove has nothing valid to invalidate server-side and
+    # can silently no-op -- but it's swallowed by failed_when: false above, so
+    # nothing here surfaces that. Either way, config.sh's own IsConfigured()
+    # check only looks at whether these local files exist, so leaving them in
+    # place makes the "Configure runner" task below fail with "Cannot
+    # configure the runner because it is already configured" even though
+    # --replace is set (--replace only overrides an existing *valid* GitHub-side
+    # registration under the same name, not this local-file check). Force-clear
+    # them here so the Configure step is guaranteed a clean slate.
+    - name: Remove stale local runner config files before reconfiguring
+      ansible.builtin.file:
+        path: "{{ runner_home }}/{{ item }}"
+        state: absent
+      loop:
+        - .runner
+        - .runner_migrated
+        - .credentials
+        - .credentials_migrated
+        - .service
+      become: true
+      become_user: "{{ runner_user }}"
+      when: runner_force_reconfigure | bool
+
     - name: Configure runner
       ansible.builtin.command:
         cmd: >


### PR DESCRIPTION
Root cause of tonight's `ci-runner-01` incident, found via its `_diag`
log: GitHub had already invalidated the runner's registration
server-side (the original "registration has been deleted from the
server" crash on reboot). `runner_force_reconfigure`'s "Deregister
existing runner" task then ran `config.sh remove`, but that's
best-effort against a registration GitHub already considers gone — it
can silently no-op, and `failed_when: false` swallows that either way.
`config.sh`'s own `IsConfigured()` check only looks at whether
`.runner`/`.credentials` exist locally, so those files survived, and
the next "Configure runner" task failed with:

> Cannot configure the runner because it is already configured. To
> reconfigure the runner, run './config.sh remove' first.

— even with `--replace`, since `--replace` only overrides an existing
*valid* GitHub-side registration under the same name, not this
local-file check.

## Fix
Force-clear `.runner`, `.runner_migrated`, `.credentials`,
`.credentials_migrated`, and `.service` under `runner_home` whenever
`runner_force_reconfigure` is set, right after the deregister attempt —
regardless of whether that attempt actually succeeded server-side.
Guarantees the Configure step gets a clean slate.

## Validation
- `ansible-playbook --syntax-check` — OK
- `ansible-lint playbooks/deploy-ci-runner.yml` — exit 0 (only
  pre-existing warn_list findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)