### PR TITLE
fix(docker-dns): repoint 8 stacks off dns-stack, onto technitium-stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ Not all stacks run Docker containers. When writing health/verify gate commands, 
 |---|---|---|
 | `apt-cacher-stack` | systemd (apt-cacher-ng) | Check systemd unit or HTTP port 3142 |
 | `technitium-stack` | Docker Compose (Technitium DNS) | **The live authoritative DNS** on both `pve` and `pve-test-vm` — MikroTik's zone-delegate rule points here. `dig` query against its IP |
-| `dns-stack` | systemd (CoreDNS) | **Rollback-only, not the active delegate target** since the cutover documented in `docs/dns-refactor/README.md` — do not assume this is live DNS just because it's deployed. `dig` query against the DNS container IP if you do need to check it |
+| `dns-stack` | systemd (CoreDNS) | **Rollback-only, not the active delegate target** since the cutover documented in `docs/dns-refactor/README.md` — do not assume this is live DNS just because it's deployed. `dig` query against the DNS container IP if you do need to check it. **This does NOT mean it's safe to stop/relocate/deprioritize** — its IP is still hardcoded as the Docker-daemon-level DNS resolver on several other stacks (a pre-cutover leftover), and stopping it has already broken Harbor's image pulls fleet-wide once via that exact path. Check current dependents before treating it as low-risk. |
 | `step-ca-stack` | systemd (step-ca) | HTTPS GET to `/acme/acme/directory` |
 | `ci-runner-01` | systemd (GitHub Actions runner) | Check systemd unit `actions.runner.*.service` |
 | `harbor-stack` | Docker Compose | `curl` to registry API or health endpoint |

--- a/docs/design/network.md
+++ b/docs/design/network.md
@@ -110,7 +110,10 @@ Two-tier model:
 
 CoreDNS (`192.168.20.13` / `192.168.20.113`) remains deployed as the legacy authority and
 immediate rollback target during the refactor, but it is no longer the active delegate path
-for clients.
+for clients. **This does not make it safe to stop or relocate** — its IP is still hardcoded
+as the Docker-daemon-level DNS resolver on several other stacks (a pre-cutover leftover),
+and stopping it has already broken Harbor's image pulls fleet-wide once via that exact path.
+See `reference_dns_stack_docker_daemon_dependency` for the incident and affected stacks.
 
 ### Name spaces
 

--- a/docs/dns-refactor/README.md
+++ b/docs/dns-refactor/README.md
@@ -1,5 +1,21 @@
 # DNS Refactor — CoreDNS to Technitium Migration
 
