### PR TITLE
fix(security-scan): fix TruffleHog base/head for push-to-main events

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -394,11 +394,18 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
+        # On a `push` event, base/head must be the actual before/after commit
+        # range -- using default_branch/HEAD unconditionally breaks whenever
+        # the push lands directly on default_branch itself (e.g. a stable ->
+        # main promotion merge), since base and head then resolve to the same
+        # commit and the action fatal-errors ("BASE and HEAD commits are the
+        # same") instead of scanning nothing. pull_request/workflow_dispatch
+        # keep the previous, working default_branch/HEAD comparison.
         uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
+          head: ${{ github.event_name == 'push' && github.event.after || 'HEAD' }}
           extra_args: --only-verified
 
   sonarcloud:


### PR DESCRIPTION
TruffleHog's action was configured with `base: default_branch, head: HEAD`
unconditionally. That's correct for `pull_request`/`workflow_dispatch`
(base differs from head), but breaks specifically when a `push` event
lands directly on `default_branch` itself — e.g. a `stable` → `main`
promotion merge — since base and head then resolve to the literal same
commit and the action fatal-errors:

> BASE and HEAD commits are the same. TruffleHog won't scan anything.

Confirmed via the "TruffleHog secret scan" job failing on this exact
push (`main`, revision `6a994d939`, the #389 merge commit).

## Fix
For `push` events, use the actual `github.event.before`/`after` commit
range instead. `pull_request`/`workflow_dispatch` keep the previous,
already-working `default_branch`/`HEAD` comparison. TruffleHog's own
bundled logic already handles `before` == the zero-SHA (a branch's
first push) by falling back to a full scan.

## Validation
- YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)