### PR TITLE
Promote stable to main: CI infra fixes (ansible-lint, bandit, Harbor-check, ci-runner re-registration, Harbor robot secret rotation, TruffleHog push-to-main bug)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -394,11 +394,18 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog OSS
+        # On a `push` event, base/head must be the actual before/after commit
+        # range -- using default_branch/HEAD unconditionally breaks whenever
+        # the push lands directly on default_branch itself (e.g. a stable ->
+        # main promotion merge), since base and head then resolve to the same
+        # commit and the action fatal-errors ("BASE and HEAD commits are the
+        # same") instead of scanning nothing. pull_request/workflow_dispatch
+        # keep the previous, working default_branch/HEAD comparison.
         uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
+          head: ${{ github.event_name == 'push' && github.event.after || 'HEAD' }}
           extra_args: --only-verified
 
   sonarcloud:

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -666,6 +666,16 @@ provision_stack() {
     cmd=(env GRAYLOG_DEPLOY_RUNTIME=true "${cmd[@]}")
   fi
 
+  # Opt-in only: GitHub deletes a runner's registration after enough idle
+  # time (or certain server-side events), independent of whether the LXC
+  # itself is up. When that happens the runner service starts and exits
+  # immediately (see runsvc.sh's "registration has been deleted" error) --
+  # a plain restart never fixes it, it needs actual re-registration.
+  if [[ "$stack" == "ci-runner-01" && "${RUNNER_FORCE_RECONFIGURE:-false}" == "true" ]]; then
+    log "ci-runner-01: forcing runner de-registration + re-registration (RUNNER_FORCE_RECONFIGURE=true)"
+    cmd+=(-e "runner_force_reconfigure=true")
+  fi
+
   if [[ "$stack" == "technitium-stack" ]]; then
     local generated_records
     if [[ -n "${PVE_ENV:-}" ]]; then

--- a/terraform/lxc/ansible/playbooks/deploy-ci-runner.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-ci-runner.yml
@@ -207,6 +207,31 @@
       failed_when: false
       no_log: true
 
+    # `config.sh remove` above is best-effort: if GitHub already considers
+    # the runner's registration gone (the exact incident this force-reconfigure
+    # path exists for), remove has nothing valid to invalidate server-side and
+    # can silently no-op -- but it's swallowed by failed_when: false above, so
+    # nothing here surfaces that. Either way, config.sh's own IsConfigured()
+    # check only looks at whether these local files exist, so leaving them in
+    # place makes the "Configure runner" task below fail with "Cannot
+    # configure the runner because it is already configured" even though
+    # --replace is set (--replace only overrides an existing *valid* GitHub-side
+    # registration under the same name, not this local-file check). Force-clear
+    # them here so the Configure step is guaranteed a clean slate.
+    - name: Remove stale local runner config files before reconfiguring
+      ansible.builtin.file:
+        path: "{{ runner_home }}/{{ item }}"
+        state: absent
+      loop:
+        - .runner
+        - .runner_migrated
+        - .credentials
+        - .credentials_migrated
+        - .service
+      become: true
+      become_user: "{{ runner_user }}"
+      when: runner_force_reconfigure | bool
+
     - name: Configure runner
       ansible.builtin.command:
         cmd: >

--- a/terraform/secrets.common.enc.yaml
+++ b/terraform/secrets.common.enc.yaml
@@ -14,7 +14,7 @@ HARBOR_ADMIN: ENC[AES256_GCM,data:f+LQ4S0=,iv:0E7a48XX2/FlOfk/CyBN//b3+QuQamwC0o
 HARBOR_DB_PASSWORD: ENC[AES256_GCM,data:sicG1wtxdDKSoGpqAS817sBWeBhuSC0I2DXc/PWNfHI=,iv:0+esbHaRDTHiaIM8WBlz9UZrGM5vA/ioPM+3NhagFec=,tag:eSL/UdxrlEfNt0M/bYi5RQ==,type:str]
 HARBOR_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:xqXuUoxOTzyCNPeSQjTKvZPOX8af9o3UtGS7+A3dyAPbPiJSaP4/14gyL+0/1+KKsi7A4/cz,iv:tBptzb8Y66KHDnCqbPdWjz+QBA7eMKWZ5VgRWdUmTgo=,tag:VP6Pia+qfympGfEndmXLtA==,type:str]
 HARBOR_OIDC_PRIMARY_AUTH_MODE: ENC[AES256_GCM,data:hELC5w==,iv:7BxSi0ywRVMsRSMHsblFt7lZfM2r8WJ1kL9VKtl5Y/A=,tag:TnNyGDbXh7bzQCAimS5/jg==,type:str]
-HARBOR_ROBOT_PASSWORD: ENC[AES256_GCM,data:G7Yq7yLqMyc6rb/yIPFuPAWoHazJJV3RZRiwkEiZOnY=,iv:BJfD37ZxYH4isNMmo/fHcTvsqCcZsXWxrXOXqTKH6uY=,tag:5ij8Wa4rz1EGC8tjSBGH5g==,type:str]
+HARBOR_ROBOT_PASSWORD: ENC[AES256_GCM,data:pOHeGJQnhwfwkjl7p7/CPEDeMxnREP7b98NdoDvj2tiZwqv0JQTFCZwbiw==,iv:/g9BOTV6BP5SX3DZzSn1ldeZGAUWk+I1fjNqZcIsEIw=,tag:9eUIQF7V2v7iKhomP/nEKw==,type:str]
 HARBOR_ROBOT_USER: ENC[AES256_GCM,data:GysnYpfMMD++OsYQUG+C,iv:dn3Sflmev/IwPABJKgxORkYnGyOU5XNjC7GkqlP1wW4=,tag:8UeFXNT+DKl3lN0f3ALbDw==,type:str]
 MIKROTIK_ADMIN: ENC[AES256_GCM,data:30KD2qu5G+w=,iv:tkER3z79sOj815J004PYq6OrMgtLItH8bS3TrGJIL80=,tag:W4ZPJwz+uTe++tTtatTiEA==,type:str]
 MIKROTIK_ADMIN_PASSWORD: ENC[AES256_GCM,data:jp8BDZ6d+2DYp0Lq9TtAOT4znwKt9MX3cRBi/ScjZQ+4XUZ9YLNkCtFrAaw=,iv:n5klFj5JHHuOUZ9rAxWac3Tf0TRjx6Dp0D5nnXzeKQE=,tag:Y9m7cllzjI5JBPOA1H4wIQ==,type:str]
@@ -109,7 +109,7 @@ sops:
             uIJIuV3DYCVtIVa863BpTRp0r1o4x+U7Dd2qQoQ/bO6/5LhUOw+x2A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1fzhfgtun0jczh6z2ksswmf4mw90p7mg5nhmhpasny6ypesxucf5sctxqpe
-    lastmodified: "2026-09-04T03:13:12Z"
-    mac: ENC[AES256_GCM,data:Cs6HAKzDcHrCI3wZ+mqg4w7fzS0nj6QdM5+r4Qb1DFZu9VJRALTJqZinyII5xZEeMnXzyle9/QSa1hugj9Kaw7qmtjL9tFCIVK76HsATDysjXAwsnvZo9QHz4u9eaOZ+Qh4qI+pZ0XlkqG0cRumAeUFstCic3pcWQ/1/ibG0d2k=,iv:CfyQ3vNeubBB8lcim5B1ciBQu9kd6UmUI00tP0rn70k=,tag:bDHI6HbGNHQMPgXt2EqN6Q==,type:str]
+    lastmodified: "2026-09-06T04:53:22Z"
+    mac: ENC[AES256_GCM,data:wjeo5c0Bepy65Qe7ENx4+4t+XBsNQI3o/uqryIzlptHLfy+K5LRUwRVjElceMz3mHG2PTlM8InzxZBxD2s6l/HaJXSfKwXHXiKxVpXDUhqWt+5qAeNpzftPC+ieZpaEL5NdTnOFinvHH2WfxgPFty3rTweJI8GgGkR+km8G2Y3g=,iv:+JczTA3ayBmlObVR4RnbFCMpQqN88+lHHy/QhIf7OeE=,tag:A5LM+L8SIa3TzyXyAkC4Zw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Promotes the CI-cleanup and incident-response work from tonight's session:

- #402 ansible-lint: clear all non-warn_list findings
- #403 Harbor-only image check: resolve all 9 false-positives
- #404 bandit: triage all severity>=medium findings
- #405 provision.sh: opt-in RUNNER_FORCE_RECONFIGURE hook for ci-runner-01
- #406 ci-runner: force-clear stale local runner config before reconfiguring
- #407 secrets: rotate stale HARBOR_ROBOT_PASSWORD for robot$ci-runner
- #408 security-scan: fix TruffleHog base/head for push-to-main events

All of #402-#404 got `validate.yml` fully green on `main` (verified after
the previous promotion, run 34009888814 successor). #405/#406 fixed a
real production incident (ci-runner-01's GitHub registration was
invalidated server-side; a plain restart couldn't fix it). #407/#408
were found investigating that same run's `security-scan.yml` results —
a long-standing (3+ week) Harbor auth failure that was silently
skipping Trivy/Signature Gate, and a TruffleHog config bug that only
manifests on a push directly to `main` (this promotion is the actual
test of that fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)