### PR TITLE
fix(graylog/greenbone/storage): 6-stack storage rebalance, graylog memory bump, log-driver + template-escape fixes

### DIFF
--- a/terraform/lxc/ansible/playbooks/deploy-greenbone-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-greenbone-stack.yml
@@ -35,6 +35,16 @@
     - docker_base
 
   tasks:
+    # Fixes a real gap found 2026-09-08 investigating the GVM login outage:
+    # this task previously overrode docker_base's syslog default back to
+    # json-file, with no comment explaining why -- almost certainly a
+    # copy-paste leftover predating the syslog-forwarding convention, not a
+    # deliberate exception. That meant gvmd's crash logs during the outage
+    # (Postgres socket errors, semaphore/DB failures) never reached Graylog,
+    # only ever existed in local `docker logs`. None of this stack's compose
+    # services set their own per-service `logging:` block, so switching the
+    # daemon default here is safe -- unlike deploy-pentagi-stack.yml, which
+    # has explicit per-service json-file log-opts that need separate handling.
     - name: Trust Harbor HTTP registry in Docker daemon
       ansible.builtin.copy:
         dest: /etc/docker/daemon.json
@@ -42,10 +52,11 @@
         content: |
           {
             "insecure-registries": ["{{ docker_registry_host }}"],
-            "log-driver": "json-file",
+            "log-driver": "syslog",
             "log-opts": {
-              "max-size": "50m",
-              "max-file": "7"
+              "syslog-address": "tcp://127.0.0.1:10514",
+              "syslog-format": "rfc5424",
+              "tag": "{% raw %}docker-{{.Name}}{% endraw %}"
             }
           }
       notify: Restart Docker

--- a/terraform/lxc/stacks/gaming-stack-lab/stack.yaml
+++ b/terraform/lxc/stacks/gaming-stack-lab/stack.yaml
@@ -14,7 +14,7 @@ cores: 8
 memory: 24576
 swap: 2048
 rootfs_size: 16
-storage_profile: platform-zfs
+storage_profile: platform-storage-zfs
 
 # Docker engine state is distinct from game-server state. The latter is the
 # dedicated gaming-containers ZFS volume mounted at /srv/docker below.

--- a/terraform/lxc/stacks/graylog-stack/stack.yaml
+++ b/terraform/lxc/stacks/graylog-stack/stack.yaml
@@ -7,7 +7,7 @@ network:
   zone: mgmt_seg
 vmid: 20014
 cores: 2
-memory: 6144
+memory: 10240
 swap: 1024
 rootfs_size: 8
 storage_profile: platform-default

--- a/terraform/lxc/stacks/graylog-stack/stack.yaml
+++ b/terraform/lxc/stacks/graylog-stack/stack.yaml
@@ -10,7 +10,7 @@ cores: 2
 memory: 10240
 swap: 1024
 rootfs_size: 8
-storage_profile: platform-default
+storage_profile: platform-gaming-zfs
 docker_storage_size: "40G"
 docker_mount:
   logical_name: docker-data

--- a/terraform/lxc/stacks/greenbone-stack/stack.yaml
+++ b/terraform/lxc/stacks/greenbone-stack/stack.yaml
@@ -19,7 +19,7 @@ cores: 2
 memory: 4096
 swap: 2048
 rootfs_size: 20
-storage_profile: platform-default
+storage_profile: platform-security-zfs
 docker_storage_size: "40G"
 docker_mount:
   logical_name: docker-data

--- a/terraform/lxc/stacks/media-stack-lab/stack.yaml
+++ b/terraform/lxc/stacks/media-stack-lab/stack.yaml
@@ -41,8 +41,8 @@ portainer_server_ip: "${lab_ip_portainer}"
 # env: Portainer's own stack-create API does NOT read the .env file
 # Ansible writes alongside each compose file -- it only ever sees the Env
 # list passed explicitly here (confirmed live: omitting it made immich's
