### PR TITLE
fix(secrets): rotate stale HARBOR_ROBOT_PASSWORD for robot$ci-runner

### DIFF
--- a/terraform/secrets.common.enc.yaml
+++ b/terraform/secrets.common.enc.yaml
@@ -14,7 +14,7 @@ HARBOR_ADMIN: ENC[AES256_GCM,data:f+LQ4S0=,iv:0E7a48XX2/FlOfk/CyBN//b3+QuQamwC0o
 HARBOR_DB_PASSWORD: ENC[AES256_GCM,data:sicG1wtxdDKSoGpqAS817sBWeBhuSC0I2DXc/PWNfHI=,iv:0+esbHaRDTHiaIM8WBlz9UZrGM5vA/ioPM+3NhagFec=,tag:eSL/UdxrlEfNt0M/bYi5RQ==,type:str]
 HARBOR_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:xqXuUoxOTzyCNPeSQjTKvZPOX8af9o3UtGS7+A3dyAPbPiJSaP4/14gyL+0/1+KKsi7A4/cz,iv:tBptzb8Y66KHDnCqbPdWjz+QBA7eMKWZ5VgRWdUmTgo=,tag:VP6Pia+qfympGfEndmXLtA==,type:str]
 HARBOR_OIDC_PRIMARY_AUTH_MODE: ENC[AES256_GCM,data:hELC5w==,iv:7BxSi0ywRVMsRSMHsblFt7lZfM2r8WJ1kL9VKtl5Y/A=,tag:TnNyGDbXh7bzQCAimS5/jg==,type:str]
-HARBOR_ROBOT_PASSWORD: ENC[AES256_GCM,data:G7Yq7yLqMyc6rb/yIPFuPAWoHazJJV3RZRiwkEiZOnY=,iv:BJfD37ZxYH4isNMmo/fHcTvsqCcZsXWxrXOXqTKH6uY=,tag:5ij8Wa4rz1EGC8tjSBGH5g==,type:str]
+HARBOR_ROBOT_PASSWORD: ENC[AES256_GCM,data:pOHeGJQnhwfwkjl7p7/CPEDeMxnREP7b98NdoDvj2tiZwqv0JQTFCZwbiw==,iv:/g9BOTV6BP5SX3DZzSn1ldeZGAUWk+I1fjNqZcIsEIw=,tag:9eUIQF7V2v7iKhomP/nEKw==,type:str]
 HARBOR_ROBOT_USER: ENC[AES256_GCM,data:GysnYpfMMD++OsYQUG+C,iv:dn3Sflmev/IwPABJKgxORkYnGyOU5XNjC7GkqlP1wW4=,tag:8UeFXNT+DKl3lN0f3ALbDw==,type:str]
 MIKROTIK_ADMIN: ENC[AES256_GCM,data:30KD2qu5G+w=,iv:tkER3z79sOj815J004PYq6OrMgtLItH8bS3TrGJIL80=,tag:W4ZPJwz+uTe++tTtatTiEA==,type:str]
 MIKROTIK_ADMIN_PASSWORD: ENC[AES256_GCM,data:jp8BDZ6d+2DYp0Lq9TtAOT4znwKt9MX3cRBi/ScjZQ+4XUZ9YLNkCtFrAaw=,iv:n5klFj5JHHuOUZ9rAxWac3Tf0TRjx6Dp0D5nnXzeKQE=,tag:Y9m7cllzjI5JBPOA1H4wIQ==,type:str]
@@ -109,7 +109,7 @@ sops:
             uIJIuV3DYCVtIVa863BpTRp0r1o4x+U7Dd2qQoQ/bO6/5LhUOw+x2A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fzhfgtun0jczh6z2ksswmf4mw90p7mg5nhmhpasny6ypesxucf5sctxqpe
-    lastmodified: "2026-09-04T03:13:12Z"
-    mac: ENC[AES256_GCM,data:Cs6HAKzDcHrCI3wZ+mqg4w7fzS0nj6QdM5+r4Qb1DFZu9VJRALTJqZinyII5xZEeMnXzyle9/QSa1hugj9Kaw7qmtjL9tFCIVK76HsATDysjXAwsnvZo9QHz4u9eaOZ+Qh4qI+pZ0XlkqG0cRumAeUFstCic3pcWQ/1/ibG0d2k=,iv:CfyQ3vNeubBB8lcim5B1ciBQu9kd6UmUI00tP0rn70k=,tag:bDHI6HbGNHQMPgXt2EqN6Q==,type:str]
+    lastmodified: "2026-09-06T04:53:22Z"
+    mac: ENC[AES256_GCM,data:wjeo5c0Bepy65Qe7ENx4+4t+XBsNQI3o/uqryIzlptHLfy+K5LRUwRVjElceMz3mHG2PTlM8InzxZBxD2s6l/HaJXSfKwXHXiKxVpXDUhqWt+5qAeNpzftPC+ieZpaEL5NdTnOFinvHH2WfxgPFty3rTweJI8GgGkR+km8G2Y3g=,iv:+JczTA3ayBmlObVR4RnbFCMpQqN88+lHHy/QhIf7OeE=,tag:A5LM+L8SIa3TzyXyAkC4Zw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
The stored `HARBOR_ROBOT_PASSWORD` 401'd against live Harbor — confirmed
stale as of 2026-07-26 (tracked in an earlier session's memory), reconfirmed
still broken tonight while investigating `security-scan.yml`'s "Build image
for scan" job failure (root cause: this exact credential, shared with
GitHub Actions repo secrets).

Regenerated `robot$ci-runner`'s secret via Harbor's admin API (`PATCH
/api/v2.0/robots/1`), verified the new secret authenticates (`HTTP 200`
against `/v2/`), and synced it here. The matching GitHub Actions repo
secret was updated in the same pass (not part of this commit — lives in
GitHub's secret store, not the repo).

No other key in this file changed — diff is scoped to
`HARBOR_ROBOT_PASSWORD`'s ciphertext plus the mandatory
`lastmodified`/`mac` metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)