+**MIGRATION COMPLETE, 2026-07-05 — `technitium-stack` is the live
+authoritative DNS on `pve` and `pve-test-vm`; `dns-stack`/CoreDNS is kept
+deployed only as a rollback point.** This workspace's own "Closeout" section
+below calls for folding these conclusions into `docs/design/network.md` and
+archiving this doc — that hasn't happened yet, so treat everything below as
+historical planning record, not something still in progress.
+
+**Read this before assuming `dns-stack` is safe to stop, relocate, or
+deprioritize just because it's "rollback-only" here**: that framing is only
+true for its original DNS-delegate role. Its IP is still hardcoded as the
+Docker-daemon-level DNS resolver on several other stacks — a leftover from
+before this cutover that was never fully repointed. Stopping it has already
+broken Harbor's image pulls fleet-wide once (2026-08-16) via that exact
+path. See the `reference_dns_stack_docker_daemon_dependency` memory / repo
+history for the full incident and which stacks are affected.
+
 ## Purpose
 
 Plan and track migrating the internal authoritative DNS service (currently

--- a/docs/reference/stack-cheatsheet.md
+++ b/docs/reference/stack-cheatsheet.md
@@ -26,7 +26,7 @@ is a cache, not a source of truth.
 | `apt-cacher-stack` | 40011 | `infra_seg` | 192.168.40.11 | Transparent apt proxy for all LXC containers during provisioning |
 | `authentik-stack` | 20010 | `mgmt_seg` | 192.168.20.10 | Identity provider / SSO gateway for the platform |
 | `ci-runner-01` | 10063 | `build_seg` | 192.168.10.63 | Self-hosted GitHub Actions runner |
-| `dns-stack` | 20013 | `mgmt_seg` | 192.168.20.13 | Rollback-only CoreDNS — **not** the active DNS delegate (`technitium-stack` is) |
+| `dns-stack` | 20013 | `mgmt_seg` | 192.168.20.13 | Rollback-only CoreDNS — **not** the active DNS delegate (`technitium-stack` is). **Do not treat this as safe to stop/relocate/deprioritize**: its IP was hardcoded as the Docker-daemon-level DNS resolver on several other stacks (a leftover from before the cutover), and stopping it has already broken Harbor's image pulls fleet-wide once (2026-08-16) via that path — see `reference_dns_stack_docker_daemon_dependency` |
 | `graylog-stack` | 20014 | `mgmt_seg` | 192.168.20.14 | Production log platform (Graylog 7.1.3) |
 | `greenbone-stack` | 70011 | `pentest_seg` | 192.168.70.11 | GVM/OpenVAS vulnerability scanner, live network scanning |
 | `harbor-stack` | 40010 | `infra_seg` | 192.168.40.10 | Private container registry + proxy-cache for all image pulls |

--- a/terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-authentik-stack.yml
@@ -57,7 +57,15 @@
     lab_admin_username: "{{ lookup('env', 'LAB_ADMIN_USERNAME') | default('steve', true) }}"
     lab_domain: "{{ lookup('env', 'LAB_DOMAIN') | default('lab.gibbsgreatly.xyz', true) }}"
     lab_admin_email: "{{ lookup('env', 'LAB_ADMIN_EMAIL') | default(lab_admin_username ~ '@' ~ lab_domain, true) }}"
-    authentik_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | default(dns_server, true) | mandatory('LAB_IP_DNS env var or dns_server inventory var is required') }}"
+    # Points at technitium-stack (the real live DNS since the CoreDNS->
+    # Technitium cutover, docs/dns-refactor/README.md) -- NOT dns-stack's
+    # LAB_IP_DNS. This var name is legacy; dns-stack is only "rollback-only"
+    # for its old MikroTik zone-delegate role, but was still hardcoded here
+    # as this container's Docker-daemon-level DNS resolver until this fix
+    # (see reference_dns_stack_docker_daemon_dependency memory/incident,
+    # 2026-08-16: stopping dns-stack broke Harbor's pulls fleet-wide because
+    # of exactly this kind of leftover reference).
+    authentik_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | default(dns_server, true) | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required') }}"
     authentik_steve_password: "{{ lookup('env', 'AUTHENTIK_STEVE_PASSWORD') | mandatory('AUTHENTIK_STEVE_PASSWORD env var is not set') }}"
     authentik_internal_tls_fqdn: "{{ lookup('env', 'LAB_FQDN_AUTHENTIK_INTERNAL') | default('authentik-int.' ~ lab_domain, true) }}"
 

--- a/terraform/lxc/ansible/playbooks/deploy-graylog-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-graylog-stack.yml
@@ -7,7 +7,9 @@
     graylog_lab_domain: "{{ lookup('env', 'LAB_DOMAIN') | default('lab.gibbsgreatly.xyz', true) }}"
     graylog_lab_fqdn_harbor: "{{ lookup('env', 'LAB_FQDN_HARBOR') | default('harbor.' ~ graylog_lab_domain, true) }}"
     graylog_lab_fqdn_graylog: "{{ lookup('env', 'LAB_FQDN_GRAYLOG') | default('graylog.' ~ graylog_lab_domain, true) }}"
-    graylog_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | mandatory('LAB_IP_DNS env var is required') }}"
+    # Points at technitium-stack, not dns-stack -- see
+    # reference_dns_stack_docker_daemon_dependency memory/incident.
+    graylog_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | mandatory('LAB_IP_TECHNITIUM env var is required') }}"
     graylog_registry_host: "{{ lookup('env', 'LAB_FQDN_HARBOR') | default(graylog_lab_fqdn_harbor, true) }}"
     docker_registry_host: "{{ graylog_registry_host }}"
   roles:

--- a/terraform/lxc/ansible/playbooks/deploy-harbor-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-harbor-stack.yml
@@ -10,7 +10,11 @@
   become: true
   gather_facts: true
   vars:
-    harbor_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | default(dns_server, true) | mandatory('LAB_IP_DNS env var or dns_server inventory var is required') }}"
+    # Points at technitium-stack, not dns-stack -- see
+    # reference_dns_stack_docker_daemon_dependency memory/incident (this
+    # stack was the ORIGINAL 2026-08-16 outage: Harbor's pulls broke
+    # fleet-wide when dns-stack was stopped, because of this exact line).
+    harbor_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | default(dns_server, true) | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required') }}"
     harbor_docker_daemon_config:
       dns:
         - "{{ harbor_lab_ip_dns }}"

--- a/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
@@ -174,6 +174,12 @@
         - { path: "{{ monitoring_compose_dir }}/uvm-dashboard-exporter", mode: "0750" }
         - { path: "{{ monitoring_compose_dir }}/victoria-metrics", mode: "0750" }
 
+    # dns-stack's node_exporter target removed 2026-09-08 -- purely cosmetic
+    # (a metrics scrape target, not a functional dependency check), but
+    # dns-stack is being decommissioned and this would otherwise just show
+    # up as a perpetually "down" target after that. See
+    # reference_dns_stack_docker_daemon_dependency for the actual dependency
+    # this stack had (already fixed separately, unrelated to this target).
     - name: Write VictoriaMetrics scrape config
       ansible.builtin.copy:
         dest: "{{ monitoring_compose_dir }}/victoria-metrics/scrape.yml"
@@ -197,8 +203,6 @@
                   labels: {stack: step-ca-stack}
                 - targets: ["{{ lookup('env', 'LAB_IP_MONITORING') }}:9100"]
                   labels: {stack: monitoring-stack}
-                - targets: ["{{ lookup('env', 'LAB_IP_DNS') }}:9100"]
-                  labels: {stack: dns-stack}
                 - targets: ["{{ lookup('env', 'LAB_IP_PORTAINER') }}:9100"]
                   labels: {stack: portainer-stack}
                 - targets: ["{{ lookup('env', 'LAB_IP_PROXY') }}:9100"]

--- a/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-monitoring-stack.yml
@@ -9,7 +9,13 @@
     monitoring_lab_fqdn_grafana: "{{ lookup('env', 'LAB_FQDN_GRAFANA') | default('grafana.' ~ monitoring_lab_domain, true) }}"
     monitoring_lab_fqdn_authentik: "{{ lookup('env', 'LAB_FQDN_AUTHENTIK') | default('authentik.' ~ monitoring_lab_domain, true) }}"
     monitoring_lab_fqdn_authentik_internal: "{{ lookup('env', 'LAB_FQDN_AUTHENTIK_INTERNAL') | default('authentik-int.' ~ monitoring_lab_domain, true) }}"
-    monitoring_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | mandatory('LAB_IP_DNS env var is required') }}"
+    # Points at technitium-stack (the real live DNS since the CoreDNS->
+    # Technitium cutover, docs/dns-refactor/README.md) -- NOT dns-stack's
+    # LAB_IP_DNS, which was hardcoded here as this container's Docker-daemon
+    # DNS resolver until this fix (reference_dns_stack_docker_daemon_dependency
+    # memory/incident, 2026-08-16: stopping dns-stack broke Harbor's pulls
+    # fleet-wide because of exactly this kind of leftover reference).
+    monitoring_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | mandatory('LAB_IP_TECHNITIUM env var is required') }}"
     monitoring_lab_admin_username: "{{ lookup('env', 'LAB_ADMIN_USERNAME') | default('steve', true) }}"
     monitoring_registry_host: "{{ lookup('env', 'MONITORING_REGISTRY_HOST') | default(monitoring_lab_fqdn_harbor, true) }}"
     docker_registry_host: "{{ monitoring_registry_host }}"