-# ${REGISTRY_HOST} resolve empty, producing an "invalid reference format"
-# 500 on cadvisor's image). Values use the same ${VAR} placeholder
+# $${REGISTRY_HOST} resolve empty, producing an "invalid reference format"
+# 500 on cadvisor's image). Values use the same $${VAR} placeholder
 # resolution as portainer_server_ip above -- provision.sh substitutes
 # from the real environment (SOPS-backed for the DB password), nothing
 # here is a literal secret.
@@ -51,14 +51,14 @@ portainer_stacks:
   compose_file: jellyfin-docker-compose.yml
   env:
   - name: LAB_DOMAIN
-    value: "${lab_domain}"
+    value: "$${lab_domain}"
 - name: media-stack-lab-immich
   compose_file: immich-docker-compose.yml
   env:
   - name: MEDIA_STACK_LAB_DB_PASSWORD
-    value: "${media_stack_lab_db_password}"
+    value: "$${media_stack_lab_db_password}"
   - name: REGISTRY_HOST
-    value: "${lab_fqdn_harbor}"
+    value: "$${lab_fqdn_harbor}"
 
 # Documentation/consistency only -- NOT applied by Terraform (bind-type
 # mount points are root@pam-only on Proxmox, same restriction as

--- a/terraform/lxc/stacks/monitoring-stack/stack.yaml
+++ b/terraform/lxc/stacks/monitoring-stack/stack.yaml
@@ -10,7 +10,7 @@ cores: 2
 memory: 1536
 swap: 1024
 rootfs_size: 8
-storage_profile: platform-default
+storage_profile: platform-monitoring-zfs
 docker_storage_size: "52G"
 docker_mount:
   logical_name: docker-data

--- a/terraform/lxc/stacks/opensearch-stack/stack.yaml
+++ b/terraform/lxc/stacks/opensearch-stack/stack.yaml
@@ -24,7 +24,7 @@ cores: 2
 memory: 6144
 swap: 1024
 rootfs_size: 16
-storage_profile: platform-zfs
+storage_profile: platform-monitoring-zfs
 docker_storage_size: "20G"
 docker_mount:
   logical_name: docker-data

--- a/terraform/lxc/stacks/wazuh-stack/stack.yaml
+++ b/terraform/lxc/stacks/wazuh-stack/stack.yaml
@@ -9,7 +9,7 @@ cores: 4
 memory: 8192
 swap: 2048
 rootfs_size: 16
-storage_profile: platform-zfs
+storage_profile: platform-apps-zfs
 docker_storage_size: "20G"
 docker_mount:
   logical_name: docker-data

--- a/terraform/lxc/storage/pve.yaml
+++ b/terraform/lxc/storage/pve.yaml
@@ -19,6 +19,15 @@ storage_backends:
   gaming-containers:
     content_types: [rootdir]
     backend_type: zfs
+  security-containers:
+    content_types: [rootdir]
+    backend_type: zfs
+  monitoring-containers:
+    content_types: [rootdir]
+    backend_type: zfs
+  apps-containers:
+    content_types: [rootdir]
+    backend_type: zfs
   local-zfs:
     content_types: [images, rootdir]
   storage-template:
@@ -57,6 +66,44 @@ profiles:
   platform-zfs:
     rootfs_storage: infrastructure-containers
     docker_storage: infrastructure-containers
