### PR TITLE
fix(docker_base): add fleet-wide daily docker image prune timer

### DIFF
--- a/terraform/lxc/ansible/roles/docker_base/defaults/main.yml
+++ b/terraform/lxc/ansible/roles/docker_base/defaults/main.yml
@@ -1,0 +1,28 @@
+# Defaults for docker_base role.
+
+# Root-cause fix for a real outage (2026-09-08, docs/threat-vuln-platform
+# investigation): nothing in this fleet ever pruned unused/superseded Docker
+# image layers on any host. greenbone-stack's own frequent `pull: always`
+# feed re-pulls silently accumulated ~20GB of dangling image versions over
+# weeks until /var/lib/docker hit 100% -- which crashed pg-gvm, corrupted
+# Docker's own container-state bookkeeping (docker ps kept reporting the
+# crashed container as "healthy" and "up"), and took gvmd's GMP auth down
+# for ~28 hours before anyone noticed. Enabled fleet-wide by default (every
+# stack includes this role) rather than only on greenbone-stack, since any
+# stack that gets redeployed/rebuilt repeatedly accumulates the same way,
+# just slower -- see the disk-usage sweep in that same investigation
+# (pentagi at 36%, wazuh at 46% were the next-highest, already trending the
+# same direction).
+docker_base_image_prune_enabled: true
+
+# `until=24h` (not an unfiltered prune) is deliberate: a stack mid-deploy
+# may have just pulled an image that isn't attached to a container yet
+# (docker compose pull, then up moments later) -- pruning immediately could
+# remove it before it's ever used. 24h is comfortably longer than any
+# deploy window this repo's playbooks take.
+docker_base_image_prune_min_age: "24h"
+
+# systemd OnCalendar expression. Default: once daily, off-the-hour to avoid
+# a thundering-herd alignment with other scheduled jobs (matches
+# harbor_repull_on_calendar's own reasoning).
+docker_base_image_prune_on_calendar: "*-*-* 03:47:00"

--- a/terraform/lxc/ansible/roles/docker_base/tasks/main.yml
+++ b/terraform/lxc/ansible/roles/docker_base/tasks/main.yml
@@ -65,3 +65,47 @@
     name: root
     groups: docker
     append: true
+
+# Root-cause fix for a real outage (2026-09-08) -- see defaults/main.yml
+# for the full incident writeup. Enabled on every stack that includes this
+# role, not just the one that triggered it, since the underlying gap
+# (nothing ever prunes old image layers) applies fleet-wide.
+- name: Write docker-image-prune systemd service
+  ansible.builtin.template:
+    src: docker-image-prune.service.j2
+    dest: /etc/systemd/system/docker-image-prune.service
+    owner: root
+    group: root
+    mode: "0644"  # nosonar: ansible:S2612 - standard systemd unit file permissions
+  register: docker_image_prune_service
+  when: docker_base_image_prune_enabled | bool
+
+- name: Write docker-image-prune systemd timer
+  ansible.builtin.template:
+    src: docker-image-prune.timer.j2
+    dest: /etc/systemd/system/docker-image-prune.timer
+    owner: root
+    group: root
+    mode: "0644"  # nosonar: ansible:S2612 - standard systemd unit file permissions
+  register: docker_image_prune_timer
+  when: docker_base_image_prune_enabled | bool
+
+- name: Reload systemd after docker-image-prune unit changes
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: (docker_image_prune_service.changed | default(false)) or (docker_image_prune_timer.changed | default(false))
+
+- name: Enable and start docker-image-prune timer
+  ansible.builtin.systemd:
+    name: docker-image-prune.timer
+    state: started
+    enabled: true
+  when: docker_base_image_prune_enabled | bool
+
+- name: Disable docker-image-prune timer when opted out
+  ansible.builtin.systemd:
+    name: docker-image-prune.timer
+    state: stopped
+    enabled: false
+  failed_when: false
+  when: not (docker_base_image_prune_enabled | bool)

--- a/terraform/lxc/ansible/roles/docker_base/templates/docker-image-prune.service.j2
+++ b/terraform/lxc/ansible/roles/docker_base/templates/docker-image-prune.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prune unused Docker images older than {{ docker_base_image_prune_min_age }} (root-cause fix for 2026-09-08 disk-full outage)
+After=docker.service
+Wants=docker.service
+
+[Service]
+Type=oneshot
+# -a removes every image not referenced by any container (running or
+# stopped), not just fully untagged ones -- confirmed live during the
+# 2026-09-08 incident that a plain `docker image prune` (no -a) leaves
+# behind old-but-still-real-repo-tagged image versions that a newer pull
+# already superseded, since those don't count as "dangling" without -a.
+ExecStart=/usr/bin/docker image prune -a -f --filter "until={{ docker_base_image_prune_min_age }}"
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/lxc/ansible/roles/docker_base/templates/docker-image-prune.timer.j2
+++ b/terraform/lxc/ansible/roles/docker_base/templates/docker-image-prune.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Schedule for docker-image-prune.service
+
+[Timer]
+OnCalendar={{ docker_base_image_prune_on_calendar }}
+Persistent=true
+RandomizedDelaySec=1800
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Root cause of the 2026-09-08 `greenbone-stack` outage: nothing in this
fleet ever pruned unused/superseded Docker image layers on any host.
`greenbone-stack`'s frequent `pull: always` feed re-pulls silently
accumulated ~20GB of dangling image versions over weeks until
`/var/lib/docker` hit 100% — which crashed `pg-gvm`, corrupted Docker's
own container-state bookkeeping (`docker ps` kept reporting the crashed
container as "healthy" and "up" for ~28 hours), and took `gvmd`'s GMP
auth down the whole time.

A fleet-wide disk-usage sweep during the incident found nothing else
critical yet, but `pentagi-stack` (36%) and `wazuh-stack` (46%) were
already the next-highest, trending the same direction — the underlying
gap applies to every stack, just at different rates.

## Fix
Adds a new `docker-image-prune.timer`/`.service` pair to `docker_base`
(the role every stack already includes), enabled by default fleet-wide:
`docker image prune -a -f --filter "until=24h"` once daily, staggered
by up to 30 minutes.

- The 24h age filter (not an unfiltered prune) is deliberate — a stack
  mid-deploy may have just pulled an image that isn't attached to a
  container yet, and pruning immediately could remove it before it's
  ever used.
- `-a` (not just dangling) is needed because a plain `docker image
  prune` doesn't count an old-but-still-tagged image version a newer
  pull superseded as "dangling" — confirmed live during the incident
  that this is exactly what let ~20GB of old
  `vulnerability-tests`/`scap-data`/etc. layers survive an initial
  (non-`-a`) prune attempt with 0B reclaimed.

## Validation
- `ansible-lint` — exit 0, only pre-existing warn_list findings
- `ansible-playbook --syntax-check` on `deploy-greenbone-stack.yml`
- Plain YAML parse on both new template-backing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)