@@ -66,7 +72,9 @@
     monitoring_lab_fqdn_grafana: "{{ lookup('env', 'LAB_FQDN_GRAFANA') | default('grafana.' ~ monitoring_lab_domain, true) }}"
     monitoring_lab_fqdn_authentik: "{{ lookup('env', 'LAB_FQDN_AUTHENTIK') | default('authentik.' ~ monitoring_lab_domain, true) }}"
     monitoring_lab_fqdn_authentik_internal: "{{ lookup('env', 'LAB_FQDN_AUTHENTIK_INTERNAL') | default('authentik-int.' ~ monitoring_lab_domain, true) }}"
-    monitoring_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | mandatory('LAB_IP_DNS env var is required') }}"
+    # Points at technitium-stack, not dns-stack -- see the matching comment
+    # on this same var in the "Configure Docker base" play above.
+    monitoring_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | mandatory('LAB_IP_TECHNITIUM env var is required') }}"
     monitoring_lab_admin_username: "{{ lookup('env', 'LAB_ADMIN_USERNAME') | default('steve', true) }}"
     monitoring_compose_dir: /opt/monitoring-stack
     vm_version: "v1.148.0"

--- a/terraform/lxc/ansible/playbooks/deploy-netbox-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-netbox-stack.yml
@@ -75,7 +75,13 @@
   gather_facts: true
   vars:
     docker_registry_host: "{{ lookup('env', 'LAB_FQDN_HARBOR') | default(registry_host, true) | default(lookup('env', 'LAB_IP_HARBOR'), true) | mandatory('LAB_FQDN_HARBOR env var, registry_host var, or LAB_IP_HARBOR env var is required') }}"
-    netbox_lab_ip_dns: "{{ lookup('env', 'LAB_IP_DNS') | default(dns_server, true) | mandatory('LAB_IP_DNS env var or dns_server inventory var is required') }}"
+    # Points at technitium-stack (the real live DNS since the CoreDNS->
+    # Technitium cutover, docs/dns-refactor/README.md) -- NOT dns-stack's
+    # LAB_IP_DNS, which was hardcoded here as this container's Docker-daemon
+    # DNS resolver until this fix (reference_dns_stack_docker_daemon_dependency
+    # memory/incident, 2026-08-16: stopping dns-stack broke Harbor's pulls
+    # fleet-wide because of exactly this kind of leftover reference).
+    netbox_lab_ip_dns: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | default(dns_server, true) | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required') }}"
     netbox_api_token: "{{ lookup('env', 'NETBOX_API_TOKEN') | default(lookup('env', 'NETBOX_SUPERUSER_API_TOKEN') | default('', true), true) }}"
   roles:
     - lxc_base

--- a/terraform/lxc/ansible/playbooks/deploy-opensearch-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-opensearch-stack.yml
@@ -27,11 +27,13 @@
   become: true
   gather_facts: true
   vars:
+    # Points at technitium-stack, not dns-stack -- see
+    # reference_dns_stack_docker_daemon_dependency memory/incident.
     opensearch_lab_ip_dns: >-
       {{
-        lookup('env', 'LAB_IP_DNS')
+        lookup('env', 'LAB_IP_TECHNITIUM')
         | default(dns_server, true)
-        | mandatory('LAB_IP_DNS env var or dns_server inventory var is required')
+        | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required')
       }}
     # FQDN, not the raw LAB_IP_HARBOR — proven pattern (elasticsearch-stack,
     # deploy-graylog-stack.yml). docker login against the bare Harbor IP

--- a/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-portainer-stack.yml
@@ -9,7 +9,13 @@
   tags: [pre_restore]
   vars:
     docker_registry_host: "{{ registry_host | default('') | trim }}"
-    docker_dns_server: "{{ lookup('env', 'LAB_IP_DNS') | default(dns_server, true) | mandatory('LAB_IP_DNS env var or dns_server inventory var is required') }}"
+    # Points at technitium-stack (the real live DNS since the CoreDNS->
+    # Technitium cutover, docs/dns-refactor/README.md) -- NOT dns-stack's
+    # LAB_IP_DNS, which was hardcoded here as this container's Docker-daemon
+    # DNS resolver until this fix (reference_dns_stack_docker_daemon_dependency
+    # memory/incident, 2026-08-16: stopping dns-stack broke Harbor's pulls
+    # fleet-wide because of exactly this kind of leftover reference).
+    docker_dns_server: "{{ lookup('env', 'LAB_IP_TECHNITIUM') | default(dns_server, true) | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required') }}"
     docker_daemon_config_base:
       dns:
         - "{{ docker_dns_server }}"