+    rootfs_required_content_type: rootdir
+    docker_required_content_type: rootdir
+  # The five profiles below reflect a manual, non-destructive rebalance
+  # performed 2026-09-08 (docs/threat-vuln-platform or session notes --
+  # see the pmxcfs-contention/rpool-capacity investigation): every profile
+  # above resolves to the same backend (infrastructure-containers / pool
+  # `rpool`) regardless of name, which is why every stack piled onto one
+  # disk that also backs pmxcfs's own config.db. These name real
+  # destinations chosen by actual pool headroom + device speed (NVMe vs
+  # SATA SSD), not by the pool's original functional-sounding name --
+  # `rpool` was at 83%+38.8GB free and I/O-contended; the alternates were
+  # 2-16% used. Applied live via `pct move-volume` (rsync-based, default
+  # keeps the old rpool copy as an unused volume -- not deleted) BEFORE
+  # these profile declarations existed, so this is the config catching up
+  # to already-live reality, not a change that should trigger a move.
+  platform-security-zfs:
+    rootfs_storage: security-containers
+    docker_storage: security-containers
+    rootfs_required_content_type: rootdir
+    docker_required_content_type: rootdir
+  platform-gaming-zfs:
+    rootfs_storage: gaming-containers
+    docker_storage: gaming-containers
+    rootfs_required_content_type: rootdir
+    docker_required_content_type: rootdir
+  platform-storage-zfs:
+    rootfs_storage: storage-containers
+    docker_storage: storage-containers
+    rootfs_required_content_type: rootdir
+    docker_required_content_type: rootdir
+  platform-apps-zfs:
+    rootfs_storage: apps-containers
+    docker_storage: apps-containers
+    rootfs_required_content_type: rootdir
+    docker_required_content_type: rootdir
+  platform-monitoring-zfs:
+    rootfs_storage: monitoring-containers
+    docker_storage: monitoring-containers
     rootfs_required_content_type: rootdir
     docker_required_content_type: rootdir
 


### PR DESCRIPTION
## Summary

Chain of fixes stemming from today's GVM outage investigation and the follow-up "could this affect any other stacks?" question.

1. **greenbone-stack log-driver fix** — restores `syslog` (was overridden to `json-file`), so GVM's container logs actually reach Graylog. Root-caused during the original outage investigation.

2. **media-stack-lab template-escape fixes** — two bugs where literal `${...}` text (a doc comment, and portainer_stacks env values meant for `provision.sh`'s own substitution pass) collided with Terraform's `templatefile()` — which renders the *entire* raw YAML to extract `ip_address`, not just the fields it needs. This was silently blocking `terragrunt plan`/`apply` for **every** stack in the repo, not just media-stack-lab.

3. **6-stack storage rebalance** — `rpool` (the single NVMe backing the Proxmox host's OS *and* `pmxcfs`'s own config.db) was at 83% capacity and I/O-contended, because every storage profile the manifest defined resolved to the same backend regardless of name. This surfaced during a separate live incident: `pmxcfs`'s internal SQLite transaction got wedged during the original disk-full incident (`commit transaction failed: database or disk is full` followed by a failed rollback), causing every `pvesh`/`pct`/Terraform config write on `pve` to fail for 5+ hours — fixed live via `systemctl restart pve-cluster` (not part of this diff, no code change involved). Once that was resolved, moved 6 stacks live via `pct move-volume` (rsync-based, non-destructive — default keeps the old copy as an unused volume) onto underused pools, matched to actual headroom + device speed:
   - `greenbone-stack` → `security` (NVMe)
   - `graylog-stack` → `gaming` (NVMe)
   - `gaming-stack-lab` → `storage` (SATA SSD)
   - `wazuh-stack` → `apps` (SATA SSD)
   - `opensearch-stack` + `monitoring-stack` → `monitoring` (SATA SSD, quietest)

   `pentagi-stack` deliberately left on `rpool` — deprecated, no further work planned.

4. **Storage manifest fix** — declares real per-pool profiles matching the 6 stacks' new live locations. Without this, any future `apply` for any of the 6 would see `datastore_id` drift and force-replace (destroy + recreate) the container trying to "fix" it back onto `rpool` — caught live while applying the graylog memory bump below.

5. **graylog-stack memory bump** — 6144→10240 MiB. `graylog` (2.1GB) + `datanode`/OpenSearch (3.5GB) alone consumed ~95% of the previous ceiling, leaving `mongodb`/`cadvisor`/OS overhead almost nothing (67MB free, load average 8.0 on 2 cores) — root cause of Graylog's own search API erroring with a MongoDB connection timeout during the original outage investigation.

## Validation

- `terragrunt plan` verified clean (no destructive diffs) for all 6 rebalanced stacks post-fix
- All 6 stacks' containers confirmed running with healthy Docker containers after migration
- `graylog-stack`'s memory bump applied live via `terragrunt apply`, confirmed via `pct config`
- GVM login and Graylog API both confirmed responding after all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)