--- a/terraform/lxc/ansible/playbooks/deploy-wazuh-stack.yml
+++ b/terraform/lxc/ansible/playbooks/deploy-wazuh-stack.yml
@@ -35,11 +35,13 @@
   become: true
   gather_facts: true
   vars:
+    # Points at technitium-stack, not dns-stack -- see
+    # reference_dns_stack_docker_daemon_dependency memory/incident.
     wazuh_lab_ip_dns: >-
       {{
-        lookup('env', 'LAB_IP_DNS')
+        lookup('env', 'LAB_IP_TECHNITIUM')
         | default(dns_server, true)
-        | mandatory('LAB_IP_DNS env var or dns_server inventory var is required')
+        | mandatory('LAB_IP_TECHNITIUM env var or dns_server inventory var is required')
       }}
     wazuh_registry_host: "{{ lookup('env', 'LAB_FQDN_HARBOR') | default('harbor.' ~ lookup('env', 'LAB_DOMAIN'), true) }}"
   roles:


### PR DESCRIPTION
## Summary

Found while assessing whether `dns-stack` (CoreDNS, superseded by `technitium-stack` since 2026-07-05) was safe to decommission — it wasn't, yet.

`dns-stack`'s IP was still hardcoded as the Docker daemon-level DNS resolver on 8 stacks, a leftover never fully repointed after the CoreDNS→Technitium cutover:

- **Already known** (from `reference_dns_stack_docker_daemon_dependency` memory, 2026-08-16 incident): `authentik-stack`, `netbox-stack`, `monitoring-stack`, `portainer-stack`
- **Found via a fresh, comprehensive fleet-wide sweep** (not just the 4 above): `graylog-stack`, `harbor-stack`, `opensearch-stack`, `wazuh-stack` — notably `harbor-stack` is the stack whose outage *was* the original 2026-08-16 incident; it was apparently never fixed at the source or drifted back.

Also caught and corrected the same mistake live during memory-capacity planning: recommended `dns-stack` as a "low-risk" candidate to relocate to spare hardware, directly contradicting the existing memory.

## Changes

1. Repointed all 8 stacks' `LAB_IP_DNS` → `LAB_IP_TECHNITIUM` in their deploy playbooks (source fix, for future deploys)
2. Applied live via targeted SSH edits (`daemon.json` + `systemctl restart docker` per stack, no full Ansible re-run, no unrelated drift) — verified healthy after each: `pg-gvm`/`gvmd`, Authentik `/-/health/live/` (200), Harbor `/api/v2.0/health` (200), all container lists confirmed up
3. Found and fixed a compose-level per-container override on `monitoring-stack`'s `grafana` that `daemon.json` alone wouldn't have touched
4. Removed `monitoring-stack`'s VictoriaMetrics scrape target for `dns-stack` (cosmetic, but would show as perpetually "down" post-decommission) — confirmed gone from the live target list after a targeted `victoriametrics` container restart
5. Fixed the same half-truth "rollback-only" framing (technically true, dangerously incomplete) in `CLAUDE.md`, `docs/reference/stack-cheatsheet.md`, `docs/dns-refactor/README.md`, and `docs/design/network.md` — all described dns-stack as safe-sounding without mentioning the hidden dependency
6. Strengthened the `reference_dns_stack_docker_daemon_dependency` memory itself, since this recurred despite it already being on record

## Validation

- Fresh fleet-wide sweep post-fix confirmed **zero** remaining `daemon.json` or compose-level references to `dns-stack`'s IP across every running container
- MikroTik REST API checked directly (static DNS, DHCP leases, NAT, firewall filter, address-lists, mangle) — zero references
- All 8 stacks confirmed healthy after their restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)